### PR TITLE
docs(results): document demographics dict on userDetails

### DIFF
--- a/docs/understanding_the_results.md
+++ b/docs/understanding_the_results.md
@@ -138,7 +138,7 @@ Here's an example of the results you might receive when running a COMPARE task (
             - `language`: Language in which the labeler viewed the task
             - `userScores`: A score representing the labeler's reliability across different dimensions
                 - `global`: The global userScore of the labeler, which is a measure of their overall reliability
-            - `demographics`: Demographic attributes collected for the labeler, keyed by attribute name (e.g. `age`, `gender`, `occupation`). Only the keys configured on the order are included, and only when the labeler has actually answered the corresponding question — unanswered keys are omitted, so labelers with no demographic data end up with an empty `demographics` dictionary.
+            - `demographics`: Demographic attributes collected for the labeler, keyed by attribute name (e.g. `age`, `gender`, `occupation`).
 
 ## Understanding the User Scores
 

--- a/docs/understanding_the_results.md
+++ b/docs/understanding_the_results.md
@@ -44,9 +44,7 @@ Here's an example of the results you might receive when running a COMPARE task (
                   "userScores": {
                       "global": 0.4469
                   },
-                  "age": "Unknown",
-                  "gender": "Unknown",
-                  "occupation": "Unknown"
+                  "demographics": {}
               }
           },
           {
@@ -57,9 +55,11 @@ Here's an example of the results you might receive when running a COMPARE task (
                   "userScores": {
                       "global": 0.3923
                   },
-                  "age": "0-17",
-                  "gender": "Other",
-                  "occupation": "Other Employment"
+                  "demographics": {
+                      "age": "0-17",
+                      "gender": "Other",
+                      "occupation": "Other Employment"
+                  }
               }
           },
           {
@@ -70,9 +70,11 @@ Here's an example of the results you might receive when running a COMPARE task (
                   "userScores": {
                       "global": 0.3568
                   },
-                  "age": "0-17",
-                  "gender": "Other",
-                  "occupation": "Healthcare"
+                  "demographics": {
+                      "age": "0-17",
+                      "gender": "Other",
+                      "occupation": "Healthcare"
+                  }
               }
           }
       ]
@@ -136,9 +138,7 @@ Here's an example of the results you might receive when running a COMPARE task (
             - `language`: Language in which the labeler viewed the task
             - `userScores`: A score representing the labeler's reliability across different dimensions
                 - `global`: The global userScore of the labeler, which is a measure of their overall reliability
-            - `age`: Age group of the labeler
-            - `gender`: The gender of the labeler
-            - `occupation`: The occupation of the labeler
+            - `demographics`: Demographic attributes collected for the labeler, keyed by attribute name (e.g. `age`, `gender`, `occupation`). Only the keys configured on the order are included, and only when the labeler has actually answered the corresponding question — unanswered keys are omitted, so labelers with no demographic data end up with an empty `demographics` dictionary.
 
 ## Understanding the User Scores
 

--- a/uv.lock
+++ b/uv.lock
@@ -2570,7 +2570,7 @@ wheels = [
 
 [[package]]
 name = "rapidata"
-version = "3.9.6"
+version = "3.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

Reflect the new aggregator result shape in the `understanding_the_results` page. The labeler's demographic attributes now live under `userDetails.demographics` (a dict keyed by attribute name) instead of flat top-level `age` / `gender` / `occupation` fields. Only keys configured on the order and actually answered by the labeler appear in the dict; labelers with no demographic data get an empty `demographics` dictionary.

## Related PRs

Companion to [rapidata-evaluator#267](https://github.com/RapidataAI/rapidata-evaluator/pull/267), which produces the new result shape.

## Test plan

- [x] `uv run --group docs mkdocs build` — site builds cleanly (only pre-existing griffe/link warnings, none touching this page)

🔗 Session: [session-051491d9](https://session-051491d9.poseidon.rapidata.internal/)