### PR TITLE
fix(validation): use LocateBoxTruth for Draw rapid and attach all boxes

### DIFF
--- a/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
@@ -296,6 +296,8 @@ class RapidsManager:
         Args:
             instruction (str): The instructions on what the labeler
             truths (list[Box]): The bounding boxes of the object that the labeler ought to be drawing.
+                All boxes are attached as the ground truth — labelers are graded on whether
+                their drawn lines fall within any of these boxes.
             datapoint (str): The asset that the labeler will be drawing the object in.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
             media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
@@ -308,10 +310,13 @@ class RapidsManager:
         from rapidata.api_client.models.i_validation_truth_model import (
             IValidationTruthModel,
         )
-        from rapidata.api_client.models.i_validation_truth_model_bounding_box_truth_model import (
-            IValidationTruthModelBoundingBoxTruthModel,
+        from rapidata.api_client.models.i_validation_truth_model_locate_box_truth_model import (
+            IValidationTruthModelLocateBoxTruthModel,
         )
         from rapidata.rapidata_client.validation.rapids.rapids import Rapid
+
+        if not truths:
+            raise ValueError("Draw rapid requires at least one truth bounding box")
 
         payload = IRapidPayload(
             actual_instance=IRapidPayloadLinePayload(
@@ -320,12 +325,9 @@ class RapidsManager:
         )
 
         model_truth = IValidationTruthModel(
-            actual_instance=IValidationTruthModelBoundingBoxTruthModel(
-                _t="BoundingBoxTruth",
-                xMax=truths[0].x_max * 100,
-                xMin=truths[0].x_min * 100,
-                yMax=truths[0].y_max * 100,
-                yMin=truths[0].y_min * 100,
+            actual_instance=IValidationTruthModelLocateBoxTruthModel(
+                _t="LocateBoxTruth",
+                boundingBoxes=[truth.to_model() for truth in truths],
             )
         )
 


### PR DESCRIPTION
## Summary

- The `draw_rapid` builder was using `BoundingBoxTruth` (the legacy single-box truth) and silently discarded every truth except `truths[0]`, so multi-box ground truths were never sent to the backend.
- Switched to `LocateBoxTruth`, which is what `LinesToLocateBoxesProfessor` (the backend grader for `LineResult`) is actually keyed on, and it now sends every box in `truths`.
- Added an explicit empty-list check so callers get a clear error instead of an `IndexError` from the old `truths[0]` access.

## Why this is the right truth

`LineTruth` itself is an empty marker on the backend (`LineProfessor` always returns `true`), and the validator router has no `(LinePayload, LineTruth)` pair — so a `LineTruth` attached to a Draw rapid is effectively a no-op. The real grading happens via `LinesToLocateBoxesProfessor : IProfessor<LocateBoxTruth, LineResult>`, which iterates `truth.BoundingBoxes` and checks every drawn point against them. Pairing the `LinePayload` with `LocateBoxTruth` (as `locate_rapid` already does) is what unlocks proper multi-box grading.

## Test plan

- [x] `pyright src/rapidata/rapidata_client` — 0 errors / 0 warnings
- [x] Constructed a Draw rapid with two boxes and verified the serialized truth contains a `LocateBoxTruth` with both boxes scaled to the 0–100 range:
  ```json
  {"_t": "LocateBoxTruth", "boundingBoxes": [
      {"xMin": 10.0, "yMin": 10.0, "xMax": 30.0, "yMax": 30.0},
      {"xMin": 50.0, "yMin": 50.0, "xMax": 70.0, "yMax": 70.0}
  ]}
  ```
- [x] Empty `truths` raises `ValueError("Draw rapid requires at least one truth bounding box")`.
- [ ] Smoke test against staging by creating a draw validation set with multiple ground-truth boxes per datapoint and confirming labelers get graded against all of them.

🔗 Session: [d484ec56](https://session-d484ec56.poseidon.rapidata.internal/)