### PR TITLE
fix(auth): handle malformed bridge-token responses gracefully

### DIFF
--- a/src/rapidata/service/credential_manager.py
+++ b/src/rapidata/service/credential_manager.py
@@ -135,19 +135,32 @@ class CredentialManager:
     def _get_bridge_tokens(self) -> Optional[BridgeToken]:
         """Get bridge tokens from the identity endpoint."""
         logger.debug("Getting bridge tokens")
+        bridge_endpoint = (
+            f"{self.endpoint}/identity/bridge-token?clientId=rapidata-cli"
+        )
         try:
-            bridge_endpoint = (
-                f"{self.endpoint}/identity/bridge-token?clientId=rapidata-cli"
-            )
             response = requests.post(bridge_endpoint, verify=self.cert_path)
             if not response.ok:
                 logger.error("Failed to get bridge tokens: %s", response.status_code)
                 return None
 
             data = response.json()
-            return BridgeToken(read_key=data["readKey"], write_key=data["writeKey"])
         except requests.RequestException as e:
             logger.error("Failed to get bridge tokens: %s", e)
+            return None
+        except ValueError as e:
+            # `response.json()` raises ValueError on malformed bodies.
+            logger.error("Bridge token response was not valid JSON: %s", e)
+            return None
+
+        try:
+            return BridgeToken(read_key=data["readKey"], write_key=data["writeKey"])
+        except (KeyError, TypeError) as e:
+            logger.error(
+                "Bridge token response missing expected keys (got: %s): %s",
+                list(data.keys()) if isinstance(data, dict) else type(data).__name__,
+                e,
+            )
             return None
 
     def _poll_read_key(self, read_key: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

\`\`\`python
data = response.json()
return BridgeToken(read_key=data[\"readKey\"], write_key=data[\"writeKey\"])
\`\`\`

`_get_bridge_tokens` only caught `requests.RequestException`. A 200 response with:
- a non-JSON body → `ValueError` (from `response.json()`)
- JSON missing `readKey` / `writeKey` → `KeyError`
- JSON where `data` is a list or `None` → `TypeError`

…all bubbled up as raw tracebacks out of the first call the user makes.

## Fix

Catch `ValueError` on the JSON parse and `KeyError` / `TypeError` on the model construction. Log a diagnostic that includes the keys the server did return, and fall through to `return None` — which the caller already treats as \"no bridge token\" and reports with a readable message.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Walked the three failure modes: non-JSON, missing key, list-as-data.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>