### PR TITLE
fix: return payload directly in _get_payload instead of re-wrapping

### DIFF
--- a/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
+++ b/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
@@ -131,6 +131,4 @@ class ValidationRapidUploader:
         return rapid.truth
 
     def _get_payload(self, rapid: Rapid) -> IRapidPayload:
-        if isinstance(rapid.payload, dict):
-            return IRapidPayload(actual_instance=rapid.payload)
-        return IRapidPayload(actual_instance=rapid.payload.to_dict())
+        return rapid.payload


### PR DESCRIPTION
## Problem

`ValidationRapidUploader._get_payload()` was broken for all validation rapid uploads. The method called `.to_dict()` on `rapid.payload` (which is already an `IRapidPayload`), converting it to a plain `dict`, then tried to wrap that dict in a new `IRapidPayload(actual_instance=dict)`.

This fails immediately because `IRapidPayload` uses a pydantic `field_validator` (`actual_instance_must_validate_oneof`) that strictly checks the type of `actual_instance` against a list of allowed payload types (e.g. `IRapidPayloadClassifyPayload`, `IRapidPayloadLocatePayload`, etc.). A plain `dict` matches none of them → `ValueError: No match found`.

This caused classify orders (and all other rapid types) with a validation set to fail at the `add_rapid()` step.

## Fix

`rapid.payload` is already typed as `IRapidPayload` (see `rapids.py` line 12). Simply return it directly — no wrapping needed.

```python
# Before (broken)
def _get_payload(self, rapid: Rapid) -> IRapidPayload:
    if isinstance(rapid.payload, dict):
        return IRapidPayload(actual_instance=rapid.payload)
    return IRapidPayload(actual_instance=rapid.payload.to_dict())

# After (fixed)
def _get_payload(self, rapid: Rapid) -> IRapidPayload:
    return rapid.payload
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)