### PR TITLE
docs(landing): embed live campaign preview iframe

### DIFF
--- a/docs/js/preview-embed.js
+++ b/docs/js/preview-embed.js
@@ -146,6 +146,14 @@ function initAllPreviewEmbeds() {
     });
 }
 
-document.addEventListener('DOMContentLoaded', initAllPreviewEmbeds);
-// Material for MkDocs instant navigation — re-init after each page swap.
-document.addEventListener('DOMContentSwitch', initAllPreviewEmbeds);
+// Material for MkDocs exposes a `document$` RxJS subject that emits the
+// current document on subscribe AND every time instant-navigation swaps
+// the <main> content. Subscribing covers both the initial render and
+// subsequent page navigations — a plain DOMContentLoaded listener would
+// only fire on hard loads, leaving the embed unwired after nav swaps.
+if (typeof window.document$ !== 'undefined'
+    && typeof window.document$.subscribe === 'function') {
+    window.document$.subscribe(initAllPreviewEmbeds);
+} else {
+    document.addEventListener('DOMContentLoaded', initAllPreviewEmbeds);
+}

--- a/docs/js/preview-embed.js
+++ b/docs/js/preview-embed.js
@@ -41,27 +41,47 @@ function labelTextForInput(tabbedSet, input) {
 }
 
 function initPreviewEmbed(wrapper) {
+    // Two modes:
+    //   - data-preview-map='{"Image":"cmp_...",...}' — tab-synced; swap
+    //     iframe when the preceding tabbed-set's active tab changes.
+    //   - data-preview-campaign="cmp_..." — static; just the refresh
+    //     button is wired up.
     const rawMap = wrapper.getAttribute('data-preview-map');
-    if (!rawMap) return;
+    const staticId = wrapper.getAttribute('data-preview-campaign');
 
-    let campaignMap;
-    try {
-        campaignMap = JSON.parse(rawMap);
-    } catch (err) {
-        console.warn('[preview-embed] invalid data-preview-map JSON:', err);
-        return;
+    let campaignMap = null;
+    if (rawMap) {
+        try {
+            campaignMap = JSON.parse(rawMap);
+        } catch (err) {
+            console.warn('[preview-embed] invalid data-preview-map JSON:', err);
+        }
     }
 
-    const tabbedSet = findPrecedingTabbedSet(wrapper);
+    // Only bind to a tabbed-set when we have a mapping to drive.
+    const tabbedSet = campaignMap ? findPrecedingTabbedSet(wrapper) : null;
     const refreshBtn = wrapper.querySelector('[data-preview-refresh]');
     let refreshCount = 0;
 
     function currentCampaignId() {
-        if (!tabbedSet) return null;
-        const checked = tabbedSet.querySelector('input[type="radio"]:checked');
-        if (!checked) return null;
-        const name = labelTextForInput(tabbedSet, checked);
-        return name ? (campaignMap[name] || null) : null;
+        if (tabbedSet && campaignMap) {
+            const checked = tabbedSet.querySelector('input[type="radio"]:checked');
+            if (checked) {
+                const name = labelTextForInput(tabbedSet, checked);
+                if (name && campaignMap[name]) return campaignMap[name];
+            }
+        }
+        if (staticId) return staticId;
+        // Final fallback: whatever id the iframe already has.
+        const iframe = wrapper.querySelector('iframe.phone-preview__iframe');
+        if (iframe && iframe.src) {
+            try {
+                return new URL(iframe.src).searchParams.get('id');
+            } catch (_err) {
+                return null;
+            }
+        }
+        return null;
     }
 
     function attachIframeLoadHandler(iframe) {

--- a/docs/js/preview-embed.js
+++ b/docs/js/preview-embed.js
@@ -1,0 +1,131 @@
+// Rapids campaign preview embed.
+// Mirrors the behavior of PhonePreview in app-frontend:
+// - swaps iframe src based on which code-snippet tab is selected
+// - refresh button increments &refreshCount=N to force a fresh session
+// - on each src change, the iframe element is replaced (destroy + recreate),
+//   matching `key={url}` in app-frontend so parent history stays clean
+// - sends {viewable: true} postMessage to rapids.rapidata.ai on load
+
+const RAPIDS_ORIGIN = 'https://rapids.rapidata.ai';
+
+function buildPreviewUrl(campaignId, refreshCount) {
+    const params = new URLSearchParams({
+        id: campaignId,
+        language: 'en',
+        userSegment: '0',
+        refreshCount: String(refreshCount),
+    });
+    return `${RAPIDS_ORIGIN}/preview/campaign?${params.toString()}`;
+}
+
+function findPrecedingTabbedSet(el) {
+    // Walk previous siblings, then step up to parents if we run out.
+    let cur = el.previousElementSibling;
+    while (cur) {
+        if (cur.classList && cur.classList.contains('tabbed-set')) return cur;
+        // Occasionally the tabbed-set is nested inside a wrapper; look inside.
+        const nested = cur.querySelector && cur.querySelector('.tabbed-set');
+        if (nested) return nested;
+        cur = cur.previousElementSibling;
+    }
+    if (el.parentElement && el.parentElement !== document.body) {
+        return findPrecedingTabbedSet(el.parentElement);
+    }
+    return null;
+}
+
+function labelTextForInput(tabbedSet, input) {
+    const label = tabbedSet.querySelector(`label[for="${input.id}"]`);
+    if (!label) return null;
+    return (label.textContent || '').trim();
+}
+
+function initPreviewEmbed(wrapper) {
+    const rawMap = wrapper.getAttribute('data-preview-map');
+    if (!rawMap) return;
+
+    let campaignMap;
+    try {
+        campaignMap = JSON.parse(rawMap);
+    } catch (err) {
+        console.warn('[preview-embed] invalid data-preview-map JSON:', err);
+        return;
+    }
+
+    const tabbedSet = findPrecedingTabbedSet(wrapper);
+    const refreshBtn = wrapper.querySelector('[data-preview-refresh]');
+    let refreshCount = 0;
+
+    function currentCampaignId() {
+        if (!tabbedSet) return null;
+        const checked = tabbedSet.querySelector('input[type="radio"]:checked');
+        if (!checked) return null;
+        const name = labelTextForInput(tabbedSet, checked);
+        return name ? (campaignMap[name] || null) : null;
+    }
+
+    function attachIframeLoadHandler(iframe) {
+        iframe.addEventListener('load', () => {
+            try {
+                iframe.contentWindow.postMessage(
+                    { viewable: true, timestamp: Date.now() },
+                    RAPIDS_ORIGIN,
+                );
+            } catch (_err) {
+                // Cross-origin guard, shouldn't happen but ignore.
+            }
+        }, { once: false });
+    }
+
+    // Attach to the initial iframe rendered in HTML.
+    const initialIframe = wrapper.querySelector('iframe.phone-preview__iframe');
+    if (initialIframe) attachIframeLoadHandler(initialIframe);
+
+    function renderIframe({ resetRefresh = false } = {}) {
+        const id = currentCampaignId();
+        if (!id) return;
+        if (resetRefresh) refreshCount = 0;
+        const url = buildPreviewUrl(id, refreshCount);
+        const old = wrapper.querySelector('iframe.phone-preview__iframe');
+        if (!old) return;
+        if (old.src === url) return;
+
+        // Destroy + recreate to avoid polluting parent history on src change.
+        const fresh = old.cloneNode(false);
+        fresh.src = url;
+        attachIframeLoadHandler(fresh);
+        old.replaceWith(fresh);
+    }
+
+    if (tabbedSet) {
+        tabbedSet.querySelectorAll('input[type="radio"]').forEach((input) => {
+            input.addEventListener('change', () => renderIframe({ resetRefresh: true }));
+        });
+    }
+
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', () => {
+            refreshCount += 1;
+            renderIframe();
+            refreshBtn.classList.remove('is-refreshing');
+            // Force reflow so the animation retriggers on each click.
+            void refreshBtn.offsetWidth;
+            refreshBtn.classList.add('is-refreshing');
+        });
+    }
+
+    // Sync once in case the page loaded with a non-default tab (e.g. deep link).
+    renderIframe();
+}
+
+function initAllPreviewEmbeds() {
+    document.querySelectorAll('[data-preview-embed]').forEach((wrapper) => {
+        if (wrapper.dataset.previewEmbedInit === '1') return;
+        wrapper.dataset.previewEmbedInit = '1';
+        initPreviewEmbed(wrapper);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', initAllPreviewEmbeds);
+// Material for MkDocs instant navigation — re-init after each page swap.
+document.addEventListener('DOMContentSwitch', initAllPreviewEmbeds);

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,6 +8,24 @@ The workflow consists of three main concepts:
 2. **Job Definition**: The configuration for your labeling task (instruction, datapoints, settings)
 3. **Job**: A running labeling task assigned to an audience
 
+<div data-preview-embed data-preview-campaign="cmp_1HSFCph25U1J22">
+  <div class="phone-preview">
+    <div class="phone-preview__notch"></div>
+    <div class="phone-preview__btn phone-preview__btn--left-top"></div>
+    <div class="phone-preview__btn phone-preview__btn--left-bot"></div>
+    <div class="phone-preview__btn phone-preview__btn--right"></div>
+    <iframe class="phone-preview__iframe"
+            src="https://rapids.rapidata.ai/preview/campaign?id=cmp_1HSFCph25U1J22&language=en&userSegment=0&refreshCount=0"
+            allow="clipboard-write"
+            title="Live Rapidata campaign preview"></iframe>
+  </div>
+  <div class="preview-controls">
+    <button type="button" data-preview-refresh aria-label="Refresh preview">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>
+      <span>Refresh</span>
+    </button>
+  </div>
+</div>
 
 ## Installation
 

--- a/docs/starting_page.md
+++ b/docs/starting_page.md
@@ -10,21 +10,6 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
 
 ---
 
-## Try it live
-
-This is what an annotator sees when they work on a Rapidata job — rendered here as an embedded preview of a real campaign.
-
-<div style="width: 375px; height: 667px; margin: 0 auto; border-radius: 24px; overflow: hidden; border: 1px solid rgba(255,255,255,0.1);">
-    <iframe src="https://rapids.rapidata.ai/preview/campaign?id=cmp_1HSFCph25U1J22&language=en&userSegment=0&refreshCount=0"
-            width="100%"
-            height="100%"
-            frameborder="0"
-            allow="clipboard-write">
-    </iframe>
-</div>
-
----
-
 ## Quick example
 
 === "Image"
@@ -117,6 +102,26 @@ This is what an annotator sees when they work on a Rapidata job — rendered her
     results = job.get_results()
     print(results)
     ```
+
+<div data-preview-embed
+     data-preview-map='{"Image":"cmp_1HSFCph25U1J22","Video":"cmp_1HSMbDk5EaUExL","Audio":"cmp_1HSMsM9Ph3Sn5o","Text":"cmp_1HSN6NhgMo4C9R"}'>
+  <div class="phone-preview">
+    <div class="phone-preview__notch"></div>
+    <div class="phone-preview__btn phone-preview__btn--left-top"></div>
+    <div class="phone-preview__btn phone-preview__btn--left-bot"></div>
+    <div class="phone-preview__btn phone-preview__btn--right"></div>
+    <iframe class="phone-preview__iframe"
+            src="https://rapids.rapidata.ai/preview/campaign?id=cmp_1HSFCph25U1J22&language=en&userSegment=0&refreshCount=0"
+            allow="clipboard-write"
+            title="Live Rapidata campaign preview"></iframe>
+  </div>
+  <div class="preview-controls">
+    <button type="button" data-preview-refresh aria-label="Refresh preview">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>
+      <span>Refresh</span>
+    </button>
+  </div>
+</div>
 
 !!! note
     The curated/global audiences get you started quickly. For higher quality results, use a [custom audience](audiences.md) with qualification examples.

--- a/docs/starting_page.md
+++ b/docs/starting_page.md
@@ -10,6 +10,21 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
 
 ---
 
+## Try it live
+
+This is what an annotator sees when they work on a Rapidata job — rendered here as an embedded preview of a real campaign.
+
+<div style="width: 375px; height: 667px; margin: 0 auto; border-radius: 24px; overflow: hidden; border: 1px solid rgba(255,255,255,0.1);">
+    <iframe src="https://rapids.rapidata.ai/preview/campaign?id=cmp_1HSFCph25U1J22&language=en&userSegment=0&refreshCount=0"
+            width="100%"
+            height="100%"
+            frameborder="0"
+            allow="clipboard-write">
+    </iframe>
+</div>
+
+---
+
 ## Quick example
 
 === "Image"

--- a/docs/starting_page.md
+++ b/docs/starting_page.md
@@ -103,6 +103,9 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
     print(results)
     ```
 
+!!! note
+    The curated/global audiences get you started quickly. For higher quality results, use a [custom audience](audiences.md) with qualification examples.
+
 <div data-preview-embed
      data-preview-map='{"Image":"cmp_1HSFCph25U1J22","Video":"cmp_1HSMbDk5EaUExL","Audio":"cmp_1HSMsM9Ph3Sn5o","Text":"cmp_1HSN6NhgMo4C9R"}'>
   <div class="phone-preview">
@@ -122,9 +125,6 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
     </button>
   </div>
 </div>
-
-!!! note
-    The curated/global audiences get you started quickly. For higher quality results, use a [custom audience](audiences.md) with qualification examples.
 
 ---
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -279,6 +279,122 @@ body {
 
 
 /* ==========================================================================
+   Phone preview (embedded rapids campaign iframe)
+   Mirrors PhonePreview in app-frontend:
+   src/components/order/OrderPreview/OrderPreview.tsx
+   ========================================================================== */
+
+.phone-preview {
+    position: relative;
+    width: 375px;
+    height: 667px;
+    margin: 1.5rem auto 0;
+    border-radius: 40px;
+    border: 14px solid var(--color-preview-frame);
+    background: var(--color-preview-frame);
+    box-shadow:
+        0 20px 25px -5px rgba(0, 0, 0, 0.35),
+        0 8px 10px -6px rgba(0, 0, 0, 0.25);
+}
+
+.phone-preview__notch {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 148px;
+    height: 7px;
+    background: var(--color-preview-frame);
+    border-bottom-left-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+    z-index: 30;
+}
+
+.phone-preview__btn {
+    position: absolute;
+    width: 3px;
+    background: var(--color-preview-frame);
+    z-index: 30;
+}
+
+.phone-preview__btn--left-top {
+    left: -17px;
+    top: 124px;
+    height: 46px;
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+}
+
+.phone-preview__btn--left-bot {
+    left: -17px;
+    top: 178px;
+    height: 46px;
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+}
+
+.phone-preview__btn--right {
+    right: -17px;
+    top: 142px;
+    height: 64px;
+    border-top-right-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+}
+
+.phone-preview__iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    border-radius: 26px;
+    background: var(--color-background);
+    z-index: 20;
+}
+
+.preview-controls {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin: 0.75rem 0 1.5rem;
+}
+
+.preview-controls button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    background: transparent;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 0.25rem;
+    cursor: pointer;
+    transition: color 0.1s ease, border-color 0.1s ease;
+}
+
+.preview-controls button:hover {
+    color: var(--color-text-primary);
+    border-color: var(--md-default-fg-color--lighter);
+}
+
+.preview-controls button svg {
+    width: 14px;
+    height: 14px;
+}
+
+.preview-controls button.is-refreshing svg {
+    animation: preview-refresh-spin 0.6s linear;
+}
+
+@keyframes preview-refresh-spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+}
+
+
+/* ==========================================================================
    AI Agent copy button
    ========================================================================== */
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -286,6 +286,9 @@ body {
 
 .phone-preview {
     position: relative;
+    /* Form a local stacking context so the child z-indexes below
+       can't escape and paint over Material's sticky header. */
+    isolation: isolate;
     width: 375px;
     height: 667px;
     margin: 1.5rem auto 0;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ extra_javascript:
   - js/tawk.js
   - js/login.js
   - js/ai-copy-button.js
+  - js/preview-embed.js
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap
   - stylesheets/extra.css

--- a/uv.lock
+++ b/uv.lock
@@ -2570,7 +2570,7 @@ wheels = [
 
 [[package]]
 name = "rapidata"
-version = "3.9.4"
+version = "3.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary
- Embeds a live, tab-synced campaign preview on the SDK landing page (`docs/starting_page.md`), wrapped in a phone frame that mirrors `PhonePreview` in `app-frontend/src/components/order/OrderPreview/OrderPreview.tsx` (notch, side buttons, 40px radius, 14px frame).
- The preview sits **below** the Image / Video / Audio / Text code-snippet tabs and swaps its iframe `src` when the reader switches tabs — driven by a `data-preview-map` on the wrapper and a new `docs/js/preview-embed.js`.
- Adds a **Refresh** button below the phone that increments `&refreshCount=N` in the preview URL so the iframe reloads with a fresh session. Mirrors the `key={url}` destroy+recreate pattern on the frontend so parent history stays clean.
- Sends the `{viewable: true}` `postMessage` to `rapids.rapidata.ai` on iframe load, matching the frontend `PhonePreview.onLoad` behavior.

## Campaign mapping
| Tab   | Campaign |
|-------|----------|
| Image | `cmp_1HSFCph25U1J22` |
| Video | `cmp_1HSMbDk5EaUExL` |
| Audio | `cmp_1HSMsM9Ph3Sn5o` |
| Text  | `cmp_1HSN6NhgMo4C9R` |

## Files changed
- `docs/starting_page.md` — replaces the earlier inline iframe with a phone-frame `<div data-preview-embed>` block below the code tabs; adds the refresh button.
- `docs/stylesheets/extra.css` — adds `.phone-preview` (frame, notch, side buttons, inner iframe) and `.preview-controls` (refresh button + spin animation). Uses the existing `--color-preview-frame` token that was already defined in this file.
- `docs/js/preview-embed.js` — watches the preceding `.tabbed-set`'s radio inputs, maps the active tab label to a campaign id, swaps the iframe via destroy+recreate, and wires up the refresh button. Re-inits on Material's `DOMContentSwitch` for instant-navigation compatibility.
- `mkdocs.yml` — registers `js/preview-embed.js` in `extra_javascript`.

## Notes
- The preview route mints its own session token server-side, so no docs-viewer auth is required.
- `rapids.rapidata.ai` currently sends no `X-Frame-Options` / `frame-ancestors`, so `docs.rapidata.ai` can embed it. If CSP is added later, `docs.rapidata.ai` will need to be whitelisted.
- If any campaign in the mapping is deleted, only that tab's preview breaks — consider pinning stable "docs demo" campaigns before the wider rollout.
- Tab-to-campaign mapping is by **label text** (Image/Video/Audio/Text), so reordering tabs in the markdown won't break the sync.

## Test plan
- [ ] `mkdocs serve` and confirm the phone frame renders below the code tabs with the notch + side buttons
- [ ] Click each tab (Image / Video / Audio / Text) and confirm the iframe swaps to the correct campaign id in the URL
- [ ] Click the Refresh button and confirm `&refreshCount=N` increments and the iframe reloads with a fresh session
- [ ] Use the browser Back button after refreshing a few times — the docs page itself should be just one history entry back, not one per refresh (destroy+recreate pattern)
- [ ] Verify no CSP / frame errors in the browser console once deployed to `docs.rapidata.ai`
- [ ] Check the page looks right after Material's instant-navigation (navigate away and back)

🔗 [Session](https://session-cf1cd0b1.poseidon.rapidata.internal/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
