### PR TITLE
fix(datapoints): allow shared group ids across datapoints

### DIFF
--- a/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
@@ -30,11 +30,14 @@ class DatapointsValidator:
             raise ValueError(
                 "Number of private metadata entries must match number of datapoints"
             )
-        if groups and (
-            len(groups) != len(datapoints) or len(groups) != len(set(groups))
-        ):
+        # `groups` lets multiple datapoints share a group id — that's the
+        # whole point (see `_rapidata_dataset._create_dataset_groups`, which
+        # collects the unique group ids from the datapoints). We only need
+        # to check the list length matches the datapoints list; a uniqueness
+        # check would reject legitimate grouped input.
+        if groups and len(groups) != len(datapoints):
             raise ValueError(
-                "Number of groups must match number of datapoints and must be unique."
+                "Number of groups must match number of datapoints."
             )
 
     @staticmethod


### PR DESCRIPTION
## Summary

`DatapointsValidator.validate_datapoints` requires the `groups` list to contain unique values:

\`\`\`python
if groups and (
    len(groups) != len(datapoints) or len(groups) != len(set(groups))
):
    raise ValueError(\"...must be unique.\")
\`\`\`

But the group id is literally meant to be shared across multiple datapoints — `_rapidata_dataset._create_dataset_groups` collects the *unique* group ids from the datapoints and creates one dataset-group API record per id, with all member datapoints sharing it. Uniqueness defeats the feature.

Latent today because no current caller exposes `groups=`, but the next one does a false `ValueError`.

## Fix

Keep the length-matches-datapoints check, drop the uniqueness clause, update the message.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] `_create_dataset_groups` reads `groups` via `dict` dedup — still correct with shared ids.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>