### PR TITLE
fix(client): replace asserts with real runtime checks

### DIFF
--- a/openapi/templates/api_client.mustache
+++ b/openapi/templates/api_client.mustache
@@ -301,8 +301,10 @@ class ApiClient:
         :return: ApiResponse
         """
 
-        msg = "RESTResponse.read() must be called before passing it to response_deserialize()"
-        assert response_data.data is not None, msg
+        if response_data.data is None:
+            raise ApiValueError(
+                "RESTResponse.read() must be called before passing it to response_deserialize()"
+            )
 
         response_type = response_types_map.get(str(response_data.status), None)
         if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
@@ -441,14 +443,20 @@ class ApiClient:
         if isinstance(klass, str):
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
-                assert m is not None, "Malformed List type definition"
+                if m is None:
+                    raise ApiValueError(
+                        f"Malformed List type definition: {klass!r}"
+                    )
                 sub_kls = m.group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('Dict['):
                 m = re.match(r'Dict\[([^,]*), (.*)]', klass)
-                assert m is not None, "Malformed Dict type definition"
+                if m is None:
+                    raise ApiValueError(
+                        f"Malformed Dict type definition: {klass!r}"
+                    )
                 sub_kls = m.group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in data.items()}

--- a/src/rapidata/api_client/api_client.py
+++ b/src/rapidata/api_client/api_client.py
@@ -293,8 +293,10 @@ class ApiClient:
         :return: ApiResponse
         """
 
-        msg = "RESTResponse.read() must be called before passing it to response_deserialize()"
-        assert response_data.data is not None, msg
+        if response_data.data is None:
+            raise ApiValueError(
+                "RESTResponse.read() must be called before passing it to response_deserialize()"
+            )
 
         response_type = response_types_map.get(str(response_data.status), None)
         if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
@@ -433,14 +435,20 @@ class ApiClient:
         if isinstance(klass, str):
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
-                assert m is not None, "Malformed List type definition"
+                if m is None:
+                    raise ApiValueError(
+                        f"Malformed List type definition: {klass!r}"
+                    )
                 sub_kls = m.group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('Dict['):
                 m = re.match(r'Dict\[([^,]*), (.*)]', klass)
-                assert m is not None, "Malformed Dict type definition"
+                if m is None:
+                    raise ApiValueError(
+                        f"Malformed Dict type definition: {klass!r}"
+                    )
                 sub_kls = m.group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in data.items()}

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -116,7 +116,10 @@ class AssetUploader:
 
     def upload_asset(self, asset: str) -> str:
         logger.debug("Uploading asset: %s", asset)
-        assert isinstance(asset, str), "Asset must be a string"
+        if not isinstance(asset, str):
+            raise TypeError(
+                f"Asset must be a string, got {type(asset).__name__}"
+            )
 
         if re.match(r"^https?://", asset):
             return self._upload_url_asset(asset)


### PR DESCRIPTION
## Summary

Four `assert` statements live on user-reachable paths:

- `api_client.py:297` — `assert response_data.data is not None`
- `api_client.py:438` / `:445` — `assert m is not None` when parsing `List[…]` / `Dict[…]` type names
- `_asset_uploader.py:119` — `assert isinstance(asset, str)`

Under `python -O` (`PYTHONOPTIMIZE=1`) every `assert` is stripped at compile time. When those assertions would have fired, the next line raises a generic `AttributeError` / `TypeError` with a confusing traceback instead of the helpful message we intended.

## Fix

Swap each one for an explicit raise:

- `ApiValueError` for the api_client paths (keeps the existing exception family consistent).
- `TypeError` for the uploader argument check.
- Include the offending value (`klass!r`, `type(asset).__name__`) in the message.
- Mirrored into `openapi/templates/api_client.mustache`.

The Content-Disposition assert was already handled by #553, so it's skipped here.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Re-checked every remaining `assert` in `src/rapidata/rapidata_client` — the others guard true invariants (post-condition checks inside lazy initializers / typing helpers), not user input.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>