### PR TITLE
fix(client): prevent path traversal via Content-Disposition header

### DIFF
--- a/openapi/templates/api_client.mustache
+++ b/openapi/templates/api_client.mustache
@@ -717,9 +717,13 @@ class ApiClient:
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',
                 content_disposition
             )
-            assert m is not None, "Unexpected 'content-disposition' header value"
-            filename = m.group(1)
-            path = os.path.join(os.path.dirname(path), filename)
+            if m is not None:
+                # Strip any directory components from the server-supplied
+                # filename so an attacker-controlled Content-Disposition
+                # header can't escape the temp directory (CWE-22).
+                filename = os.path.basename(m.group(1))
+                if filename and filename not in (".", ".."):
+                    path = os.path.join(os.path.dirname(path), filename)
 
         with open(path, "wb") as f:
             f.write(response.data)

--- a/src/rapidata/api_client/api_client.py
+++ b/src/rapidata/api_client/api_client.py
@@ -700,9 +700,13 @@ class ApiClient:
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',
                 content_disposition
             )
-            assert m is not None, "Unexpected 'content-disposition' header value"
-            filename = m.group(1)
-            path = os.path.join(os.path.dirname(path), filename)
+            if m is not None:
+                # Strip any directory components from the server-supplied
+                # filename so an attacker-controlled Content-Disposition
+                # header can't escape the temp directory (CWE-22).
+                filename = os.path.basename(m.group(1))
+                if filename and filename not in (".", ".."):
+                    path = os.path.join(os.path.dirname(path), filename)
 
         with open(path, "wb") as f:
             f.write(response.data)


### PR DESCRIPTION
## Summary

`ApiClient.__deserialize_file` trusts the filename from the server's `Content-Disposition` header and joins it with `os.path.dirname(mkstemp_path)` with no sanitization. Two escapes:

- **Relative** — `Content-Disposition: filename="../../home/<user>/.ssh/authorized_keys"` walks out of the tempdir.
- **Absolute** — `filename="/etc/cron.d/backdoor"` — `os.path.join("/tmp/abc", "/etc/...")` silently discards the left side and returns the right side, so the SDK writes wherever the caller has permission.

A malicious or compromised API (or a MITM against a misconfigured install) can clobber arbitrary files on the SDK user's disk via any call that resolves to `response_type == "file"`. CWE-22.

Also: `assert m is not None` on line 703 vanishes under `python -O`, leaving the next line to raise `AttributeError` on `None.group(1)`.

## Fix

- `os.path.basename()` the server-supplied filename before joining.
- Replace the `assert` with a real conditional, fall back to the `mkstemp` path when the header is unparseable.
- Reject `"."` / `".."` / empty names.
- Mirror the change into `openapi/templates/api_client.mustache` so the next regen keeps the fix.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Spot-checked the regex with `../../etc/passwd`, `/etc/passwd`, `legit.pdf`, `""` — all stay inside the tempdir parent.
- [ ] E2E sanity check against a real file-download endpoint.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>