### PR TITLE
fix(order): break progress bar out of loop on terminal order states

### DIFF
--- a/src/rapidata/rapidata_client/order/rapidata_order.py
+++ b/src/rapidata/rapidata_client/order/rapidata_order.py
@@ -330,6 +330,16 @@ class RapidataOrder:
                 f"Once started, run this method again to display the progress bar."
             )
 
+        # Terminal states that should break the progress-bar loop
+        # regardless of completion_percentage. Without this check a
+        # Failed or Paused order would pin the caller's thread forever.
+        terminal_states = {
+            OrderState.COMPLETED,
+            OrderState.PAUSED,
+            OrderState.FAILED,
+            OrderState.MANUALREVIEW,
+        }
+
         with tqdm(
             total=100,
             desc="Processing order",
@@ -348,6 +358,14 @@ class RapidataOrder:
                     last_percentage = current_percentage
 
                 if current_percentage >= 100:
+                    break
+
+                current_state = self.get_status()
+                if current_state in terminal_states:
+                    logger.info(
+                        "Progress bar exiting early: order is in state %s",
+                        current_state,
+                    )
                     break
 
                 sleep(refresh_rate)


### PR DESCRIPTION
## Summary

`RapidataOrder.display_progress_bar` polls `completion_percentage` and only exits when it reaches 100. If the order transitions to `Failed`, `Paused`, or `ManualReview` while the bar is running, the percentage stays under 100 and the loop holds the caller's thread forever.

## Fix

After each tick, re-check `get_status()`. If the order is in any terminal state (`COMPLETED`, `PAUSED`, `FAILED`, `MANUALREVIEW`), log and break. Completion path is unchanged.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Logic walkthrough: happy path hits `>= 100` before the terminal check; stalled order hits terminal check after one refresh_rate tick; completed order still exits via the `>= 100` branch.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>