### PR TITLE
Feat/rapid 3103 streamline order creation

### DIFF
--- a/docs/custom_orders.md
+++ b/docs/custom_orders.md
@@ -1,4 +1,4 @@
-# Quickstart
+# Custom orders
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,4 +3,6 @@
 
 The Rapidata Python Client is a convenient way to interact with the Rapidata Web API from python applications.
 
-Check out the [Quickstart](quickstart.md) section to get started!
+Check out the [Quickstart for classification](quickstart_classification.md) or [Quickstart for comparisons](quickstart_compare.md) section to get started!
+
+or try a more complex order with [Custom Orders](custom_orders.md)!

--- a/docs/quickstart_classification.md
+++ b/docs/quickstart_classification.md
@@ -77,7 +77,7 @@ with open("order_ids.txt", "a") as file:
 
 ### Short Form
 
-The [`RapidataOrderBuilder`](reference/rapidata/rapidata_client/order/rapidata_order_builder.md/#rapidata.rapidata_client.order.rapidata_order_builder.RapidataOrderBuilder) supports a fluent interface, allowing method call chaining. This enables a more concise order creation:
+The `RapidataSDK` supports a fluent interface, allowing method call chaining. This enables a more concise order creation:
 
 ```py
 order = (rapi.create_classify_order("classifcaiton order")

--- a/docs/quickstart_classification.md
+++ b/docs/quickstart_classification.md
@@ -60,7 +60,7 @@ order_builder = order_builder.media(["examples/data/wallaby.jpg"])
 order_builder = order_builder.votes(20)
 ```
 
-6. Finally create the order. This executes all the HTTP requests to the Rapidata API:
+6. Finally create the order. This sends the order off for verification and will start collecting responses.
 
 ```py
 order = order_builder.create()

--- a/docs/quickstart_classification.md
+++ b/docs/quickstart_classification.md
@@ -1,0 +1,112 @@
+# Quickstart Classification Guide
+
+## Installation
+
+Install Rapidata using pip:
+
+```
+pip install rapidata
+```
+
+To update an existing installation:
+
+```
+pip install rapidata -U
+```
+
+## Usage
+
+Orders are managed through the [`RapidataClient`](reference/rapidata/rapidata_client/rapidata_client.md#rapidata.rapidata_client.rapidata_client.RapidataClient).
+
+Create a client as follows:
+
+```py
+from rapidata import RapidataClient
+
+rapi = RapidataClient(client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+```
+
+Contact a Rapidata representative at [info@rapidata.ai](mailto:info@rapidata.ai) to obtain your `CLIENT_ID` and `CLIENT_SECRET`.
+
+### Creating an Order
+
+1. Create a new `Classification Order` and specify the name:
+
+```py
+order_builder = rapi.create_classify_order("Simple Classification")
+```
+
+2. Add the question you want to ask.
+
+```py
+order_builder = order_builder.question("What is shown in the image?")
+```
+
+3. add the different answer options:
+
+```py
+order_builder = order_builder.options(["Fish", "Cat", "Wallaby", "Airplane"])
+```
+
+4. Add the paths to the images you want to classify:
+
+```py
+order_builder = order_builder.media(["examples/data/wallaby.jpg"])
+```
+
+5. Optionally add additional specifications, here we're adding a specific amount of votes we want per datapoint, there are other functionalities you can explore:
+
+```py
+order_builder = order_builder.votes(20)
+```
+
+6. Finally create the order. This executes all the HTTP requests to the Rapidata API:
+
+```py
+order = order_builder.create()
+```
+
+7. Save the order ID for future reference, especially if you need to download results later after restarting the kernel:
+
+```py
+print("order id: ", order.order_id)
+# Optionally save the order ID to a file
+with open("order_ids.txt", "a") as file:
+    file.write(f"{order.order_id}\n")
+```
+
+### Short Form
+
+The [`RapidataOrderBuilder`](reference/rapidata/rapidata_client/order/rapidata_order_builder.md/#rapidata.rapidata_client.order.rapidata_order_builder.RapidataOrderBuilder) supports a fluent interface, allowing method call chaining. This enables a more concise order creation:
+
+```py
+order = (rapi.create_classify_order("classifcaiton order")
+         .question("what is this?")
+         .options(["a", "b", "c"])
+         .media(["C:\\Users\\linog\\Pictures\\example_jpg.jpg"])
+         .votes(20)
+         .create())
+print("order id: ", order.order_id)
+# Optionally save the order ID to a file
+with open("order_ids.txt", "a") as file:
+    file.write(f"{order.order_id}\n")
+```
+
+### Downloading Results
+
+To download the results, you'll need the order object (this will throw an error if the order is not complete yet):
+
+```py
+results = order.get_results()
+```
+
+If you've restarted the kernel, you can retrieve the order using the order ID and the `rapi` client:
+
+```py
+from rapidata import RapidataClient
+
+rapi = RapidataClient(client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+order_id = "your_order_id"  # as a string
+order = rapi.get_order(order_id)
+results = order.get_results()
+```

--- a/docs/quickstart_compare.md
+++ b/docs/quickstart_compare.md
@@ -54,7 +54,7 @@ order_builder = order_builder.media([["examples/data/rapidata_logo.png", "exampl
 order_builder = order_builder.votes(20)
 ```
 
-5. Finally create the order. This executes all the HTTP requests to the Rapidata API:
+5. Finally create the order. This sends the order off for verification and will start collecting responses.
 
 ```py
 order = order_builder.create()

--- a/docs/quickstart_compare.md
+++ b/docs/quickstart_compare.md
@@ -1,0 +1,106 @@
+# Quickstart Classification Guide
+
+## Installation
+
+Install Rapidata using pip:
+
+```
+pip install rapidata
+```
+
+To update an existing installation:
+
+```
+pip install rapidata -U
+```
+
+## Usage
+
+Orders are managed through the [`RapidataClient`](reference/rapidata/rapidata_client/rapidata_client.md#rapidata.rapidata_client.rapidata_client.RapidataClient).
+
+Create a client as follows:
+
+```py
+from rapidata import RapidataClient
+
+rapi = RapidataClient(client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+```
+
+Contact a Rapidata representative at [info@rapidata.ai](mailto:info@rapidata.ai) to obtain your `CLIENT_ID` and `CLIENT_SECRET`.
+
+### Creating an Order
+
+1. Create a new `Compare Order` and specify the name:
+
+```py
+order_builder = rapi.create_compare_order("Simple Compare")
+```
+
+2. Add the criteria for the comparison.
+
+```py
+order_builder = order_builder.criteria("Which logo looks better?")
+```
+
+3. Add the paths to the images you want to classify:
+
+```py
+order_builder = order_builder.media([["examples/data/rapidata_logo.png", "examples/data/rapidata_concept_logo.jpg"]])
+```
+
+4. Optionally add additional specifications, here we're adding a specific amount of votes we want per datapoint, there are other functionalities you can explore:
+
+```py
+order_builder = order_builder.votes(20)
+```
+
+5. Finally create the order. This executes all the HTTP requests to the Rapidata API:
+
+```py
+order = order_builder.create()
+```
+
+6. Save the order ID for future reference, especially if you need to download results later after restarting the kernel:
+
+```py
+print("order id: ", order.order_id)
+# Optionally save the order ID to a file
+with open("order_ids.txt", "a") as file:
+    file.write(f"{order.order_id}\n")
+```
+
+### Short Form
+
+The [`RapidataOrderBuilder`](reference/rapidata/rapidata_client/order/rapidata_order_builder.md/#rapidata.rapidata_client.order.rapidata_order_builder.RapidataOrderBuilder) supports a fluent interface, allowing method call chaining. This enables a more concise order creation:
+
+```py
+order = (rapi.create_classify_order("classifcaiton order")
+         .question("what is this?")
+         .options(["a", "b", "c"])
+         .media(["C:\\Users\\linog\\Pictures\\example_jpg.jpg"])
+         .votes(20)
+         .create())
+print("order id: ", order.order_id)
+# Optionally save the order ID to a file
+with open("order_ids.txt", "a") as file:
+    file.write(f"{order.order_id}\n")
+```
+
+### Downloading Results
+
+To download the results, you'll need the order object (this will throw an error if the order is not complete yet):
+
+```py
+results = order.get_results()
+```
+
+If you've restarted the kernel, you can retrieve the order using the order ID and the `rapi` client:
+
+```py
+from rapidata import RapidataClient
+
+rapi = RapidataClient(client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+order_id = "your_order_id"  # as a string
+order = rapi.get_order(order_id)
+results = order.get_results()
+```

--- a/docs/quickstart_compare.md
+++ b/docs/quickstart_compare.md
@@ -71,15 +71,15 @@ with open("order_ids.txt", "a") as file:
 
 ### Short Form
 
-The [`RapidataOrderBuilder`](reference/rapidata/rapidata_client/order/rapidata_order_builder.md/#rapidata.rapidata_client.order.rapidata_order_builder.RapidataOrderBuilder) supports a fluent interface, allowing method call chaining. This enables a more concise order creation:
+The `RapidataSDK` supports a fluent interface, allowing method call chaining. This enables a more concise order creation:
 
 ```py
-order = (rapi.create_classify_order("classifcaiton order")
-         .question("what is this?")
-         .options(["a", "b", "c"])
-         .media(["C:\\Users\\linog\\Pictures\\example_jpg.jpg"])
-         .votes(20)
-         .create())
+order = (rapi.create_compare_order("Simple Compare")
+        .criteria("Which logo looks better?")
+        .media([["examples/data/rapidata_logo.png", 
+                 "examples/data/rapidata_concept_logo.jpg"]])
+        .votes(20)
+        .create())
 print("order id: ", order.order_id)
 # Optionally save the order ID to a file
 with open("order_ids.txt", "a") as file:

--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -8,6 +8,8 @@ from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.order.rapidata_order import RapidataOrder
 from rapidata.rapidata_client.dataset.rapidata_dataset import RapidataDataset
 
+from rapidata.rapidata_client.simple_builders.simple_classification_builders import ClassificationQuestionBuilder
+from rapidata.rapidata_client.simple_builders.simple_compare_builders import CompareCriteriaBuilder
 
 
 class RapidataClient:
@@ -81,6 +83,28 @@ class RapidataClient:
             dataset=temp_dataset, 
             order_id=order_id, 
             openapi_service=self.openapi_service)
+    
+    def create_classify_order(self, name: str) -> ClassificationQuestionBuilder:
+        """Create a new classification order where people are asked to classify an image.
+
+        Args:
+            name (str): The name of the order.
+
+        Returns:
+            ClassificationQuestionBuilder: A ClassificationQuestionBuilder instance.
+        """
+        return ClassificationQuestionBuilder(name=name, openapi_service=self.openapi_service)
+    
+    def create_compare_order(self, name: str) -> CompareCriteriaBuilder:
+        """Create a new comparison order where people are asked to compare two images.
+
+        Args:
+            name (str): The name of the order.
+
+        Returns:
+            CompareQuestionBuilder: A CompareQuestionBuilder instance.
+        """
+        return CompareCriteriaBuilder(name=name, openapi_service=self.openapi_service)
 
     @property
     def utils(self) -> Utils:

--- a/src/rapidata/rapidata_client/simple_builders/simple_classification_builders.py
+++ b/src/rapidata/rapidata_client/simple_builders/simple_classification_builders.py
@@ -39,7 +39,7 @@ class ClassificationOrderBuilder:
         self._validation_set_id = validation_set_id
         return self
     
-    def create(self, submit: bool = False, max_upload_workers: int = 10):
+    def create(self, submit: bool = True, max_upload_workers: int = 10):
         if self._probability_threshold and self._votes_required:
             referee = ClassifyEarlyStoppingReferee(
                 max_vote_count=self._votes_required,

--- a/src/rapidata/rapidata_client/simple_builders/simple_classification_builders.py
+++ b/src/rapidata/rapidata_client/simple_builders/simple_classification_builders.py
@@ -1,0 +1,122 @@
+from rapidata.rapidata_client.order.rapidata_order_builder import RapidataOrderBuilder
+from rapidata.rapidata_client.metadata.base_metadata import Metadata
+from rapidata.rapidata_client.referee.naive_referee import NaiveReferee
+from rapidata.rapidata_client.referee.classify_early_stopping_referee import ClassifyEarlyStoppingReferee
+from rapidata.rapidata_client.selection.base_selection import Selection
+from rapidata.rapidata_client.workflow.classify_workflow import ClassifyWorkflow
+from rapidata.rapidata_client.selection.validation_selection import ValidationSelection
+from rapidata.rapidata_client.selection.labeling_selection import LabelingSelection
+from rapidata.service.openapi_service import OpenAPIService
+
+class ClassificationOrderBuilder:
+    def __init__(self, name: str, question: str, options: list[str], media_paths: list[str], openapi_service: OpenAPIService):
+        self._order_builder = RapidataOrderBuilder(name=name, openapi_service=openapi_service)
+        self._question = question
+        self._options = options
+        self._media_paths = media_paths
+        self._votes_required = 10
+        self._probability_threshold = None
+        self._metadata = None
+        self._validation_set_id = None
+
+    def metadata(self, metadata: list[Metadata]):
+        """Set the metadata for the classification order."""
+        self._metadata = metadata
+        return self
+
+    def votes(self, votes_required: int):
+        """Set the number of votes required for the classification order."""
+        self._votes_required = votes_required
+        return self
+    
+    def probability_threshold(self, probability_threshold: float):
+        """Set the probability threshold for early stopping."""
+        self._probability_threshold = probability_threshold
+        return self
+    
+    def validation_set_id(self, validation_set_id: str):
+        """Set the validation set ID for the classification order."""
+        self._validation_set_id = validation_set_id
+        return self
+    
+    def create(self, submit: bool = False, max_upload_workers: int = 10):
+        if self._probability_threshold and self._votes_required:
+            referee = ClassifyEarlyStoppingReferee(
+                max_vote_count=self._votes_required,
+                threshold=self._probability_threshold
+            )
+            
+        else:
+            referee = NaiveReferee(required_guesses=self._votes_required)
+        
+        selection: list[Selection] = ([ValidationSelection(amount=1, validation_set_id=self._validation_set_id), LabelingSelection(amount=2)] 
+                     if self._validation_set_id 
+                     else [LabelingSelection(amount=3)])
+
+        order = (self._order_builder
+            .workflow(
+                ClassifyWorkflow(
+                    question=self._question,
+                    options=self._options
+                )
+            )
+            .referee(referee)
+            .media(self._media_paths, metadata=self._metadata) # type: ignore
+            .selections(selection)
+            .create(submit=submit, max_workers=max_upload_workers))
+
+        return order 
+    
+
+class ClassificationMediaBuilder:
+    def __init__(self, name: str, question: str, options: list[str], openapi_service: OpenAPIService):
+        self._openapi_service = openapi_service
+        self._name = name
+        self._question = question
+        self._options = options
+        self._media_paths = None
+
+    def media(self, media_paths: list[str]) -> ClassificationOrderBuilder:
+        """Set the media assets for the classification order by providing the local paths to the files."""
+        self._media_paths = media_paths
+        return self._build()
+
+    def _build(self) -> ClassificationOrderBuilder:
+        if self._media_paths is None:
+            raise ValueError("Media paths are required")
+        return ClassificationOrderBuilder(self._name, self._question, self._options, self._media_paths, openapi_service=self._openapi_service)
+    
+
+class ClassificationOptionsBuilder:
+    def __init__(self, name: str, question: str, openapi_service: OpenAPIService):
+        self._openapi_service = openapi_service
+        self._name = name
+        self._question = question
+        self._options = None
+
+    def options(self, options: list[str]) -> ClassificationMediaBuilder:
+        """Set the answer options for the classification order."""
+        self._options = options
+        return self._build()
+
+    def _build(self) -> ClassificationMediaBuilder:
+        if self._options is None:
+            raise ValueError("Options are required")
+        return ClassificationMediaBuilder(self._name, self._question, self._options, self._openapi_service)
+
+
+class ClassificationQuestionBuilder:
+    def __init__(self, name: str, openapi_service: OpenAPIService):
+        self._openapi_service = openapi_service
+        self._name = name
+        self._question = None
+
+    def question(self, question: str) -> ClassificationOptionsBuilder:
+        """Set the question for the classification order."""
+        self._question = question
+        return self._build()
+
+    def _build(self) -> ClassificationOptionsBuilder:
+        if self._question is None:
+            raise ValueError("Question is required")
+        return ClassificationOptionsBuilder(self._name, self._question, self._openapi_service)

--- a/src/rapidata/rapidata_client/simple_builders/simple_classification_builders.py
+++ b/src/rapidata/rapidata_client/simple_builders/simple_classification_builders.py
@@ -14,19 +14,19 @@ class ClassificationOrderBuilder:
         self._question = question
         self._options = options
         self._media_paths = media_paths
-        self._votes_required = 10
+        self._responses_required = 10
         self._probability_threshold = None
         self._metadata = None
         self._validation_set_id = None
 
     def metadata(self, metadata: list[Metadata]):
-        """Set the metadata for the classification order."""
+        """Set the metadata for the classification order. Has to be the same lenght as the media paths."""
         self._metadata = metadata
         return self
 
-    def votes(self, votes_required: int):
-        """Set the number of votes required for the classification order."""
-        self._votes_required = votes_required
+    def responses(self, responses_required: int):
+        """Set the number of responses required for the classification order."""
+        self._responses_required = responses_required
         return self
     
     def probability_threshold(self, probability_threshold: float):
@@ -40,14 +40,14 @@ class ClassificationOrderBuilder:
         return self
     
     def create(self, submit: bool = True, max_upload_workers: int = 10):
-        if self._probability_threshold and self._votes_required:
+        if self._probability_threshold and self._responses_required:
             referee = ClassifyEarlyStoppingReferee(
-                max_vote_count=self._votes_required,
+                max_vote_count=self._responses_required,
                 threshold=self._probability_threshold
             )
             
         else:
-            referee = NaiveReferee(required_guesses=self._votes_required)
+            referee = NaiveReferee(required_guesses=self._responses_required)
         
         selection: list[Selection] = ([ValidationSelection(amount=1, validation_set_id=self._validation_set_id), LabelingSelection(amount=2)] 
                      if self._validation_set_id 

--- a/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
+++ b/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
@@ -17,7 +17,7 @@ class CompareOrderBuilder:
         self._metadata = None
         self._validation_set_id = None
 
-    def votes_required(self, votes_required: int) -> 'CompareOrderBuilder':
+    def votes(self, votes_required: int) -> 'CompareOrderBuilder':
         """Set the number of votes required for the comparison order."""
         self._votes_required = votes_required
         return self
@@ -32,7 +32,7 @@ class CompareOrderBuilder:
         self._validation_set_id = validation_set_id
         return self
     
-    def create(self, submit: bool = False, max_upload_workers: int = 10):
+    def create(self, submit: bool = True, max_upload_workers: int = 10):
         selection: list[Selection] = ([ValidationSelection(amount=1, validation_set_id=self._validation_set_id), LabelingSelection(amount=2)] 
                      if self._validation_set_id 
                      else [LabelingSelection(amount=3)])

--- a/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
+++ b/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
@@ -8,7 +8,7 @@ from rapidata.rapidata_client.selection.labeling_selection import LabelingSelect
 from rapidata.rapidata_client.selection.base_selection import Selection
 
 class CompareOrderBuilder:
-    def __init__(self, name:str, criteria: str, media_paths: list[str], openapi_service: OpenAPIService):
+    def __init__(self, name:str, criteria: str, media_paths: list[list[str]], openapi_service: OpenAPIService):
         self._order_builder = RapidataOrderBuilder(name=name, openapi_service=openapi_service)
         self._name = name
         self._criteria = criteria
@@ -57,7 +57,7 @@ class CompareMediaBuilder:
         self._criteria = criteria
         self._media_paths = None
 
-    def media(self, media_paths: list[str]) -> CompareOrderBuilder:
+    def media(self, media_paths: list[list[str]]) -> CompareOrderBuilder:
         """Set the media assets for the comparison order by providing the local paths to the files."""
         self._media_paths = media_paths
         return self._build()

--- a/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
+++ b/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
@@ -1,0 +1,86 @@
+from rapidata.service.openapi_service import OpenAPIService
+from rapidata.rapidata_client.metadata.base_metadata import Metadata
+from rapidata.rapidata_client.order.rapidata_order_builder import RapidataOrderBuilder
+from rapidata.rapidata_client.workflow.compare_workflow import CompareWorkflow
+from rapidata.rapidata_client.referee.naive_referee import NaiveReferee
+from rapidata.rapidata_client.selection.validation_selection import ValidationSelection
+from rapidata.rapidata_client.selection.labeling_selection import LabelingSelection
+from rapidata.rapidata_client.selection.base_selection import Selection
+
+class CompareOrderBuilder:
+    def __init__(self, name:str, criteria: str, media_paths: list[str], openapi_service: OpenAPIService):
+        self._order_builder = RapidataOrderBuilder(name=name, openapi_service=openapi_service)
+        self._name = name
+        self._criteria = criteria
+        self._media_paths = media_paths
+        self._votes_required = 10
+        self._metadata = None
+        self._validation_set_id = None
+
+    def votes_required(self, votes_required: int) -> 'CompareOrderBuilder':
+        """Set the number of votes required for the comparison order."""
+        self._votes_required = votes_required
+        return self
+    
+    def metadata(self, metadata: list[Metadata]) -> 'CompareOrderBuilder':
+        """Set the metadata for the comparison order."""
+        self._metadata = metadata
+        return self
+    
+    def validation_set_id(self, validation_set_id: str) -> 'CompareOrderBuilder':
+        """Set the validation set ID for the comparison order."""
+        self._validation_set_id = validation_set_id
+        return self
+    
+    def create(self, submit: bool = False, max_upload_workers: int = 10):
+        selection: list[Selection] = ([ValidationSelection(amount=1, validation_set_id=self._validation_set_id), LabelingSelection(amount=2)] 
+                     if self._validation_set_id 
+                     else [LabelingSelection(amount=3)])
+        
+        order = (self._order_builder
+            .workflow(
+                CompareWorkflow(
+                    criteria=self._criteria
+                )
+            )
+            .referee(NaiveReferee(required_guesses=self._votes_required))
+            .media(self._media_paths, metadata=self._metadata) # type: ignore
+            .selections(selection)
+            .create(submit=submit, max_workers=max_upload_workers))
+        
+        return order
+
+class CompareMediaBuilder:
+    def __init__(self, name: str, criteria: str, openapi_service: OpenAPIService):
+        self._openapi_service = openapi_service
+        self._name = name
+        self._criteria = criteria
+        self._media_paths = None
+
+    def media(self, media_paths: list[str]) -> CompareOrderBuilder:
+        """Set the media assets for the comparison order by providing the local paths to the files."""
+        self._media_paths = media_paths
+        return self._build()
+    
+    def _build(self) -> CompareOrderBuilder:
+        if self._media_paths is None:
+            raise ValueError("Media paths are required")
+        assert all([len(path) == 2 for path in self._media_paths]), "The media paths must come in pairs for comparison tasks."
+        return CompareOrderBuilder(self._name, self._criteria, self._media_paths, self._openapi_service)
+
+class CompareCriteriaBuilder:
+    def __init__(self, name: str, openapi_service: OpenAPIService):
+        self._openapi_service = openapi_service
+        self._name = name
+        self._criteria = None
+
+    def criteria(self, criteria: str) -> CompareMediaBuilder:
+        """Set the criteria how the images should be compared."""
+        self._criteria = criteria
+        return self._build()
+    
+    def _build(self) -> CompareMediaBuilder:
+        if self._criteria is None:
+            raise ValueError("Criteria are required")
+        return CompareMediaBuilder(self._name, self._criteria, self._openapi_service)
+

--- a/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
+++ b/src/rapidata/rapidata_client/simple_builders/simple_compare_builders.py
@@ -13,17 +13,17 @@ class CompareOrderBuilder:
         self._name = name
         self._criteria = criteria
         self._media_paths = media_paths
-        self._votes_required = 10
+        self._responses_required = 10
         self._metadata = None
         self._validation_set_id = None
 
-    def votes(self, votes_required: int) -> 'CompareOrderBuilder':
-        """Set the number of votes required for the comparison order."""
-        self._votes_required = votes_required
+    def responses(self, responses_required: int) -> 'CompareOrderBuilder':
+        """Set the number of resoonses required per matchup/pairing for the comparison order."""
+        self._responses_required = responses_required
         return self
     
     def metadata(self, metadata: list[Metadata]) -> 'CompareOrderBuilder':
-        """Set the metadata for the comparison order."""
+        """Set the metadata for the comparison order. Has to be the same shape as the media paths."""
         self._metadata = metadata
         return self
     
@@ -43,7 +43,7 @@ class CompareOrderBuilder:
                     criteria=self._criteria
                 )
             )
-            .referee(NaiveReferee(required_guesses=self._votes_required))
+            .referee(NaiveReferee(required_guesses=self._responses_required))
             .media(self._media_paths, metadata=self._metadata) # type: ignore
             .selections(selection)
             .create(submit=submit, max_workers=max_upload_workers))


### PR DESCRIPTION
example usage: rapi.create_classify_order("classifcaiton order").question("what is this?").options(["a", "b", "c"]).media(["C:\\Users\\linog\\Pictures\\example_jpg.jpg"]).create()

i'd just start with those 2 order types and then see if it's widely used and then add it for the others.