### PR TITLE
fix(upload): detect URL assets case-insensitively

### DIFF
--- a/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
@@ -113,6 +113,9 @@ class AssetUploadOrchestrator:
         self._log_upload_results(failed_uploads)
         return failed_uploads
 
+    # Keep the URL scheme check case-insensitive to match AssetUploader.
+    _URL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
+
     def _separate_urls_and_files(self, assets: set[str]) -> tuple[set[str], set[str]]:
         """
         Separate assets into URLs and file paths.
@@ -123,8 +126,8 @@ class AssetUploadOrchestrator:
         Returns:
             Tuple of (urls, files).
         """
-        urls = {a for a in assets if re.match(r"^https?://", a)}
-        files = {a for a in assets if not re.match(r"^https?://", a)}
+        urls = {a for a in assets if self._URL_SCHEME_RE.match(a)}
+        files = {a for a in assets if not self._URL_SCHEME_RE.match(a)}
         logger.debug(f"Asset breakdown: {len(urls)} URL(s), {len(files)} file(s)")
         return urls, files
 
@@ -257,7 +260,7 @@ class AssetUploadOrchestrator:
         for asset in assets:
             try:
                 # Try to get cache key using centralized methods
-                if re.match(r"^https?://", asset):
+                if self._URL_SCHEME_RE.match(asset):
                     cache_key = self.asset_uploader.get_url_cache_key(asset)
                 else:
                     cache_key = self.asset_uploader.get_file_cache_key(asset)

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -114,11 +114,15 @@ class AssetUploader:
             self.get_file_cache_key(file_path), upload_file
         )
 
+    # Accept http / https / HTTP / HTTPS / mixed case — people type URLs
+    # by hand or copy them from docs with varying capitalisation.
+    _URL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
+
     def upload_asset(self, asset: str) -> str:
         logger.debug("Uploading asset: %s", asset)
         assert isinstance(asset, str), "Asset must be a string"
 
-        if re.match(r"^https?://", asset):
+        if self._URL_SCHEME_RE.match(asset):
             return self._upload_url_asset(asset)
 
         return self._upload_file_asset(asset)


### PR DESCRIPTION
## Summary

Three sites classified URL vs. local file via \`re.match(r\"^https?://\", asset)\` — case-sensitive:

- `AssetUploader.upload_asset` (`_asset_uploader.py`)
- `AssetUploadOrchestrator._separate_urls_and_files` / `_filter_uncached` (`_asset_upload_orchestrator.py`)

An asset like `\"HTTPS://cdn.example.com/image.png\"` was treated as a local filesystem path and then blew up with `FileNotFoundError` inside `get_file_cache_key`.

## Fix

Pre-compiled `re.compile(r\"^https?://\", re.IGNORECASE)` per class; reuse at every match site.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Manually confirmed `http://`, `https://`, `HTTPS://`, `HtTp://`, `file.txt`, `/abs/path.png` all classify correctly.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>