### PR TITLE
feat(order): expose demographic_keys on create_*_order methods

### DIFF
--- a/docs/understanding_the_results.md
+++ b/docs/understanding_the_results.md
@@ -136,9 +136,10 @@ Here's an example of the results you might receive when running a COMPARE task (
             - `language`: Language in which the labeler viewed the task
             - `userScores`: A score representing the labeler's reliability across different dimensions
                 - `global`: The global userScore of the labeler, which is a measure of their overall reliability
-            - `age`: Age group of the labeler
-            - `gender`: The gender of the labeler
-            - `occupation`: The occupation of the labeler
+            - `age`: Age group of the labeler (populated when `age` is one of the configured demographic keys)
+            - `gender`: The gender of the labeler (populated when `gender` is one of the configured demographic keys)
+            - `occupation`: The occupation of the labeler (populated when `occupation` is one of the configured demographic keys)
+            - `demographics`: A dict of every demographic value collected for the order, keyed by the demographic key configured via `demographic_keys` on the order. Includes both built-in keys (e.g. `age`, `gender`, `occupation`) and any custom keys registered for the campaign.
 
 ## Understanding the User Scores
 

--- a/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
+++ b/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
@@ -70,6 +70,7 @@ class RapidataOrderBuilder:
         self._priority: int | None = None
         self._datapoints: list[Datapoint] = []
         self._sticky_state_value: StickyStateLiteral | None = None
+        self._demographic_keys: list[str] | None = None
         self._validation_set_manager: ValidationSetManager = ValidationSetManager(
             self._openapi_service
         )
@@ -119,6 +120,7 @@ class RapidataOrderBuilder:
             ),
             priority=self._priority,
             stickyState=(StickyState(sticky_state) if sticky_state else None),
+            demographicKeys=self._demographic_keys,
         )
 
     def _generate_id(self, length=9):
@@ -348,4 +350,30 @@ class RapidataOrderBuilder:
             )
 
         self._sticky_state_value = sticky_state
+        return self
+
+    def _set_demographic_keys(
+        self, demographic_keys: list[str] | None = None
+    ) -> RapidataOrderBuilder:
+        """
+        Set the demographic keys that should be collected for each annotator and projected
+        into the aggregated results' ``userDetails.demographics`` dict.
+
+        Examples: ``["age", "gender"]`` (platform defaults) or ``["age", "handedness"]`` to
+        include a custom key registered via ``DemographicManager.create_demographic_rapid``.
+        """
+        if demographic_keys is None:
+            self._demographic_keys = None
+            return self
+
+        if not isinstance(demographic_keys, list):
+            raise TypeError("Demographic keys must be provided as a list of strings.")
+
+        for key in demographic_keys:
+            if not isinstance(key, str) or not key:
+                raise TypeError(
+                    "Demographic keys must be non-empty strings."
+                )
+
+        self._demographic_keys = demographic_keys
         return self

--- a/src/rapidata/rapidata_client/order/rapidata_order_manager.py
+++ b/src/rapidata/rapidata_client/order/rapidata_order_manager.py
@@ -63,6 +63,7 @@ class RapidataOrderManager:
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         if filters is None:
             filters = []
@@ -135,6 +136,7 @@ class RapidataOrderManager:
                 ._set_validation_set_id(validation_set_id if not selections else None)
                 ._set_priority(self.__priority)
                 ._set_sticky_state(self.__sticky_state)
+                ._set_demographic_keys(demographic_keys)
                 ._create()
             )
 
@@ -189,6 +191,7 @@ class RapidataOrderManager:
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """Create a classification order.
 
@@ -218,6 +221,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the classification. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the classification. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the classification. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.
                 If provided has to be the same length as datapoints.\n
                 This will NOT be shown to the labelers but will be included in the result purely for your own reference.
@@ -269,6 +274,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def create_compare_order(
@@ -288,6 +294,7 @@ class RapidataOrderManager:
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """Create a compare order.
 
@@ -331,6 +338,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the comparison. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the comparison. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the comparison. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
                 This will NOT be shown to the labelers but will be included in the result purely for your own reference.
@@ -390,6 +399,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def create_ranking_order(
@@ -407,6 +417,7 @@ class RapidataOrderManager:
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """
         Create a ranking order.
@@ -434,6 +445,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the ranking. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the ranking. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the ranking. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
 
         Example:
             ```python
@@ -506,6 +519,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def create_free_text_order(
@@ -521,6 +535,7 @@ class RapidataOrderManager:
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """Create a free text order.
 
@@ -543,6 +558,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the free text. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the free text. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the free text. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
                 This will NOT be shown to the labelers but will be included in the result purely for your own reference.
@@ -583,6 +600,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def create_select_words_order(
@@ -598,6 +616,7 @@ class RapidataOrderManager:
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """Create a select words order.
 
@@ -619,6 +638,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the select words. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the select words. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the select words. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
                 This will NOT be shown to the labelers but will be included in the result purely for your own reference.
@@ -661,6 +682,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def create_locate_order(
@@ -676,6 +698,7 @@ class RapidataOrderManager:
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """Create a locate order.
 
@@ -697,6 +720,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the locate. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the locate. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the locate. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
                 This will NOT be shown to the labelers but will be included in the result purely for your own reference.
@@ -734,6 +759,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def create_draw_order(
@@ -749,6 +775,7 @@ class RapidataOrderManager:
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """Create a draw order.
 
@@ -770,6 +797,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the draw lines. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the draw lines. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the draw lines. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
                 This will NOT be shown to the labelers but will be included in the result purely for your own reference.
@@ -807,6 +836,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def create_timestamp_order(
@@ -822,6 +852,7 @@ class RapidataOrderManager:
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
+        demographic_keys: list[str] | None = None,
     ) -> RapidataOrder:
         """Create a timestamp order.
 
@@ -846,6 +877,8 @@ class RapidataOrderManager:
             filters (Sequence[RapidataFilter], optional): The list of filters for the timestamp. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the timestamp. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the timestamp. Defaults to []. Decides in what order the tasks should be shown.
+            demographic_keys (list[str], optional): Demographic keys to collect for each annotator and project into the aggregated results under ``userDetails.demographics``.\n
+                Defaults to None, which keeps the platform default of ``["age", "gender", "occupation"]``. Accepts any custom key registered beforehand via the demographic rapid creation endpoint.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
                 This will NOT be shown to the labelers but will be included in the result purely for your own reference.
@@ -871,6 +904,7 @@ class RapidataOrderManager:
                 filters=filters,
                 selections=selections,
                 settings=settings,
+                demographic_keys=demographic_keys,
             )
 
     def get_order_by_id(self, order_id: str) -> RapidataOrder:


### PR DESCRIPTION
## Summary

- Adds `demographic_keys: list[str] | None = None` to every `rapi.order.create_*_order(...)` method and to the internal `RapidataOrderBuilder`.
- Plumbs the list into the generated `CreateOrderModel.demographicKeys` field (which the backend already understands on its API model).
- Updates `docs/understanding_the_results.md` with the new `userDetails.demographics` dict surfaced by the evaluator.

## Usage

```python
from rapidata import RapidataClient, LabelingSelection
from rapidata.rapidata_client.selection import DemographicSelection

rapi = RapidataClient()

# One-time: register a custom demographic question.
rapi._demographic.create_demographic_rapid(
    key="handedness",
    instruction="Which hand do you write with?",
    answer_options=["Left", "Right", "Both"],
    datapoint="path/to/illustration.png",
)

rapi.order.create_classification_order(
    name="My order",
    instruction="...",
    answer_options=["A", "B"],
    datapoints=[...],
    demographic_keys=["age", "gender", "handedness"],  # NEW
    selections=[
        LabelingSelection(amount=2),
        DemographicSelection(keys=["age", "gender", "handedness"], max_rapids=1),
    ],
)
```

Custom keys end up in `userDetails.demographics` on each response in the results file (the historical `age`/`gender`/`occupation` top-level fields are still populated when those keys are configured, for back-compat).

## Back-compat

Omitting `demographic_keys` keeps the platform default `[age, gender, occupation]` — no change for existing callers.

## Related PRs

Part of an E2E change:
- rapidata-backend: `feat(aggregation): propagate demographic keys from campaign to aggregator`
- rapidata-evaluator: `feat(aggregator): honor demographic keys for userDetails projection`

## Test plan

- [ ] `pyright src/rapidata/rapidata_client` clean
- [ ] `uv run --group docs mkdocs build` succeeds with the updated docs
- [ ] Staging smoke: create an order with a custom demographic key and confirm `get_results()` surfaces it under `userDetails.demographics`

🔗 Session: [session-051491d9](https://session-051491d9.poseidon.rapidata.internal/)