### PR TITLE
fix(datapoints): detect asset type case-insensitively and handle URL query strings

### DIFF
--- a/src/rapidata/rapidata_client/datapoints/_datapoint.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint.py
@@ -60,16 +60,24 @@ class Datapoint(BaseModel):
 
     def get_asset_type(self) -> AssetType:
         from rapidata.api_client.models.asset_type import AssetType
+        from urllib.parse import urlparse
 
         if self.data_type == "text":
             return AssetType.TEXT
 
         evaluation_asset = self.asset[0] if isinstance(self.asset, list) else self.asset
-        if any(evaluation_asset.endswith(ext) for ext in ALLOWED_IMAGE_EXTENSIONS):
+
+        # Compare extensions case-insensitively and ignore URL query /
+        # fragment so `photo.JPG` and `https://x/image.png?v=2` are both
+        # recognised correctly.
+        parsed_path = urlparse(evaluation_asset).path or evaluation_asset
+        lower = parsed_path.lower()
+
+        if any(lower.endswith(ext) for ext in ALLOWED_IMAGE_EXTENSIONS):
             return AssetType.IMAGE
-        elif any(evaluation_asset.endswith(ext) for ext in ALLOWED_VIDEO_EXTENSIONS):
+        elif any(lower.endswith(ext) for ext in ALLOWED_VIDEO_EXTENSIONS):
             return AssetType.VIDEO
-        elif any(evaluation_asset.endswith(ext) for ext in ALLOWED_AUDIO_EXTENSIONS):
+        elif any(lower.endswith(ext) for ext in ALLOWED_AUDIO_EXTENSIONS):
             return AssetType.AUDIO
         else:
             logger.debug(


### PR DESCRIPTION
## Summary

`Datapoint.get_asset_type` compares the asset string with `endswith(\".jpg\")` etc. Consequences:

- `photo.JPG`, `clip.MP4` → `AssetType.NONE` (uppercase ext).
- `https://cdn.example.com/image.png?v=2` → `AssetType.NONE` (query string).
- `https://cdn.example.com/image.jpg#fragment` → `AssetType.NONE` (fragment).

## Fix

`urlparse(asset).path.lower()` before the `endswith` checks. Local paths still work because `urlparse` leaves them alone.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Verified `photo.JPG`, `photo.jpg`, `https://.../a.PNG`, `...png?v=2`, `clip.MP4`, `audio.MP3`, `...jpg#f`, `random.txt` all return the expected enum.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>