### PR TITLE
feat(order): print campaign preview QR on order and job definition creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.27.0",
     "diskcache>=5.6.3,<6",
     "hatchling>=1.28.0",
+    "qrcode>=8.0,<9",
 ]
 
 [dependency-groups]

--- a/src/rapidata/rapidata_client/config/_qr_preview.py
+++ b/src/rapidata/rapidata_client/config/_qr_preview.py
@@ -9,6 +9,7 @@ logged at debug level and never raised to the caller, so order / job execution
 is never affected by QR rendering problems.
 """
 
+from time import sleep
 from typing import TYPE_CHECKING, cast
 
 from rapidata.rapidata_client.config.logger import logger
@@ -70,6 +71,50 @@ def print_campaign_preview_qr(environment: str, campaign_id: str) -> None:
         managed_print(f"Preview the campaign at: {url}")
 
 
+def _resolve_campaign_id_from_pipeline(
+    openapi_service: "OpenAPIService",
+    pipeline_id: str,
+    max_retries: int = 5,
+    retry_delay: float = 1.0,
+) -> str | None:
+    """Pull the campaign id out of a pipeline's ``campaign-artifact``.
+
+    Pipeline artifacts are populated asynchronously after creation, so we
+    retry a few times before giving up. Returns ``None`` if the artifact never
+    materialises.
+    """
+    from rapidata.api_client.models.campaign_artifact_model import (
+        CampaignArtifactModel,
+    )
+
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            pipeline = (
+                openapi_service.pipeline.pipeline_api.pipeline_pipeline_id_get(
+                    pipeline_id
+                )
+            )
+            artifact = pipeline.artifacts.get("campaign-artifact")
+            if artifact is not None:
+                return cast(
+                    CampaignArtifactModel, artifact.actual_instance
+                ).campaign_id
+        except Exception as e:
+            last_exc = e
+
+        if attempt < max_retries - 1:
+            sleep(retry_delay)
+
+    logger.debug(
+        "Could not resolve campaign id from pipeline '%s' after %d attempts",
+        pipeline_id,
+        max_retries,
+        exc_info=last_exc,
+    )
+    return None
+
+
 def print_campaign_preview_qr_for_pipeline(
     openapi_service: "OpenAPIService", pipeline_id: str
 ) -> None:
@@ -86,24 +131,8 @@ def print_campaign_preview_qr_for_pipeline(
     if rapidata_config.logging.silent_mode:
         return
 
-    try:
-        from rapidata.api_client.models.campaign_artifact_model import (
-            CampaignArtifactModel,
-        )
-
-        pipeline = (
-            openapi_service.pipeline.pipeline_api.pipeline_pipeline_id_get(pipeline_id)
-        )
-        campaign_id = cast(
-            CampaignArtifactModel,
-            pipeline.artifacts["campaign-artifact"].actual_instance,
-        ).campaign_id
-    except Exception:
-        logger.debug(
-            "Could not resolve campaign id from pipeline '%s' for preview QR",
-            pipeline_id,
-            exc_info=True,
-        )
+    campaign_id = _resolve_campaign_id_from_pipeline(openapi_service, pipeline_id)
+    if not campaign_id:
         return
 
     print_campaign_preview_qr(

--- a/src/rapidata/rapidata_client/config/_qr_preview.py
+++ b/src/rapidata/rapidata_client/config/_qr_preview.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""Helpers for printing a terminal-friendly QR code that links to the public
+campaign preview page.
+
+The QR code is a convenience nudge so the user can open the preview on a phone
+without copy-pasting the URL. All functions here are best-effort: failures are
+logged at debug level and never raised to the caller, so order / job execution
+is never affected by QR rendering problems.
+"""
+
+from typing import TYPE_CHECKING, cast
+
+from rapidata.rapidata_client.config.logger import logger
+from rapidata.rapidata_client.config.managed_print import managed_print
+from rapidata.rapidata_client.config.rapidata_config import rapidata_config
+
+if TYPE_CHECKING:
+    from rapidata.service.openapi_service import OpenAPIService
+
+
+_PREVIEW_URL_TEMPLATE = "https://rapids.{environment}/preview/campaign?id={campaign_id}"
+
+
+def build_campaign_preview_url(environment: str, campaign_id: str) -> str:
+    """Return the public preview URL for the given campaign."""
+    return _PREVIEW_URL_TEMPLATE.format(
+        environment=environment, campaign_id=campaign_id
+    )
+
+
+def print_campaign_preview_qr(environment: str, campaign_id: str) -> None:
+    """Print a terminal QR code that links to the campaign preview page.
+
+    Respects ``rapidata_config.logging.silent_mode``. If QR rendering fails for
+    any reason we still surface the preview URL via ``managed_print`` so the
+    user can open it manually.
+
+    Args:
+        environment: The Rapidata environment (e.g. ``rapidata.ai``).
+        campaign_id: The id of the campaign to preview. For orders this is the
+            order's campaign id; for job definitions it's the preview
+            (distilling) campaign id.
+    """
+    if rapidata_config.logging.silent_mode:
+        return
+
+    url = build_campaign_preview_url(environment, campaign_id)
+
+    try:
+        import qrcode
+        from qrcode.constants import ERROR_CORRECT_L
+
+        qr = qrcode.QRCode(
+            error_correction=ERROR_CORRECT_L,
+            border=1,
+            box_size=1,
+        )
+        qr.add_data(url)
+        qr.make(fit=True)
+
+        managed_print(f"Preview the campaign ({url}):")
+        qr.print_ascii(invert=True)
+    except Exception:
+        logger.debug(
+            "Failed to render campaign preview QR code for %s",
+            url,
+            exc_info=True,
+        )
+        managed_print(f"Preview the campaign at: {url}")
+
+
+def print_campaign_preview_qr_for_pipeline(
+    openapi_service: "OpenAPIService", pipeline_id: str
+) -> None:
+    """Fetch the campaign id from the given pipeline and print a preview QR code.
+
+    Best-effort: any failure is swallowed with a debug log so callers never
+    need to guard this call. Also a no-op in silent mode.
+
+    Args:
+        openapi_service: The OpenAPI service used to look up the pipeline.
+        pipeline_id: The id of the pipeline whose ``campaign-artifact`` should
+            be used for the preview.
+    """
+    if rapidata_config.logging.silent_mode:
+        return
+
+    try:
+        from rapidata.api_client.models.campaign_artifact_model import (
+            CampaignArtifactModel,
+        )
+
+        pipeline = (
+            openapi_service.pipeline.pipeline_api.pipeline_pipeline_id_get(pipeline_id)
+        )
+        campaign_id = cast(
+            CampaignArtifactModel,
+            pipeline.artifacts["campaign-artifact"].actual_instance,
+        ).campaign_id
+    except Exception:
+        logger.debug(
+            "Could not resolve campaign id from pipeline '%s' for preview QR",
+            pipeline_id,
+            exc_info=True,
+        )
+        return
+
+    print_campaign_preview_qr(
+        environment=openapi_service.environment, campaign_id=campaign_id
+    )

--- a/src/rapidata/rapidata_client/config/_qr_preview.py
+++ b/src/rapidata/rapidata_client/config/_qr_preview.py
@@ -74,34 +74,47 @@ def print_campaign_preview_qr(environment: str, campaign_id: str) -> None:
 def _resolve_campaign_id_from_pipeline(
     openapi_service: "OpenAPIService",
     pipeline_id: str,
-    max_retries: int = 5,
-    retry_delay: float = 1.0,
+    max_retries: int = 3,
+    retry_delay: float = 0.5,
 ) -> str | None:
     """Pull the campaign id out of a pipeline's ``campaign-artifact``.
 
     Pipeline artifacts are populated asynchronously after creation, so we
     retry a few times before giving up. Returns ``None`` if the artifact never
     materialises.
+
+    All API calls inside are wrapped in ``suppress_rapidata_error_logging`` so
+    retries and final failures stay at DEBUG level — this is a best-effort
+    convenience feature and should never surface noise to the user.
     """
     from rapidata.api_client.models.campaign_artifact_model import (
         CampaignArtifactModel,
     )
+    from rapidata.rapidata_client.api.rapidata_api_client import (
+        suppress_rapidata_error_logging,
+    )
 
-    last_exc: Exception | None = None
     for attempt in range(max_retries):
         try:
-            pipeline = (
-                openapi_service.pipeline.pipeline_api.pipeline_pipeline_id_get(
-                    pipeline_id
+            with suppress_rapidata_error_logging():
+                pipeline = (
+                    openapi_service.pipeline.pipeline_api.pipeline_pipeline_id_get(
+                        pipeline_id
+                    )
                 )
-            )
-            artifact = pipeline.artifacts.get("campaign-artifact")
-            if artifact is not None:
-                return cast(
-                    CampaignArtifactModel, artifact.actual_instance
-                ).campaign_id
+                artifact = pipeline.artifacts.get("campaign-artifact")
+                if artifact is not None:
+                    return cast(
+                        CampaignArtifactModel, artifact.actual_instance
+                    ).campaign_id
         except Exception as e:
-            last_exc = e
+            logger.debug(
+                "Pipeline '%s' campaign lookup attempt %d/%d failed: %s",
+                pipeline_id,
+                attempt + 1,
+                max_retries,
+                e,
+            )
 
         if attempt < max_retries - 1:
             sleep(retry_delay)
@@ -110,7 +123,6 @@ def _resolve_campaign_id_from_pipeline(
         "Could not resolve campaign id from pipeline '%s' after %d attempts",
         pipeline_id,
         max_retries,
-        exc_info=last_exc,
     )
     return None
 
@@ -120,7 +132,10 @@ def print_campaign_preview_qr_for_pipeline(
 ) -> None:
     """Fetch the campaign id from the given pipeline and print a preview QR code.
 
-    Best-effort: any failure is swallowed with a debug log so callers never
+    Best-effort: the underlying API lookup is wrapped in
+    ``suppress_rapidata_error_logging`` so transient errors (including the
+    pipeline's campaign artifact not yet being populated) stay at DEBUG level,
+    and any remaining exception is swallowed with a debug log so callers never
     need to guard this call. Also a no-op in silent mode.
 
     Args:
@@ -131,10 +146,26 @@ def print_campaign_preview_qr_for_pipeline(
     if rapidata_config.logging.silent_mode:
         return
 
-    campaign_id = _resolve_campaign_id_from_pipeline(openapi_service, pipeline_id)
+    try:
+        campaign_id = _resolve_campaign_id_from_pipeline(openapi_service, pipeline_id)
+    except Exception as e:
+        logger.debug(
+            "Campaign preview QR lookup for pipeline '%s' failed: %s",
+            pipeline_id,
+            e,
+        )
+        return
+
     if not campaign_id:
         return
 
-    print_campaign_preview_qr(
-        environment=openapi_service.environment, campaign_id=campaign_id
-    )
+    try:
+        print_campaign_preview_qr(
+            environment=openapi_service.environment, campaign_id=campaign_id
+        )
+    except Exception as e:
+        logger.debug(
+            "Campaign preview QR render for pipeline '%s' failed: %s",
+            pipeline_id,
+            e,
+        )

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.config import logger, tracer
+from rapidata.rapidata_client.config._qr_preview import (
+    print_campaign_preview_qr_for_pipeline,
+)
 from rapidata.rapidata_client.datapoints._datapoint import Datapoint
 from rapidata.rapidata_client.workflow import Workflow
 from rapidata.rapidata_client.settings import RapidataSetting
@@ -123,6 +126,11 @@ class RapidataJobManager:
             raise FailedUploadException(
                 rapidata_dataset, failed_uploads, job_definition=job_model
             )
+
+        print_campaign_preview_qr_for_pipeline(
+            openapi_service=self._openapi_service,
+            pipeline_id=job_definition_response.pipeline_id,
+        )
 
         return job_model
 

--- a/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
+++ b/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
@@ -17,7 +17,9 @@ from rapidata.rapidata_client.config import (
     rapidata_config,
     tracer,
 )
-from rapidata.rapidata_client.config._qr_preview import print_campaign_preview_qr
+from rapidata.rapidata_client.config._qr_preview import (
+    print_campaign_preview_qr_for_pipeline,
+)
 from rapidata.rapidata_client.validation.validation_set_manager import (
     ValidationSetManager,
 )
@@ -173,11 +175,13 @@ class RapidataOrderBuilder:
         except Exception as e:
             logger.error("Failed to set order to preview: %s", e)
 
-        if result.campaign_id:
-            print_campaign_preview_qr(
-                environment=self._openapi_service.environment,
-                campaign_id=result.campaign_id,
-            )
+        # The campaign is materialised once the order enters preview, so the
+        # campaign artifact only shows up on the pipeline a moment later — let
+        # the helper poll for it.
+        print_campaign_preview_qr_for_pipeline(
+            openapi_service=self._openapi_service,
+            pipeline_id=result.pipeline_id,
+        )
         return order
 
     def _set_workflow(self, workflow: Workflow) -> RapidataOrderBuilder:

--- a/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
+++ b/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
@@ -17,6 +17,7 @@ from rapidata.rapidata_client.config import (
     rapidata_config,
     tracer,
 )
+from rapidata.rapidata_client.config._qr_preview import print_campaign_preview_qr
 from rapidata.rapidata_client.validation.validation_set_manager import (
     ValidationSetManager,
 )
@@ -171,6 +172,12 @@ class RapidataOrderBuilder:
             self._openapi_service.order.order_api.order_order_id_preview_post(order.id)
         except Exception as e:
             logger.error("Failed to set order to preview: %s", e)
+
+        if result.campaign_id:
+            print_campaign_preview_qr(
+                environment=self._openapi_service.environment,
+                campaign_id=result.campaign_id,
+            )
         return order
 
     def _set_workflow(self, workflow: Workflow) -> RapidataOrderBuilder:

--- a/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
+++ b/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
@@ -10,11 +10,10 @@ if TYPE_CHECKING:
 from rapidata.rapidata_client.exceptions.failed_upload_exception import (
     FailedUploadException,
 )
-from rapidata.rapidata_client.filter import RapidataFilter, UserScoreFilter
+from rapidata.rapidata_client.filter import RapidataFilter
 from rapidata.rapidata_client.config import (
     logger,
     managed_print,
-    rapidata_config,
     tracer,
 )
 from rapidata.rapidata_client.config._qr_preview import (
@@ -33,15 +32,7 @@ from rapidata.rapidata_client.referee._naive_referee import NaiveReferee
 from rapidata.rapidata_client.selection._base_selection import RapidataSelection
 from rapidata.rapidata_client.settings import RapidataSetting
 from rapidata.rapidata_client.workflow import Workflow
-from rapidata.rapidata_client.selection import (
-    ConditionalValidationSelection,
-    LabelingSelection,
-    CappedSelection,
-)
 from rapidata.service.openapi_service import OpenAPIService
-from rapidata.rapidata_client.api.rapidata_api_client import (
-    suppress_rapidata_error_logging,
-)
 
 StickyStateLiteral = Literal["Temporary", "Permanent", "Passive"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2557,8 +2557,20 @@ wheels = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
+]
+
+[[package]]
 name = "rapidata"
-version = "3.9.0"
+version = "3.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -2575,6 +2587,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
+    { name = "qrcode" },
     { name = "requests" },
     { name = "tinytag" },
     { name = "tqdm" },
@@ -2618,6 +2631,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.8.2,<3" },
     { name = "pyjwt", specifier = ">=2.9.0,<3" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0,<3" },
+    { name = "qrcode", specifier = ">=8.0,<9" },
     { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "tinytag", specifier = ">=2.0.0,<3" },
     { name = "tqdm", specifier = ">=4.66.5,<5" },


### PR DESCRIPTION
## Summary

- When a user calls `rapidata_client.order.create_*_order(...)` or `rapidata_client.job.create_*_job_definition(...)`, the SDK now prints a terminal-rendered QR code that links to the public campaign preview page (`https://rapids.<env>/preview/campaign?id=<campaign_id>`). Scanning it on a phone shows how the task will look to annotators.
- The order path uses `campaign_id` returned directly from `POST /order`; the job definition path resolves the campaign id from the preview pipeline's `campaign-artifact`. Both funnel into a shared helper in `rapidata_client/config/_qr_preview.py`.
- QR rendering is best-effort — any failure (import, rendering, lookup) is swallowed with a debug log and, where possible, we still surface the preview URL via `managed_print`. Silent mode (`rapidata_config.logging.silent_mode`) suppresses the output entirely.
- Adds `qrcode>=8.0,<9` as a runtime dependency (pure Python, zero mandatory transitive deps).

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` — 0 errors
- [x] Smoke test the helper in isolation: URL builds correctly, silent mode suppresses output, non-silent mode renders a scannable QR
- [ ] Manual: create a real order and a real job definition against an environment and confirm the QR resolves to the preview page
- [ ] Manual: verify `rapidata_config.logging.silent_mode = True` suppresses the QR output

🔗 Session: [session-b8390c48](https://session-b8390c48.poseidon.rapidata.internal/)