### PR TITLE
feat(settings): route order/job feature flags to rapidFeatureFlags

### DIFF
--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -103,6 +103,17 @@ class RapidataJobManager:
         with tracer.start_as_current_span("add_datapoints"):
             _, failed_uploads = rapidata_dataset.add_datapoints(datapoints)
 
+        rapid_feature_flags = (
+            [s._to_feature_flag() for s in settings if s.target == "rapids"]
+            if settings
+            else None
+        )
+        campaign_feature_flags = (
+            [s._to_feature_flag() for s in settings if s.target == "campaign"]
+            if settings
+            else None
+        )
+
         job_definition_response = (
             self._openapi_service.order.job_api.job_definition_post(
                 create_job_definition_endpoint_input=CreateJobDefinitionEndpointInput(
@@ -110,8 +121,9 @@ class RapidataJobManager:
                     workflow=workflow._to_model(),
                     datasetId=rapidata_dataset.id,
                     referee=referee._to_model(),
-                    featureFlags=(
-                        [s._to_feature_flag() for s in settings] if settings else None
+                    rapidFeatureFlags=rapid_feature_flags if rapid_feature_flags else None,
+                    campaignFeatureFlags=(
+                        campaign_feature_flags if campaign_feature_flags else None
                     ),
                 )
             )

--- a/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
+++ b/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
@@ -95,16 +95,34 @@ class RapidataOrderBuilder:
         from rapidata.api_client.models.create_order_model import CreateOrderModel
         from rapidata.api_client.models.sticky_state import StickyState
 
+        rapid_feature_flags = (
+            [
+                setting._to_feature_flag()
+                for setting in self._settings
+                if setting.target == "rapids"
+            ]
+            if self._settings is not None
+            else None
+        )
+        campaign_feature_flags = (
+            [
+                setting._to_feature_flag()
+                for setting in self._settings
+                if setting.target == "campaign"
+            ]
+            if self._settings is not None
+            else None
+        )
+
         return CreateOrderModel(
             orderName=self._name,
             workflow=self._workflow._to_model(),
             userFilters=[user_filter._to_model() for user_filter in self._user_filters],
             referee=self._referee._to_model(),
             validationSetId=validation_set_id,
-            featureFlags=(
-                [setting._to_feature_flag() for setting in self._settings]
-                if self._settings is not None
-                else None
+            rapidFeatureFlags=rapid_feature_flags if rapid_feature_flags else None,
+            campaignFeatureFlags=(
+                campaign_feature_flags if campaign_feature_flags else None
             ),
             selections=(
                 [selection._to_model() for selection in self._selections]

--- a/src/rapidata/rapidata_client/settings/_rapidata_setting.py
+++ b/src/rapidata/rapidata_client/settings/_rapidata_setting.py
@@ -1,16 +1,29 @@
 from __future__ import annotations
 from pydantic import BaseModel
-from typing import Any, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from rapidata.api_client.models.feature_flag import FeatureFlag
 
 
+FeatureFlagTarget = Literal["rapids", "campaign"]
+
+
 class RapidataSetting(BaseModel):
-    """Base class for all settings"""
+    """Base class for all settings.
+
+    Every setting is translated into a feature flag when sent to the API.
+    The ``target`` attribute determines whether the resulting feature flag is
+    attached to the rapid level (``rapidFeatureFlags``) or the campaign level
+    (``campaignFeatureFlags``) during order and job creation. Subclasses that
+    represent rapid-level behaviour (the default) should leave ``target`` at
+    ``"rapids"``. Only :class:`CustomSetting` exposes ``target`` as an
+    argument so users can opt into campaign-level flags.
+    """
 
     key: str
     value: Any
+    target: FeatureFlagTarget = "rapids"
 
     def _to_feature_flag(self) -> FeatureFlag:
         from rapidata.api_client.models.feature_flag import FeatureFlag
@@ -18,7 +31,10 @@ class RapidataSetting(BaseModel):
         return FeatureFlag(key=self.key, value=str(self.value))
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__}(key='{self.key}', value={self.value})"
+        return f"{self.__class__.__name__}(key='{self.key}', value={self.value}, target='{self.target}')"
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(key={self.key!r}, value={self.value!r})"
+        return (
+            f"{self.__class__.__name__}(key={self.key!r}, value={self.value!r}, "
+            f"target={self.target!r})"
+        )

--- a/src/rapidata/rapidata_client/settings/custom_setting.py
+++ b/src/rapidata/rapidata_client/settings/custom_setting.py
@@ -1,17 +1,37 @@
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from __future__ import annotations
+
+from typing import get_args
+
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    FeatureFlagTarget,
+    RapidataSetting,
+)
 
 
 class CustomSetting(RapidataSetting):
     """
-    Set a custom setting with the given key and value. Use this to enable features that do not have a dedicated method (yet)
+    Set a custom setting with the given key and value. Use this to enable features that do not have a dedicated method (yet).
 
     Args:
         key (str): The key for the custom setting.
         value (str): The value for the custom setting.
+        target (Literal["rapids", "campaign"], optional): Whether the feature flag should be applied
+            at the rapid level or the campaign level. Defaults to ``"rapids"``.
     """
 
-    def __init__(self, key: str, value: str):
+    def __init__(
+        self,
+        key: str,
+        value: str,
+        target: FeatureFlagTarget = "rapids",
+    ):
         if not isinstance(key, str):
             raise ValueError("The key must be a string.")
 
-        super().__init__(key=key, value=value)
+        valid_targets = get_args(FeatureFlagTarget)
+        if target not in valid_targets:
+            raise ValueError(
+                f"The target must be one of {valid_targets}, got {target!r}."
+            )
+
+        super().__init__(key=key, value=value, target=target)


### PR DESCRIPTION
## Summary

- Move `CreateOrderModel` and `CreateJobDefinitionEndpointInput` off the deprecated global `featureFlags` field — they now populate `rapidFeatureFlags` by default.
- `RapidataSetting` grows a `target: Literal["rapids", "campaign"]` attribute (defaults to `"rapids"`), which determines which bucket each flag is routed into at model build time.
- `CustomSetting` exposes that `target` as a third, optional argument — `CustomSetting("my_flag", "value", "campaign")` routes to `campaignFeatureFlags`. All built-in settings continue to target `"rapids"`.
- Flow, benchmark, and validation rapid uploads are left untouched — those endpoints don't yet offer the rapid/campaign split.

## Example

```python
from rapidata import CustomSetting, NoShuffleSetting

settings = [
    NoShuffleSetting(),                                 # -> rapidFeatureFlags
    CustomSetting("some_rapid_flag", "true"),           # -> rapidFeatureFlags (default)
    CustomSetting("some_campaign_flag", "x", "campaign"),  # -> campaignFeatureFlags
]
```

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Smoke-tested: existing settings keep `target="rapids"`; `CustomSetting` accepts positional and keyword `target`; invalid values raise `ValueError`.
- [x] Smoke-tested the order builder: a mix of rapid/campaign settings splits into `rapid_feature_flags` / `campaign_feature_flags` on `CreateOrderModel`; empty lists collapse to `None` on both sides; the deprecated `feature_flags` global bucket is no longer populated.
- [ ] End-to-end run against a real backend to confirm the flags land in the right bucket.

🔗 Session: <https://session-cbb61086.poseidon.rapidata.internal/>

🤖 Generated with [Claude Code](https://claude.com/claude-code)