### PR TITLE
fix(upload): collapse file-cache-key stat into a single syscall

### DIFF
--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -65,10 +65,14 @@ class AssetUploader:
     def get_file_cache_key(self, asset: str) -> str:
         """Generate cache key for a file, including environment."""
         env = self.openapi_service.environment
-        if not os.path.exists(asset):
-            raise FileNotFoundError(f"File not found: {asset}")
-
-        stat = os.stat(asset)
+        # Single `os.stat` call — guards against the TOCTOU window
+        # between an existence check and the stat, and produces a
+        # clearer error whether the file is missing, is a directory,
+        # or the caller lacks permission.
+        try:
+            stat = os.stat(asset)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"File not found: {asset}") from None
         return f"{env}@{asset}:{stat.st_size}:{stat.st_mtime_ns}"
 
     def get_url_cache_key(self, url: str) -> str:

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -65,10 +65,6 @@ class AssetUploader:
     def get_file_cache_key(self, asset: str) -> str:
         """Generate cache key for a file, including environment."""
         env = self.openapi_service.environment
-        # Single `os.stat` call — guards against the TOCTOU window
-        # between an existence check and the stat, and produces a
-        # clearer error whether the file is missing, is a directory,
-        # or the caller lacks permission.
         try:
             stat = os.stat(asset)
         except FileNotFoundError:


### PR DESCRIPTION
## Summary

\`\`\`python
if not os.path.exists(asset):
    raise FileNotFoundError(f\"File not found: {asset}\")

stat = os.stat(asset)
\`\`\`

Two sequential syscalls. If the file is unlinked between `exists()` and `stat()` (TOCTOU), the `stat()` raises a less-useful `FileNotFoundError` with its default message and the traceback looks like the bug is in the SDK rather than a concurrent operation.

## Fix

Single `os.stat()` inside a try/except. Re-raise with the original \"File not found: …\" message and `from None` so the internal syscall error doesn't appear in the traceback chain.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` → 0 errors
- [x] Verified: missing file → `FileNotFoundError: File not found: {path}`; existing file → stat values end up in the cache key as before.

🔗 Session: <https://session-bc38cc85.poseidon.rapidata.internal/>