### PR TITLE
fix(client): url-encode query parameter names

### DIFF
--- a/openapi/templates/api_client.mustache
+++ b/openapi/templates/api_client.mustache
@@ -522,10 +522,13 @@ class ApiClient:
             if isinstance(v, dict):
                 v = json.dumps(v)
 
+            encoded_key = quote(str(k))
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, str(value)) for value in v)
+                    new_params.extend(
+                        (encoded_key, quote(str(value))) for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -536,10 +539,10 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (encoded_key, delimiter.join(quote(str(value)) for value in v))
                     )
             else:
-                new_params.append((k, quote(str(v))))
+                new_params.append((encoded_key, quote(str(v))))
 
         return "&".join(["=".join(map(str, item)) for item in new_params])
 

--- a/src/rapidata/api_client/api_client.py
+++ b/src/rapidata/api_client/api_client.py
@@ -514,10 +514,13 @@ class ApiClient:
             if isinstance(v, dict):
                 v = json.dumps(v)
 
+            encoded_key = quote(str(k))
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, str(value)) for value in v)
+                    new_params.extend(
+                        (encoded_key, quote(str(value))) for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -528,10 +531,10 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (encoded_key, delimiter.join(quote(str(value)) for value in v))
                     )
             else:
-                new_params.append((k, quote(str(v))))
+                new_params.append((encoded_key, quote(str(v))))
 
         return "&".join(["=".join(map(str, item)) for item in new_params])
 


### PR DESCRIPTION
## Summary

`ApiClient.parameters_to_url_query` url-encoded every *value* but not the *key*:

\`\`\`python
new_params.extend((k, str(value)) for value in v)         # multi branch, key raw
new_params.append((k, delimiter.join(quote(str(value)) for value in v)))  # key raw
new_params.append((k, quote(str(v))))                      # key raw
\`\`\`

A key containing `&`, `=`, `#`, space, or UTF-8 bytes would break the query string — the `&` terminates the pair early, `=` merges into the value, `#` truncates at the fragment, etc.

## Fix

Compute `encoded_key = quote(str(k))` once per iteration and use it at every append site.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] The `multi` branch now also encodes its per-item value (it wasn't before — only the key fix needs it, but the symmetry is cheap and intentional).

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>