### PR TITLE
fix: update blueprint discriminator values to match new backend contract

### DIFF
--- a/src/rapidata/api_client/models/attach_category_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/attach_category_rapid_blueprint.py
@@ -27,7 +27,7 @@ class AttachCategoryRapidBlueprint(BaseModel):
     """
     AttachCategoryRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for ClassifyBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for AttachCategoryRapidBlueprint", alias="_t")
     possible_categories: Optional[List[StrictStr]] = Field(default=None, alias="possibleCategories")
     categories: Optional[List[AttachCategoryRapidBlueprintCategory]] = None
     title: StrictStr
@@ -36,8 +36,8 @@ class AttachCategoryRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['ClassifyBlueprint']):
-            raise ValueError("must be one of enum values ('ClassifyBlueprint')")
+        if value not in set(['AttachCategoryRapidBlueprint']):
+            raise ValueError("must be one of enum values ('AttachCategoryRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -98,7 +98,7 @@ class AttachCategoryRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'ClassifyBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'AttachCategoryRapidBlueprint',
             "possibleCategories": obj.get("possibleCategories"),
             "categories": [AttachCategoryRapidBlueprintCategory.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None,
             "title": obj.get("title")

--- a/src/rapidata/api_client/models/bounding_box_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/bounding_box_rapid_blueprint.py
@@ -26,15 +26,15 @@ class BoundingBoxRapidBlueprint(BaseModel):
     """
     BoundingBoxRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for BoundingBoxBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for BoundingBoxRapidBlueprint", alias="_t")
     target: StrictStr
     __properties: ClassVar[List[str]] = ["_t", "target"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['BoundingBoxBlueprint']):
-            raise ValueError("must be one of enum values ('BoundingBoxBlueprint')")
+        if value not in set(['BoundingBoxRapidBlueprint']):
+            raise ValueError("must be one of enum values ('BoundingBoxRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -88,7 +88,7 @@ class BoundingBoxRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'BoundingBoxBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'BoundingBoxRapidBlueprint',
             "target": obj.get("target")
         })
         return _obj

--- a/src/rapidata/api_client/models/compare_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/compare_rapid_blueprint.py
@@ -26,7 +26,7 @@ class CompareRapidBlueprint(BaseModel):
     """
     CompareRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for CompareBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for CompareRapidBlueprint", alias="_t")
     criteria: StrictStr
     index_identifiers: Optional[List[StrictStr]] = Field(default=None, alias="indexIdentifiers")
     __properties: ClassVar[List[str]] = ["_t", "criteria", "indexIdentifiers"]
@@ -34,8 +34,8 @@ class CompareRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['CompareBlueprint']):
-            raise ValueError("must be one of enum values ('CompareBlueprint')")
+        if value not in set(['CompareRapidBlueprint']):
+            raise ValueError("must be one of enum values ('CompareRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -89,7 +89,7 @@ class CompareRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'CompareBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'CompareRapidBlueprint',
             "criteria": obj.get("criteria"),
             "indexIdentifiers": obj.get("indexIdentifiers")
         })

--- a/src/rapidata/api_client/models/compare_rapid_blueprint1.py
+++ b/src/rapidata/api_client/models/compare_rapid_blueprint1.py
@@ -26,15 +26,15 @@ class CompareRapidBlueprint1(BaseModel):
     """
     CompareRapidBlueprint1
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for CompareBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for CompareRapidBlueprint", alias="_t")
     criteria: StrictStr
     __properties: ClassVar[List[str]] = ["_t", "criteria"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['CompareBlueprint']):
-            raise ValueError("must be one of enum values ('CompareBlueprint')")
+        if value not in set(['CompareRapidBlueprint']):
+            raise ValueError("must be one of enum values ('CompareRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -88,7 +88,7 @@ class CompareRapidBlueprint1(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'CompareBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'CompareRapidBlueprint',
             "criteria": obj.get("criteria")
         })
         return _obj

--- a/src/rapidata/api_client/models/free_text_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/free_text_rapid_blueprint.py
@@ -26,7 +26,7 @@ class FreeTextRapidBlueprint(BaseModel):
     """
     FreeTextRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for FreeTextBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for FreeTextRapidBlueprint", alias="_t")
     question: StrictStr
     validation_system_prompt: Optional[StrictStr] = Field(default=None, alias="validationSystemPrompt")
     __properties: ClassVar[List[str]] = ["_t", "question", "validationSystemPrompt"]
@@ -34,8 +34,8 @@ class FreeTextRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['FreeTextBlueprint']):
-            raise ValueError("must be one of enum values ('FreeTextBlueprint')")
+        if value not in set(['FreeTextRapidBlueprint']):
+            raise ValueError("must be one of enum values ('FreeTextRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -94,7 +94,7 @@ class FreeTextRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'FreeTextBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'FreeTextRapidBlueprint',
             "question": obj.get("question"),
             "validationSystemPrompt": obj.get("validationSystemPrompt")
         })

--- a/src/rapidata/api_client/models/i_rapid_blueprint_attach_category_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_attach_category_rapid_blueprint.py
@@ -36,8 +36,8 @@ class IRapidBlueprintAttachCategoryRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['ClassifyBlueprint']):
-            raise ValueError("must be one of enum values ('ClassifyBlueprint')")
+        if value not in set(['AttachCategoryRapidBlueprint']):
+            raise ValueError("must be one of enum values ('AttachCategoryRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_bounding_box_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_bounding_box_rapid_blueprint.py
@@ -33,8 +33,8 @@ class IRapidBlueprintBoundingBoxRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['BoundingBoxBlueprint']):
-            raise ValueError("must be one of enum values ('BoundingBoxBlueprint')")
+        if value not in set(['BoundingBoxRapidBlueprint']):
+            raise ValueError("must be one of enum values ('BoundingBoxRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_compare_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_compare_rapid_blueprint.py
@@ -34,8 +34,8 @@ class IRapidBlueprintCompareRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['CompareBlueprint']):
-            raise ValueError("must be one of enum values ('CompareBlueprint')")
+        if value not in set(['CompareRapidBlueprint']):
+            raise ValueError("must be one of enum values ('CompareRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_free_text_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_free_text_rapid_blueprint.py
@@ -35,8 +35,8 @@ class IRapidBlueprintFreeTextRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['FreeTextBlueprint']):
-            raise ValueError("must be one of enum values ('FreeTextBlueprint')")
+        if value not in set(['FreeTextRapidBlueprint']):
+            raise ValueError("must be one of enum values ('FreeTextRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_line_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_line_rapid_blueprint.py
@@ -33,8 +33,8 @@ class IRapidBlueprintLineRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['LineBlueprint']):
-            raise ValueError("must be one of enum values ('LineBlueprint')")
+        if value not in set(['LineRapidBlueprint']):
+            raise ValueError("must be one of enum values ('LineRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_locate_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_locate_rapid_blueprint.py
@@ -33,8 +33,8 @@ class IRapidBlueprintLocateRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['LocateBlueprint']):
-            raise ValueError("must be one of enum values ('LocateBlueprint')")
+        if value not in set(['LocateRapidBlueprint']):
+            raise ValueError("must be one of enum values ('LocateRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_named_entity_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_named_entity_rapid_blueprint.py
@@ -34,8 +34,8 @@ class IRapidBlueprintNamedEntityRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['NamedEntityBlueprint']):
-            raise ValueError("must be one of enum values ('NamedEntityBlueprint')")
+        if value not in set(['NamedEntityRapidBlueprint']):
+            raise ValueError("must be one of enum values ('NamedEntityRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_polygon_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_polygon_rapid_blueprint.py
@@ -33,8 +33,8 @@ class IRapidBlueprintPolygonRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['PolygonBlueprint']):
-            raise ValueError("must be one of enum values ('PolygonBlueprint')")
+        if value not in set(['PolygonRapidBlueprint']):
+            raise ValueError("must be one of enum values ('PolygonRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_scrub_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_scrub_rapid_blueprint.py
@@ -33,8 +33,8 @@ class IRapidBlueprintScrubRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['ScrubBlueprint']):
-            raise ValueError("must be one of enum values ('ScrubBlueprint')")
+        if value not in set(['ScrubRapidBlueprint']):
+            raise ValueError("must be one of enum values ('ScrubRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/i_rapid_blueprint_transcription_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/i_rapid_blueprint_transcription_rapid_blueprint.py
@@ -33,8 +33,8 @@ class IRapidBlueprintTranscriptionRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['TranscriptionBlueprint']):
-            raise ValueError("must be one of enum values ('TranscriptionBlueprint')")
+        if value not in set(['TranscriptionRapidBlueprint']):
+            raise ValueError("must be one of enum values ('TranscriptionRapidBlueprint')")
         return value
 
     model_config = ConfigDict(

--- a/src/rapidata/api_client/models/line_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/line_rapid_blueprint.py
@@ -26,15 +26,15 @@ class LineRapidBlueprint(BaseModel):
     """
     LineRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for LineBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for LineRapidBlueprint", alias="_t")
     target: StrictStr
     __properties: ClassVar[List[str]] = ["_t", "target"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['LineBlueprint']):
-            raise ValueError("must be one of enum values ('LineBlueprint')")
+        if value not in set(['LineRapidBlueprint']):
+            raise ValueError("must be one of enum values ('LineRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -88,7 +88,7 @@ class LineRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'LineBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'LineRapidBlueprint',
             "target": obj.get("target")
         })
         return _obj

--- a/src/rapidata/api_client/models/locate_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/locate_rapid_blueprint.py
@@ -26,15 +26,15 @@ class LocateRapidBlueprint(BaseModel):
     """
     LocateRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for LocateBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for LocateRapidBlueprint", alias="_t")
     target: StrictStr
     __properties: ClassVar[List[str]] = ["_t", "target"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['LocateBlueprint']):
-            raise ValueError("must be one of enum values ('LocateBlueprint')")
+        if value not in set(['LocateRapidBlueprint']):
+            raise ValueError("must be one of enum values ('LocateRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -88,7 +88,7 @@ class LocateRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'LocateBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'LocateRapidBlueprint',
             "target": obj.get("target")
         })
         return _obj

--- a/src/rapidata/api_client/models/named_entity_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/named_entity_rapid_blueprint.py
@@ -26,7 +26,7 @@ class NamedEntityRapidBlueprint(BaseModel):
     """
     NamedEntityRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for NamedEntityBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for NamedEntityRapidBlueprint", alias="_t")
     target: StrictStr
     classes: List[StrictStr]
     __properties: ClassVar[List[str]] = ["_t", "target", "classes"]
@@ -34,8 +34,8 @@ class NamedEntityRapidBlueprint(BaseModel):
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['NamedEntityBlueprint']):
-            raise ValueError("must be one of enum values ('NamedEntityBlueprint')")
+        if value not in set(['NamedEntityRapidBlueprint']):
+            raise ValueError("must be one of enum values ('NamedEntityRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -89,7 +89,7 @@ class NamedEntityRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'NamedEntityBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'NamedEntityRapidBlueprint',
             "target": obj.get("target"),
             "classes": obj.get("classes")
         })

--- a/src/rapidata/api_client/models/polygon_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/polygon_rapid_blueprint.py
@@ -26,15 +26,15 @@ class PolygonRapidBlueprint(BaseModel):
     """
     PolygonRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for PolygonBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for PolygonRapidBlueprint", alias="_t")
     target: StrictStr
     __properties: ClassVar[List[str]] = ["_t", "target"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['PolygonBlueprint']):
-            raise ValueError("must be one of enum values ('PolygonBlueprint')")
+        if value not in set(['PolygonRapidBlueprint']):
+            raise ValueError("must be one of enum values ('PolygonRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -88,7 +88,7 @@ class PolygonRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'PolygonBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'PolygonRapidBlueprint',
             "target": obj.get("target")
         })
         return _obj

--- a/src/rapidata/api_client/models/scrub_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/scrub_rapid_blueprint.py
@@ -26,15 +26,15 @@ class ScrubRapidBlueprint(BaseModel):
     """
     ScrubRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for ScrubBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for ScrubRapidBlueprint", alias="_t")
     target: StrictStr
     __properties: ClassVar[List[str]] = ["_t", "target"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['ScrubBlueprint']):
-            raise ValueError("must be one of enum values ('ScrubBlueprint')")
+        if value not in set(['ScrubRapidBlueprint']):
+            raise ValueError("must be one of enum values ('ScrubRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -88,7 +88,7 @@ class ScrubRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'ScrubBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'ScrubRapidBlueprint',
             "target": obj.get("target")
         })
         return _obj

--- a/src/rapidata/api_client/models/transcription_rapid_blueprint.py
+++ b/src/rapidata/api_client/models/transcription_rapid_blueprint.py
@@ -26,15 +26,15 @@ class TranscriptionRapidBlueprint(BaseModel):
     """
     TranscriptionRapidBlueprint
     """ # noqa: E501
-    t: StrictStr = Field(description="Discriminator value for TranscriptionBlueprint", alias="_t")
+    t: StrictStr = Field(description="Discriminator value for TranscriptionRapidBlueprint", alias="_t")
     title: StrictStr
     __properties: ClassVar[List[str]] = ["_t", "title"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['TranscriptionBlueprint']):
-            raise ValueError("must be one of enum values ('TranscriptionBlueprint')")
+        if value not in set(['TranscriptionRapidBlueprint']):
+            raise ValueError("must be one of enum values ('TranscriptionRapidBlueprint')")
         return value
 
     model_config = ConfigDict(
@@ -88,7 +88,7 @@ class TranscriptionRapidBlueprint(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "_t": obj.get("_t") if obj.get("_t") is not None else 'TranscriptionBlueprint',
+            "_t": obj.get("_t") if obj.get("_t") is not None else 'TranscriptionRapidBlueprint',
             "title": obj.get("title")
         })
         return _obj

--- a/src/rapidata/rapidata_client/workflow/_classify_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_classify_workflow.py
@@ -50,7 +50,7 @@ class ClassifyWorkflow(Workflow):
         return {
             **super()._to_dict(),
             "blueprint": {
-                "_t": "ClassifyBlueprint",
+                "_t": "AttachCategoryRapidBlueprint",
                 "title": self._instruction,
                 "possibleCategories": self._answer_options,
             },
@@ -58,7 +58,7 @@ class ClassifyWorkflow(Workflow):
 
     def _to_model(self) -> IOrderWorkflowModel:
         blueprint = IRapidBlueprintAttachCategoryRapidBlueprint(
-            _t="ClassifyBlueprint",
+            _t="AttachCategoryRapidBlueprint",
             title=self._instruction,
             categories=[
                 AttachCategoryRapidBlueprintCategory(label=option, value=option)

--- a/src/rapidata/rapidata_client/workflow/_compare_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_compare_workflow.py
@@ -49,7 +49,7 @@ class CompareWorkflow(Workflow):
 
     def _to_model(self) -> IOrderWorkflowModel:
         blueprint = IRapidBlueprintCompareRapidBlueprint(
-            _t="CompareBlueprint",
+            _t="CompareRapidBlueprint",
             criteria=self._instruction,
             indexIdentifiers=self._a_b_names,
         )

--- a/src/rapidata/rapidata_client/workflow/_draw_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_draw_workflow.py
@@ -27,7 +27,7 @@ class DrawWorkflow(Workflow):
 
     def _to_model(self) -> IOrderWorkflowModel:
         blueprint = IRapidBlueprintLineRapidBlueprint(
-            _t="LineBlueprint", target=self._target
+            _t="LineRapidBlueprint", target=self._target
         )
 
         return IOrderWorkflowModel(

--- a/src/rapidata/rapidata_client/workflow/_free_text_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_free_text_workflow.py
@@ -46,7 +46,7 @@ class FreeTextWorkflow(Workflow):
         return {
             **super()._to_dict(),
             "blueprint": {
-                "_t": "FreeTextBlueprint",
+                "_t": "FreeTextRapidBlueprint",
                 "question": self._instruction,
                 "validationSystemPrompt": self._validation_system_prompt,
             },
@@ -54,7 +54,7 @@ class FreeTextWorkflow(Workflow):
 
     def _to_model(self) -> IOrderWorkflowModel:
         blueprint = IRapidBlueprintFreeTextRapidBlueprint(
-            _t="FreeTextBlueprint",
+            _t="FreeTextRapidBlueprint",
             question=self._instruction,
             validationSystemPrompt=self._validation_system_prompt,
         )

--- a/src/rapidata/rapidata_client/workflow/_locate_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_locate_workflow.py
@@ -27,7 +27,7 @@ class LocateWorkflow(Workflow):
 
     def _to_model(self) -> IOrderWorkflowModel:
         blueprint = IRapidBlueprintLocateRapidBlueprint(
-            _t="LocateBlueprint", target=self._target
+            _t="LocateRapidBlueprint", target=self._target
         )
 
         return IOrderWorkflowModel(

--- a/src/rapidata/rapidata_client/workflow/_select_words_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_select_words_workflow.py
@@ -41,7 +41,7 @@ class SelectWordsWorkflow(Workflow):
 
     def _to_model(self) -> IOrderWorkflowModel:
         blueprint = IRapidBlueprintTranscriptionRapidBlueprint(
-            _t="TranscriptionBlueprint", title=self._instruction
+            _t="TranscriptionRapidBlueprint", title=self._instruction
         )
 
         return IOrderWorkflowModel(

--- a/src/rapidata/rapidata_client/workflow/_timestamp_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_timestamp_workflow.py
@@ -40,7 +40,7 @@ class TimestampWorkflow(Workflow):
 
     def _to_model(self) -> IOrderWorkflowModel:
         blueprint = IRapidBlueprintScrubRapidBlueprint(
-            _t="ScrubBlueprint", target=self._instruction
+            _t="ScrubRapidBlueprint", target=self._instruction
         )
 
         return IOrderWorkflowModel(


### PR DESCRIPTION
## Summary

- The backend refactor (`e2d7cf5`) changed `SimpleWorkflowModel.Blueprint` to use `Rapidata.Workflow.Contracts.Models.IRapidBlueprint`, where generated types have no `[DiscriminatedName]` attribute — so `GetDiscriminatedName()` falls back to the raw class name (e.g. `CompareRapidBlueprint`)
- The SDK was still sending the old short names (e.g. `_t="CompareBlueprint"`), causing silent 400 errors on all order/job creation endpoints
- Backend PR RapidataAI/rapidata-backend#3946 added backward-compatible aliases; this PR aligns the SDK with the new native discriminator values so we're not reliant on those aliases

## Changes

Updates all 10 blueprint `_t` discriminator values across 28 files:

| Old value | New value |
|---|---|
| `ClassifyBlueprint` | `AttachCategoryRapidBlueprint` |
| `BoundingBoxBlueprint` | `BoundingBoxRapidBlueprint` |
| `CompareBlueprint` | `CompareRapidBlueprint` |
| `FreeTextBlueprint` | `FreeTextRapidBlueprint` |
| `LineBlueprint` | `LineRapidBlueprint` |
| `LocateBlueprint` | `LocateRapidBlueprint` |
| `NamedEntityBlueprint` | `NamedEntityRapidBlueprint` |
| `PolygonBlueprint` | `PolygonRapidBlueprint` |
| `ScrubBlueprint` | `ScrubRapidBlueprint` |
| `TranscriptionBlueprint` | `TranscriptionRapidBlueprint` |

Affected file groups:
- 11 OpenAPI-generated concrete model files (`*_rapid_blueprint.py`)
- 10 OpenAPI-generated interface model files (`i_rapid_blueprint_*.py`)
- 7 high-level workflow wrappers (`_classify_workflow.py`, `_compare_workflow.py`, `_locate_workflow.py`, `_free_text_workflow.py`, `_draw_workflow.py`, `_select_words_workflow.py`, `_timestamp_workflow.py`)

## Scope

Not just orders — **all blueprint types** across orders and jobs are affected since both use the same `IRapidBlueprint` interface with the same discriminator issue.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)