### PR TITLE
fix(client): don't KeyError when a proxy is configured

### DIFF
--- a/openapi/templates/rest.mustache
+++ b/openapi/templates/rest.mustache
@@ -266,11 +266,13 @@ class RESTClientObject:
         if self.configuration.proxy:
             client_kwargs["proxy"] = self.configuration.proxy
 
-            existing_headers = client_kwargs.pop("headers")
             if self.configuration.proxy_headers:
-                for key, value in self.configuration.proxy_headers.items():
-                    existing_headers[key] = value
-            client_kwargs["headers"] = existing_headers
+                # httpx doesn't have a dedicated `proxy_headers` kwarg the way
+                # urllib3 does — merging them into the default request headers
+                # is the closest equivalent.
+                existing_headers = dict(client_kwargs.get("headers") or {})
+                existing_headers.update(self.configuration.proxy_headers)
+                client_kwargs["headers"] = existing_headers
 
         if self.configuration.retries is not None:
             transport = httpx.HTTPTransport(retries=self.configuration.retries, limits=limits)

--- a/src/rapidata/api_client/rest.py
+++ b/src/rapidata/api_client/rest.py
@@ -276,11 +276,13 @@ class RESTClientObject:
         if self.configuration.proxy:
             client_kwargs["proxy"] = self.configuration.proxy
 
-            existing_headers = client_kwargs.pop("headers")
             if self.configuration.proxy_headers:
-                for key, value in self.configuration.proxy_headers.items():
-                    existing_headers[key] = value
-            client_kwargs["headers"] = existing_headers
+                # httpx doesn't have a dedicated `proxy_headers` kwarg the way
+                # urllib3 does — merging them into the default request headers
+                # is the closest equivalent.
+                existing_headers = dict(client_kwargs.get("headers") or {})
+                existing_headers.update(self.configuration.proxy_headers)
+                client_kwargs["headers"] = existing_headers
 
         if self.configuration.retries is not None:
             transport = httpx.HTTPTransport(retries=self.configuration.retries, limits=limits)


### PR DESCRIPTION
## Summary

Any user behind a corporate proxy is hard-bricked on the first SDK call.

\`\`\`python
client_kwargs = {\"verify\": ..., \"limits\": limits}   # no \"headers\"

if self.configuration.proxy:
    client_kwargs[\"proxy\"] = self.configuration.proxy
    existing_headers = client_kwargs.pop(\"headers\")   # KeyError: 'headers'
\`\`\`

`client_kwargs` is built literally above without a `\"headers\"` key, so the `pop` always raises.

## Fix

- Use `client_kwargs.get(\"headers\") or {}` as the base.
- Only write the merged dict back when there are `proxy_headers` to merge.
- `httpx` doesn't have a dedicated `proxy_headers` kwarg (that's a urllib3 API), so folding into default request headers is the closest equivalent — kept as a comment.
- Mirrored into `openapi/templates/rest.mustache` so regen preserves the fix.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Manual trace through both branches: proxy without headers, proxy with headers, no proxy.
- [ ] Live verification via `HTTPS_PROXY=http://…` run (don't have a proxy handy in this env).

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>