### PR TITLE
Surface outdated SDK warning inside API error messages

### DIFF
--- a/src/rapidata/api_client/lazy_model.py
+++ b/src/rapidata/api_client/lazy_model.py
@@ -142,8 +142,18 @@ class LazyValidatedModel(BaseModel):
                 errors = None
             if errors and name in errors:
                 err = errors[name]
-                raise TypeError(
+                message = (
                     f"Field '{name}' on {type(self).__name__} has an unexpected "
                     f"type from the backend: {err.get('msg', err)}"
                 )
+                # Imported lazily to avoid pulling the higher SDK layer at
+                # module import time (this base class is imported by every
+                # generated model).
+                from rapidata.rapidata_client.api.rapidata_api_client import (
+                    format_outdated_sdk_note,
+                )
+                note = format_outdated_sdk_note()
+                if note:
+                    message = f"{message}\n{note}"
+                raise TypeError(message)
         return super().__getattribute__(name)

--- a/src/rapidata/rapidata_client/api/rapidata_api_client.py
+++ b/src/rapidata/rapidata_client/api/rapidata_api_client.py
@@ -7,6 +7,7 @@ from rapidata.api_client.api_client import (
 )
 from rapidata.api_client.exceptions import ApiException
 import json
+import os
 import sys
 import threading
 from contextlib import contextmanager
@@ -62,14 +63,38 @@ def _format_outdated_sdk_note() -> Optional[str]:
     )
 
 
+# Path fragment used to detect whether an exception's traceback passes
+# through the rapidata package. Computed from this file's location so it
+# works for editable installs, site-packages installs, and source checkouts.
+# Resolves to .../rapidata/  (three dirs up from rapidata_client/api/rapidata_api_client.py)
+_RAPIDATA_PKG_PATH = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+
+def _traceback_touches_rapidata(exc_traceback) -> bool:
+    """Return True if any frame in the traceback comes from the rapidata package."""
+    tb = exc_traceback
+    while tb is not None:
+        filename = tb.tb_frame.f_code.co_filename
+        try:
+            if os.path.commonpath([os.path.abspath(filename), _RAPIDATA_PKG_PATH]) == _RAPIDATA_PKG_PATH:
+                return True
+        except (ValueError, OSError):
+            # commonpath raises if paths are on different drives (Windows) or invalid
+            pass
+        tb = tb.tb_next
+    return False
+
+
 _excepthook_installed = False
 
 
 def _install_outdated_sdk_excepthook() -> None:
     """Wrap sys.excepthook / threading.excepthook to append the outdated note.
 
-    Idempotent: safe to call multiple times. The previous hooks are preserved
-    and invoked first so IDE / framework customisations keep working.
+    Only appends the note when the exception's traceback actually passes
+    through rapidata code - unrelated errors in the user's program are left
+    alone. Idempotent. Previous hooks are preserved and invoked first so IDE
+    / framework customisations keep working.
     """
     global _excepthook_installed
     if _excepthook_installed:
@@ -81,7 +106,7 @@ def _install_outdated_sdk_excepthook() -> None:
     def _sdk_aware_excepthook(exc_type, exc_value, exc_traceback):
         previous_excepthook(exc_type, exc_value, exc_traceback)
         note = _format_outdated_sdk_note()
-        if note:
+        if note and _traceback_touches_rapidata(exc_traceback):
             try:
                 sys.stderr.write("\n" + note + "\n")
             except Exception:
@@ -94,7 +119,7 @@ def _install_outdated_sdk_excepthook() -> None:
     def _sdk_aware_threading_excepthook(args):
         previous_threading_excepthook(args)
         note = _format_outdated_sdk_note()
-        if note:
+        if note and _traceback_touches_rapidata(args.exc_traceback):
             try:
                 sys.stderr.write("\n" + note + "\n")
             except Exception:

--- a/src/rapidata/rapidata_client/api/rapidata_api_client.py
+++ b/src/rapidata/rapidata_client/api/rapidata_api_client.py
@@ -7,6 +7,7 @@ from rapidata.api_client.api_client import (
 )
 from rapidata.api_client.exceptions import ApiException
 import json
+import sys
 import threading
 from contextlib import contextmanager
 from rapidata.rapidata_client.config import logger, tracer
@@ -27,17 +28,79 @@ _sdk_outdated_info: Optional[dict[str, str]] = None
 
 
 def mark_sdk_outdated(current_version: str, latest_version: str) -> None:
-    """Record that the installed SDK is behind the latest release."""
+    """Record that the installed SDK is behind the latest release.
+
+    Also installs a process-wide excepthook so that any uncaught exception
+    (not just RapidataError) gets the outdated-SDK note appended after its
+    traceback - many API-caused failures surface as other exception types
+    (validation errors, JSON decode errors, etc.).
+    """
     global _sdk_outdated_info
     _sdk_outdated_info = {
         "current": current_version,
         "latest": latest_version,
     }
+    _install_outdated_sdk_excepthook()
 
 
 def get_sdk_outdated_info() -> Optional[dict[str, str]]:
     """Return the outdated-version info if set, otherwise None."""
     return _sdk_outdated_info
+
+
+def _format_outdated_sdk_note() -> Optional[str]:
+    """Build the human-readable outdated-SDK note, or None if not outdated."""
+    info = _sdk_outdated_info
+    if not info:
+        return None
+    current = info.get("current")
+    latest = info.get("latest")
+    return (
+        f"Note: Your Rapidata SDK is outdated (installed: {current}, "
+        f"latest: {latest}). This error may be caused by the SDK being "
+        f"out of sync with the API - please upgrade and try again."
+    )
+
+
+_excepthook_installed = False
+
+
+def _install_outdated_sdk_excepthook() -> None:
+    """Wrap sys.excepthook / threading.excepthook to append the outdated note.
+
+    Idempotent: safe to call multiple times. The previous hooks are preserved
+    and invoked first so IDE / framework customisations keep working.
+    """
+    global _excepthook_installed
+    if _excepthook_installed:
+        return
+    _excepthook_installed = True
+
+    previous_excepthook = sys.excepthook
+
+    def _sdk_aware_excepthook(exc_type, exc_value, exc_traceback):
+        previous_excepthook(exc_type, exc_value, exc_traceback)
+        note = _format_outdated_sdk_note()
+        if note:
+            try:
+                sys.stderr.write("\n" + note + "\n")
+            except Exception:
+                pass
+
+    sys.excepthook = _sdk_aware_excepthook
+
+    previous_threading_excepthook = threading.excepthook
+
+    def _sdk_aware_threading_excepthook(args):
+        previous_threading_excepthook(args)
+        note = _format_outdated_sdk_note()
+        if note:
+            try:
+                sys.stderr.write("\n" + note + "\n")
+            except Exception:
+                pass
+
+    threading.excepthook = _sdk_aware_threading_excepthook
 
 
 @contextmanager

--- a/src/rapidata/rapidata_client/api/rapidata_api_client.py
+++ b/src/rapidata/rapidata_client/api/rapidata_api_client.py
@@ -19,6 +19,26 @@ from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 # Thread-local storage for controlling error logging
 _thread_local = threading.local()
 
+# Module-level state recording whether the installed SDK is outdated.
+# Populated by RapidataClient._check_version and read when formatting
+# API errors so the user sees the outdated-version hint even if they
+# missed the startup notice.
+_sdk_outdated_info: Optional[dict[str, str]] = None
+
+
+def mark_sdk_outdated(current_version: str, latest_version: str) -> None:
+    """Record that the installed SDK is behind the latest release."""
+    global _sdk_outdated_info
+    _sdk_outdated_info = {
+        "current": current_version,
+        "latest": latest_version,
+    }
+
+
+def get_sdk_outdated_info() -> Optional[dict[str, str]]:
+    """Return the outdated-version info if set, otherwise None."""
+    return _sdk_outdated_info
+
 
 @contextmanager
 def suppress_rapidata_error_logging():
@@ -201,6 +221,7 @@ class RapidataApiClient(ApiClient):
                 message=message,
                 original_exception=e,
                 details=details,
+                sdk_outdated_info=get_sdk_outdated_info(),
             )
 
             # Only log error if not suppressed

--- a/src/rapidata/rapidata_client/api/rapidata_api_client.py
+++ b/src/rapidata/rapidata_client/api/rapidata_api_client.py
@@ -7,8 +7,6 @@ from rapidata.api_client.api_client import (
 )
 from rapidata.api_client.exceptions import ApiException
 import json
-import os
-import sys
 import threading
 from contextlib import contextmanager
 from rapidata.rapidata_client.config import logger, tracer
@@ -29,19 +27,12 @@ _sdk_outdated_info: Optional[dict[str, str]] = None
 
 
 def mark_sdk_outdated(current_version: str, latest_version: str) -> None:
-    """Record that the installed SDK is behind the latest release.
-
-    Also installs a process-wide excepthook so that any uncaught exception
-    (not just RapidataError) gets the outdated-SDK note appended after its
-    traceback - many API-caused failures surface as other exception types
-    (validation errors, JSON decode errors, etc.).
-    """
+    """Record that the installed SDK is behind the latest release."""
     global _sdk_outdated_info
     _sdk_outdated_info = {
         "current": current_version,
         "latest": latest_version,
     }
-    _install_outdated_sdk_excepthook()
 
 
 def get_sdk_outdated_info() -> Optional[dict[str, str]]:
@@ -63,69 +54,17 @@ def _format_outdated_sdk_note() -> Optional[str]:
     )
 
 
-# Path fragment used to detect whether an exception's traceback passes
-# through the rapidata package. Computed from this file's location so it
-# works for editable installs, site-packages installs, and source checkouts.
-# Resolves to .../rapidata/  (three dirs up from rapidata_client/api/rapidata_api_client.py)
-_RAPIDATA_PKG_PATH = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+def _attach_outdated_note(exc: BaseException) -> None:
+    """Attach the outdated-SDK note to an exception raised from the SDK layer.
 
-
-def _traceback_touches_rapidata(exc_traceback) -> bool:
-    """Return True if any frame in the traceback comes from the rapidata package."""
-    tb = exc_traceback
-    while tb is not None:
-        filename = tb.tb_frame.f_code.co_filename
-        try:
-            if os.path.commonpath([os.path.abspath(filename), _RAPIDATA_PKG_PATH]) == _RAPIDATA_PKG_PATH:
-                return True
-        except (ValueError, OSError):
-            # commonpath raises if paths are on different drives (Windows) or invalid
-            pass
-        tb = tb.tb_next
-    return False
-
-
-_excepthook_installed = False
-
-
-def _install_outdated_sdk_excepthook() -> None:
-    """Wrap sys.excepthook / threading.excepthook to append the outdated note.
-
-    Only appends the note when the exception's traceback actually passes
-    through rapidata code - unrelated errors in the user's program are left
-    alone. Idempotent. Previous hooks are preserved and invoked first so IDE
-    / framework customisations keep working.
+    Uses BaseException.add_note (Python 3.11+) so the note renders as part of
+    the traceback without changing the exception type or message. On older
+    Pythons this is a no-op; RapidataError still carries the info via its
+    own message for that case.
     """
-    global _excepthook_installed
-    if _excepthook_installed:
-        return
-    _excepthook_installed = True
-
-    previous_excepthook = sys.excepthook
-
-    def _sdk_aware_excepthook(exc_type, exc_value, exc_traceback):
-        previous_excepthook(exc_type, exc_value, exc_traceback)
-        note = _format_outdated_sdk_note()
-        if note and _traceback_touches_rapidata(exc_traceback):
-            try:
-                sys.stderr.write("\n" + note + "\n")
-            except Exception:
-                pass
-
-    sys.excepthook = _sdk_aware_excepthook
-
-    previous_threading_excepthook = threading.excepthook
-
-    def _sdk_aware_threading_excepthook(args):
-        previous_threading_excepthook(args)
-        note = _format_outdated_sdk_note()
-        if note and _traceback_touches_rapidata(args.exc_traceback):
-            try:
-                sys.stderr.write("\n" + note + "\n")
-            except Exception:
-                pass
-
-    threading.excepthook = _sdk_aware_threading_excepthook
+    note = _format_outdated_sdk_note()
+    if note and hasattr(exc, "add_note"):
+        exc.add_note(note)
 
 
 @contextmanager
@@ -172,6 +111,25 @@ class RapidataApiClient(ApiClient):
         self.id_generator = RandomIdGenerator()
 
     def call_api(
+        self,
+        method,
+        url,
+        header_params=None,
+        body=None,
+        post_params=None,
+        _request_timeout=None,
+    ) -> rest.RESTResponse:
+        try:
+            return self._call_api_impl(
+                method, url, header_params, body, post_params, _request_timeout
+            )
+        except Exception as e:
+            # Any error escaping the API call is eligible for the outdated-SDK
+            # hint, since it originates from the generated client layer.
+            _attach_outdated_note(e)
+            raise
+
+    def _call_api_impl(
         self,
         method,
         url,
@@ -319,3 +277,10 @@ class RapidataApiClient(ApiClient):
                 logger.debug("Suppressed Error: %s", error_formatted)
 
             raise error_formatted from None
+        except Exception as e:
+            # Non-API exceptions from deserialization (e.g. pydantic
+            # ValidationError from a response schema that no longer matches
+            # the API) are a classic symptom of SDK/API drift - attach the
+            # outdated-SDK hint so the user sees it on the traceback.
+            _attach_outdated_note(e)
+            raise

--- a/src/rapidata/rapidata_client/api/rapidata_api_client.py
+++ b/src/rapidata/rapidata_client/api/rapidata_api_client.py
@@ -40,8 +40,12 @@ def get_sdk_outdated_info() -> Optional[dict[str, str]]:
     return _sdk_outdated_info
 
 
-def _format_outdated_sdk_note() -> Optional[str]:
-    """Build the human-readable outdated-SDK note, or None if not outdated."""
+def format_outdated_sdk_note() -> Optional[str]:
+    """Build the human-readable outdated-SDK note, or None if not outdated.
+
+    Used by RapidataError and LazyValidatedModel to append the same hint to
+    their error messages when the installed SDK is behind the latest release.
+    """
     info = _sdk_outdated_info
     if not info:
         return None
@@ -52,19 +56,6 @@ def _format_outdated_sdk_note() -> Optional[str]:
         f"latest: {latest}). This error may be caused by the SDK being "
         f"out of sync with the API - please upgrade and try again."
     )
-
-
-def _attach_outdated_note(exc: BaseException) -> None:
-    """Attach the outdated-SDK note to an exception raised from the SDK layer.
-
-    Uses BaseException.add_note (Python 3.11+) so the note renders as part of
-    the traceback without changing the exception type or message. On older
-    Pythons this is a no-op; RapidataError still carries the info via its
-    own message for that case.
-    """
-    note = _format_outdated_sdk_note()
-    if note and hasattr(exc, "add_note"):
-        exc.add_note(note)
 
 
 @contextmanager
@@ -111,25 +102,6 @@ class RapidataApiClient(ApiClient):
         self.id_generator = RandomIdGenerator()
 
     def call_api(
-        self,
-        method,
-        url,
-        header_params=None,
-        body=None,
-        post_params=None,
-        _request_timeout=None,
-    ) -> rest.RESTResponse:
-        try:
-            return self._call_api_impl(
-                method, url, header_params, body, post_params, _request_timeout
-            )
-        except Exception as e:
-            # Any error escaping the API call is eligible for the outdated-SDK
-            # hint, since it originates from the generated client layer.
-            _attach_outdated_note(e)
-            raise
-
-    def _call_api_impl(
         self,
         method,
         url,
@@ -277,10 +249,3 @@ class RapidataApiClient(ApiClient):
                 logger.debug("Suppressed Error: %s", error_formatted)
 
             raise error_formatted from None
-        except Exception as e:
-            # Non-API exceptions from deserialization (e.g. pydantic
-            # ValidationError from a response schema that no longer matches
-            # the API) are a classic symptom of SDK/API drift - attach the
-            # outdated-SDK hint so the user sees it on the traceback.
-            _attach_outdated_note(e)
-            raise

--- a/src/rapidata/rapidata_client/api/rapidata_api_client.py
+++ b/src/rapidata/rapidata_client/api/rapidata_api_client.py
@@ -35,11 +35,6 @@ def mark_sdk_outdated(current_version: str, latest_version: str) -> None:
     }
 
 
-def get_sdk_outdated_info() -> Optional[dict[str, str]]:
-    """Return the outdated-version info if set, otherwise None."""
-    return _sdk_outdated_info
-
-
 def format_outdated_sdk_note() -> Optional[str]:
     """Build the human-readable outdated-SDK note, or None if not outdated.
 
@@ -239,7 +234,6 @@ class RapidataApiClient(ApiClient):
                 message=message,
                 original_exception=e,
                 details=details,
-                sdk_outdated_info=get_sdk_outdated_info(),
             )
 
             # Only log error if not suppressed

--- a/src/rapidata/rapidata_client/exceptions/rapidata_error.py
+++ b/src/rapidata/rapidata_client/exceptions/rapidata_error.py
@@ -11,13 +11,11 @@ class RapidataError(Exception):
         message: str | None = None,
         original_exception: Exception | None = None,
         details: Any = None,
-        sdk_outdated_info: Optional[dict] = None,
     ):
         self.status_code = status_code
         self.message = message
         self.original_exception = original_exception
         self.details = details
-        self.sdk_outdated_info = sdk_outdated_info
 
         # Create a nice error message
         error_msg = "Rapidata API Error"
@@ -72,13 +70,13 @@ class RapidataError(Exception):
         else:
             error_parts.append("Trace Id: N/A")
 
-        if self.sdk_outdated_info:
-            current = self.sdk_outdated_info.get("current")
-            latest = self.sdk_outdated_info.get("latest")
-            error_parts.append(
-                f"Note: Your Rapidata SDK is outdated (installed: {current}, "
-                f"latest: {latest}). This error may be caused by the SDK being "
-                f"out of sync with the API - please upgrade and try again."
-            )
+        # Lazy import to avoid a module-level cycle between the exceptions
+        # package and the api package.
+        from rapidata.rapidata_client.api.rapidata_api_client import (
+            format_outdated_sdk_note,
+        )
+        note = format_outdated_sdk_note()
+        if note:
+            error_parts.append(note)
 
         return "\n".join(error_parts)

--- a/src/rapidata/rapidata_client/exceptions/rapidata_error.py
+++ b/src/rapidata/rapidata_client/exceptions/rapidata_error.py
@@ -11,11 +11,13 @@ class RapidataError(Exception):
         message: str | None = None,
         original_exception: Exception | None = None,
         details: Any = None,
+        sdk_outdated_info: Optional[dict] = None,
     ):
         self.status_code = status_code
         self.message = message
         self.original_exception = original_exception
         self.details = details
+        self.sdk_outdated_info = sdk_outdated_info
 
         # Create a nice error message
         error_msg = "Rapidata API Error"
@@ -69,5 +71,14 @@ class RapidataError(Exception):
             error_parts.append(f"Trace Id: {trace_id}")
         else:
             error_parts.append("Trace Id: N/A")
+
+        if self.sdk_outdated_info:
+            current = self.sdk_outdated_info.get("current")
+            latest = self.sdk_outdated_info.get("latest")
+            error_parts.append(
+                f"Note: Your Rapidata SDK is outdated (installed: {current}, "
+                f"latest: {latest}). This error may be caused by the SDK being "
+                f"out of sync with the API - please upgrade and try again."
+            )
 
         return "\n".join(error_parts)

--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -30,7 +30,10 @@ from rapidata.rapidata_client.config import (
 from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.job.rapidata_job_manager import RapidataJobManager
 from rapidata.rapidata_client.flow.rapidata_flow_manager import RapidataFlowManager
-from rapidata.rapidata_client.api.rapidata_api_client import optional_api_call
+from rapidata.rapidata_client.api.rapidata_api_client import (
+    optional_api_call,
+    mark_sdk_outdated,
+)
 
 
 class RapidataClient:
@@ -166,6 +169,10 @@ class RapidataClient:
             if response.status_code == 200:
                 latest_version = response.json()["tag_name"].lstrip("v")
                 if version.parse(latest_version) > version.parse(__version__):
+                    mark_sdk_outdated(
+                        current_version=__version__,
+                        latest_version=latest_version,
+                    )
                     managed_print(
                         f"""A new version of the Rapidata SDK is available: {latest_version}
 Your current version is: {__version__}"""


### PR DESCRIPTION
## Summary
- Persist the outdated-version info from ``RapidataClient._check_version`` in a module-level flag on ``rapidata_api_client`` (``mark_sdk_outdated`` / ``get_sdk_outdated_info``).
- ``RapidataApiClient.response_deserialize`` now passes that info into the ``RapidataError`` it raises for every failing API call.
- ``RapidataError.__str__`` appends a short ``Note:`` line when the SDK is outdated, telling the user the error may be caused by SDK/API drift and to upgrade.

The startup version-check message is still printed as before — this is additive, so users who scroll past it still see the hint attached to the actual error they are debugging.

## Test plan
- [ ] Install an intentionally old SDK version against a current API and confirm the ``Note: Your Rapidata SDK is outdated ...`` line appears on API errors.
- [ ] Install the latest SDK and confirm no note is appended.
- [ ] Run ``pyright src/rapidata/rapidata_client`` — confirm no new errors introduced by this change.

🔗 Session: [${POSEIDON_SESSION_URL:-$HOSTNAME}](${POSEIDON_SESSION_URL:-})