### PR TITLE
fix(client): make admin role check exact, not substring

### DIFF
--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -183,7 +183,20 @@ class RapidataClient:
                 if client_id and email:
                     tracer.set_user_info(client_id=client_id, email=email)
 
-                if "Admin" not in result.get("role", []):
+                # OIDC userinfo returns `role` as a list when there are
+                # multiple, or a bare string when there is exactly one.
+                # A substring check like `"Admin" in result.get("role", [])`
+                # matches `"Administrator"`, `"SuperAdmin"`, etc., so do an
+                # explicit equality check against a normalized list.
+                roles_raw = result.get("role", [])
+                if isinstance(roles_raw, str):
+                    roles = [roles_raw]
+                elif isinstance(roles_raw, list):
+                    roles = roles_raw
+                else:
+                    roles = []
+
+                if "Admin" not in roles:
                     logger.debug("User is not an admin, not enabling beta features")
                     return
 


### PR DESCRIPTION
## Summary

\`\`\`python
if \"Admin\" not in result.get(\"role\", []):
    return
rapidata_config.enableBetaFeatures = True
\`\`\`

OIDC userinfo returns `role` as a list when there are several roles and as a bare string when there's one. If the server returns a string like `\"Administrator\"`, `\"SuperAdmin\"`, or `\"AdminReadOnly\"`, `\"Admin\" in <string>` is True via substring match, and the non-admin user gets the beta flag.

Impact is scoped to the `enableBetaFeatures` flag, not privilege escalation against the backend, but the check is still wrong.

## Fix

Normalize `role` into a list up-front, then do `\"Admin\" in roles` as an exact equality check.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Walked through the four shapes: `\"Admin\"`, `\"Administrator\"`, `[\"Admin\", \"User\"]`, missing.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>