### PR TITLE
fix(client): raise on SSL verify failure instead of calling exit()

### DIFF
--- a/openapi/templates/rest.mustache
+++ b/openapi/templates/rest.mustache
@@ -68,9 +68,12 @@ class RESTClientObject:
             self.session.fetch_token()
         except ConnectError as e:
             if self._is_certificate_validation_error(e):
-                exit(self._get_ssl_verify_error_message())
-            else:
-                raise
+                raise ApiException(
+                    status=0,
+                    reason="SSL Certificate Verification Failed\n"
+                    + self._get_ssl_verify_error_message(),
+                ) from e
+            raise
 
     def setup_oauth_with_token(
         self,

--- a/src/rapidata/api_client/rest.py
+++ b/src/rapidata/api_client/rest.py
@@ -78,9 +78,12 @@ class RESTClientObject:
             self.session.fetch_token()
         except ConnectError as e:
             if self._is_certificate_validation_error(e):
-                exit(self._get_ssl_verify_error_message())
-            else:
-                raise
+                raise ApiException(
+                    status=0,
+                    reason="SSL Certificate Verification Failed\n"
+                    + self._get_ssl_verify_error_message(),
+                ) from e
+            raise
 
     def setup_oauth_with_token(
         self,


### PR DESCRIPTION
## Summary

`RESTClientObject.setup_oauth_client_credentials` calls \`exit(self._get_ssl_verify_error_message())\` when it sees an SSL certificate validation error. A library **should not** `exit()` — it kills the host process with no chance for the application to catch, log, clean up, or fall back.

The sibling path in `_handle_http_error` already does the right thing (raises `ApiException` with the same message). Just make the two branches consistent.

## Fix

- Raise `ApiException` with the `SSL Certificate Verification Failed` preamble + the help text.
- Chain via `from e` so the original `ConnectError` stays in the traceback.
- Drop `exit()`.
- Mirrored into `openapi/templates/rest.mustache`.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Error path is already handled downstream — the higher-level code in `openapi_service.py` lets exceptions propagate today.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>