### PR TITLE
feat(client): read credentials and environment from env vars

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -62,6 +62,25 @@ Environment variables are applied at initialization and act as defaults — valu
 2. Environment variables (`RAPIDATA_*`)
 3. Built-in defaults
 
+### Client authentication
+
+The `RapidataClient` constructor also picks up credentials and the target environment from the following variables when the matching constructor arguments are omitted:
+
+| Variable | Maps to | Description |
+|---|---|---|
+| `RAPIDATA_CLIENT_ID` | `client_id` | OAuth client ID |
+| `RAPIDATA_CLIENT_SECRET` | `client_secret` | OAuth client secret |
+| `RAPIDATA_ENVIRONMENT` | `environment` | API endpoint (defaults to `rapidata.ai`) |
+
+Resolution order for these values:
+
+1. Arguments passed to `RapidataClient(...)`.
+2. The environment variables above.
+3. Credentials stored under `~/.config/rapidata/credentials.json`.
+4. Interactive browser login.
+
+Empty strings are treated as unset, so `RAPIDATA_CLIENT_ID=""` falls through to the next layer instead of attempting to authenticate with an empty value.
+
 ### Example `.env` file
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,25 +38,6 @@ from rapidata import RapidataClient
 client = RapidataClient(client_id="Your client ID", client_secret="Your client secret")
 ```
 
-You can also provide the client ID and secret through environment variables.
-This is the recommended approach for headless environments such as CI jobs
-or containerised workloads, where opening a browser is not an option:
-
-```bash
-export RAPIDATA_CLIENT_ID="Your client ID"
-export RAPIDATA_CLIENT_SECRET="Your client secret"
-# Optionally override the target environment (defaults to rapidata.ai)
-export RAPIDATA_ENVIRONMENT="rapidata.ai"
-```
-
-```py
-from rapidata import RapidataClient
-client = RapidataClient()  # picks up credentials and environment from the env
-```
-
-Explicit arguments take precedence over environment variables, which in turn
-take precedence over the cached credentials file.
-
 ### Step 1: Get an Audience
 
 The simplest way to get started is with a curated audience:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,6 +38,25 @@ from rapidata import RapidataClient
 client = RapidataClient(client_id="Your client ID", client_secret="Your client secret")
 ```
 
+You can also provide the client ID and secret through environment variables.
+This is the recommended approach for headless environments such as CI jobs
+or containerised workloads, where opening a browser is not an option:
+
+```bash
+export RAPIDATA_CLIENT_ID="Your client ID"
+export RAPIDATA_CLIENT_SECRET="Your client secret"
+# Optionally override the target environment (defaults to rapidata.ai)
+export RAPIDATA_ENVIRONMENT="rapidata.ai"
+```
+
+```py
+from rapidata import RapidataClient
+client = RapidataClient()  # picks up credentials and environment from the env
+```
+
+Explicit arguments take precedence over environment variables, which in turn
+take precedence over the cached credentials file.
+
 ### Step 1: Get an Audience
 
 The simplest way to get started is with a curated audience:

--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 import requests
 from packaging import version
@@ -43,19 +44,38 @@ class RapidataClient:
         self,
         client_id: str | None = None,
         client_secret: str | None = None,
-        environment: str = "rapidata.ai",
+        environment: str | None = None,
         oauth_scope: str = "openid roles email",
         cert_path: str | None = None,
         token: dict | None = None,
         leeway: int = 60,
     ):
-        """Initialize the RapidataClient. If both the client_id and client_secret are None, it will try using your credentials under "~/.config/rapidata/credentials.json".
-        If this is not successful, it will open a browser window and ask you to log in, then save your new credentials in said json file.
+        """Initialize the RapidataClient.
+
+        Credentials are resolved in the following order:
+
+        1. ``client_id`` / ``client_secret`` passed explicitly to this
+           constructor.
+        2. The ``RAPIDATA_CLIENT_ID`` / ``RAPIDATA_CLIENT_SECRET``
+           environment variables (useful for headless / container
+           deployments).
+        3. Credentials stored under ``~/.config/rapidata/credentials.json``.
+        4. Interactive browser login, which then saves credentials to the
+           file above so you don't have to log in again.
+
+        The ``environment`` argument follows the same pattern: when omitted
+        it falls back to the ``RAPIDATA_ENVIRONMENT`` environment variable,
+        and finally to the default ``"rapidata.ai"``.
 
         Args:
-            client_id (str): The client ID for authentication.
-            client_secret (str): The client secret for authentication.
-            environment (str, optional): The API endpoint.
+            client_id (str): The client ID for authentication. Falls back to
+                the ``RAPIDATA_CLIENT_ID`` environment variable when omitted.
+            client_secret (str): The client secret for authentication. Falls
+                back to the ``RAPIDATA_CLIENT_SECRET`` environment variable
+                when omitted.
+            environment (str, optional): The API endpoint. Falls back to the
+                ``RAPIDATA_ENVIRONMENT`` environment variable, and then to
+                ``"rapidata.ai"``.
             oauth_scope (str, optional): The scopes to use for authentication. In general this does not need to be changed.
             cert_path (str, optional): An optional path to a certificate file useful for development.
             token (dict, optional): If you already have a token that the client should use for authentication. Important, if set, this needs to be the complete token object containing the access token, token type and expiration time.
@@ -72,6 +92,17 @@ class RapidataClient:
         tracer.set_session_id(
             uuid.UUID(int=random.Random().getrandbits(128), version=4).hex
         )
+
+        # Fall back to RAPIDATA_CLIENT_ID / RAPIDATA_CLIENT_SECRET /
+        # RAPIDATA_ENVIRONMENT when the caller didn't pass them explicitly.
+        # Empty env vars are treated as unset so we fall through to the
+        # next layer (credential file / browser flow, or the default env).
+        if client_id is None:
+            client_id = os.environ.get("RAPIDATA_CLIENT_ID") or None
+        if client_secret is None:
+            client_secret = os.environ.get("RAPIDATA_CLIENT_SECRET") or None
+        if environment is None:
+            environment = os.environ.get("RAPIDATA_ENVIRONMENT") or "rapidata.ai"
 
         with tracer.start_as_current_span("RapidataClient.__init__"):
             logger.debug("Checking version")


### PR DESCRIPTION
## Summary

- `RapidataClient` now falls back to `RAPIDATA_CLIENT_ID`, `RAPIDATA_CLIENT_SECRET`, and `RAPIDATA_ENVIRONMENT` when the matching constructor arguments are omitted.
- Explicit args still win, and the existing `~/.config/rapidata/credentials.json` / browser flow is unchanged when neither args nor env vars are set.
- Empty env vars are treated as unset, so `RAPIDATA_CLIENT_ID=""` falls through to the next layer instead of failing auth with an empty string.

### Resolution order

1. Explicit `client_id` / `client_secret` / `environment` arguments.
2. `RAPIDATA_CLIENT_ID` / `RAPIDATA_CLIENT_SECRET` / `RAPIDATA_ENVIRONMENT` environment variables.
3. Credentials stored under `~/.config/rapidata/credentials.json`.
4. Interactive browser login.

### Why

Unblocks headless usage in CI jobs and containerised workloads (e.g. K8s pods that can't open a browser). Matches the existing `RAPIDATA_`-prefix convention already used in `src/rapidata/rapidata_client/config/_env_utils.py` and `RAPIDATA_DISABLE_OTLP`.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` — 0 errors, 0 warnings.
- [x] Smoke-tested the four cases against a mocked `OpenAPIService`:
  - env vars set → env vars forwarded
  - explicit kwargs + env vars → kwargs win
  - empty env vars → treated as unset, defaults apply
  - no env + no kwargs → original behaviour (credential manager path)
- [ ] Tag a new patch release and verify the built package picks up `RAPIDATA_CLIENT_ID` etc. in a Vessel pod.

🔗 [Session](https://session-1604da76.poseidon.rapidata.internal/)