### PR TITLE
feat(audience): add locate / line / transcription qualification examples

### DIFF
--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -77,6 +77,42 @@ for prompt, datapoint in zip(PROMPTS, DATAPOINTS):
 !!! note
     In practice you'd want to add more examples to the audience to improve the quality of the results.
 
+`add_compare_example` is one of several qualification helpers; pick the one that matches the task the audience will receive:
+
+| Method | Task |
+|---|---|
+| `add_compare_example` | Pick the better of two media items. |
+| `add_classification_example` | Choose the correct label(s) from a list. |
+| `add_locate_example` | Click inside the correct region(s) on an image. |
+| `add_line_example` | Draw a line through a region of an image. |
+| `add_transcription_example` | Pick the correct words out of a transcription of an audio. |
+
+```py
+from rapidata import Box
+
+# Locate — click inside any of the boxes
+audience.add_locate_example(
+    instruction="Click the dog's face",
+    truth=[Box(x_min=0.3, y_min=0.2, x_max=0.55, y_max=0.45)],
+    datapoint="https://assets.rapidata.ai/dog.jpg",
+)
+
+# Line — draw a line through any of the boxes (truth is optional)
+audience.add_line_example(
+    instruction="Trace the horizon line",
+    datapoint="https://assets.rapidata.ai/landscape.jpg",
+    truth=[Box(x_min=0.0, y_min=0.45, x_max=1.0, y_max=0.55)],
+)
+
+# Transcription — pick the correct words from the spoken sentence
+audience.add_transcription_example(
+    instruction="Select the words actually spoken",
+    sentence="the quick brown fox jumps over the lazy dog",
+    truth=[1, 2, 3],  # indices of "quick", "brown", "fox"
+    datapoint="https://assets.rapidata.ai/fox.mp3",
+)
+```
+
 ### Step 3: Create and Assign a Job
 
 Once your audience is set up, create a job definition and assign it to the audience:
@@ -188,8 +224,8 @@ audience.add_classification_example(
 1. Applies the setting as a feature flag on this single example. Use the same
    `RapidataSetting` subclasses you would pass to `settings=` on a job or
    order (e.g. `NoShuffleSetting`, `MarkdownSetting`,
-   `AllowNeitherBothSetting`, `ComparePanoramaSetting`). Both
-   `add_classification_example` and `add_compare_example` accept `settings`.
+   `AllowNeitherBothSetting`, `ComparePanoramaSetting`). All
+   `add_*_example` methods on `Audience` accept `settings`.
 
 ## Reusing Audiences
 

--- a/openapi/schemas/audience.openapi.json
+++ b/openapi/schemas/audience.openapi.json
@@ -3125,6 +3125,21 @@
               "LineExampleTruth"
             ],
             "type": "string"
+          },
+          "boundingBoxes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExampleBoxShape"
+            },
+            "nullable": true
+          },
+          "requiredPrecision": {
+            "type": "number",
+            "format": "double"
+          },
+          "requiredCompleteness": {
+            "type": "number",
+            "format": "double"
           }
         }
       },

--- a/openapi/schemas/rapid.openapi.json
+++ b/openapi/schemas/rapid.openapi.json
@@ -1361,7 +1361,7 @@
           "result": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidResult"
+                "$ref": "#/components/schemas/IRapidResultModel"
               }
             ],
             "description": "The result submitted by the user."
@@ -1382,7 +1382,7 @@
           "validationTruth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The validation truth applied to the response, if any."
@@ -1402,7 +1402,7 @@
           }
         }
       },
-      "BoxShape": {
+      "BoundingBoxResultModel_Box": {
         "type": "object",
         "properties": {
           "xMin": {
@@ -1423,7 +1423,7 @@
           }
         }
       },
-      "ClassifyPayload": {
+      "ClassifyPayloadModel": {
         "required": [
           "categories",
           "title"
@@ -1433,7 +1433,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyPayloadModel_Category"
             }
           },
           "title": {
@@ -1441,10 +1441,9 @@
           }
         }
       },
-      "ClassifyPayload_Category": {
+      "ClassifyPayloadModel_Category": {
         "required": [
-          "label",
-          "value"
+          "label"
         ],
         "type": "object",
         "properties": {
@@ -1452,7 +1451,8 @@
             "type": "string"
           },
           "value": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -1470,7 +1470,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ClassifyPayload"
+                "$ref": "#/components/schemas/ClassifyPayloadModel"
               }
             ],
             "description": "The payload for the classification."
@@ -1568,7 +1568,7 @@
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/GetGlobalResponsesEndpoint_Response"
+                  "$ref": "#/components/schemas/GetGlobalResponsesEndpoint_Output_Response"
                 }
               }
             ],
@@ -1576,7 +1576,7 @@
           }
         }
       },
-      "GetGlobalResponsesEndpoint_Response": {
+      "GetGlobalResponsesEndpoint_Output_Response": {
         "required": [
           "id",
           "userId",
@@ -1633,7 +1633,7 @@
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/GetResponsesForRapidResult_Response"
+                  "$ref": "#/components/schemas/GetResponsesForRapidEndpoint_Output_Response"
                 }
               }
             ],
@@ -1642,14 +1642,14 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
           }
         }
       },
-      "GetResponsesForRapidResult_Response": {
+      "GetResponsesForRapidEndpoint_Output_Response": {
         "required": [
           "id",
           "userId",
@@ -1671,7 +1671,7 @@
             "type": "string"
           },
           "result": {
-            "$ref": "#/components/schemas/IRapidResult"
+            "$ref": "#/components/schemas/IRapidResultModel"
           },
           "userScore": {
             "type": "number",
@@ -2234,60 +2234,60 @@
           }
         }
       },
-      "IRapidPayload": {
+      "IRapidPayloadModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelComparePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLinePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLocatePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadClassifyPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelScrubPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload",
-            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
-            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
-            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
-            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
-            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
-            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
-            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
-            "ClassifyPayload": "#/components/schemas/IRapidPayloadClassifyPayload",
-            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel",
+            "ClassifyPayload": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel",
+            "ComparePayload": "#/components/schemas/IRapidPayloadModelComparePayloadModel",
+            "FreeTextPayload": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel",
+            "LinePayload": "#/components/schemas/IRapidPayloadModelLinePayloadModel",
+            "LocatePayload": "#/components/schemas/IRapidPayloadModelLocatePayloadModel",
+            "NamedEntityPayload": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel",
+            "PolygonPayload": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel",
+            "ScrubPayload": "#/components/schemas/IRapidPayloadModelScrubPayloadModel",
+            "TranscriptionPayload": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         }
       },
-      "IRapidPayloadBoundingBoxPayload": {
+      "IRapidPayloadModelBoundingBoxPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2304,7 +2304,7 @@
           }
         }
       },
-      "IRapidPayloadClassifyPayload": {
+      "IRapidPayloadModelClassifyPayloadModel": {
         "required": [
           "categories",
           "title",
@@ -2320,7 +2320,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyPayloadModel_Category"
             }
           },
           "title": {
@@ -2328,7 +2328,7 @@
           }
         }
       },
-      "IRapidPayloadComparePayload": {
+      "IRapidPayloadModelComparePayloadModel": {
         "required": [
           "criteria",
           "_t"
@@ -2345,7 +2345,7 @@
           }
         }
       },
-      "IRapidPayloadFreeTextPayload": {
+      "IRapidPayloadModelFreeTextPayloadModel": {
         "required": [
           "question",
           "_t"
@@ -2369,7 +2369,7 @@
           }
         }
       },
-      "IRapidPayloadLinePayload": {
+      "IRapidPayloadModelLinePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2386,7 +2386,7 @@
           }
         }
       },
-      "IRapidPayloadLocatePayload": {
+      "IRapidPayloadModelLocatePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2403,7 +2403,7 @@
           }
         }
       },
-      "IRapidPayloadNamedEntityPayload": {
+      "IRapidPayloadModelNamedEntityPayloadModel": {
         "required": [
           "target",
           "classes",
@@ -2427,7 +2427,7 @@
           }
         }
       },
-      "IRapidPayloadPolygonPayload": {
+      "IRapidPayloadModelPolygonPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2444,7 +2444,7 @@
           }
         }
       },
-      "IRapidPayloadScrubPayload": {
+      "IRapidPayloadModelScrubPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2461,7 +2461,7 @@
           }
         }
       },
-      "IRapidPayloadTranscriptionPayload": {
+      "IRapidPayloadModelTranscriptionPayloadModel": {
         "required": [
           "title",
           "transcription",
@@ -2480,72 +2480,72 @@
           "transcription": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionPayloadModel_TranscriptionWord"
             }
           }
         }
       },
-      "IRapidResult": {
+      "IRapidResultModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidResultTranscriptionResult"
+            "$ref": "#/components/schemas/IRapidResultModelAttachCategoryResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultScrubResult"
+            "$ref": "#/components/schemas/IRapidResultModelBoundingBoxResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultPolygonResult"
+            "$ref": "#/components/schemas/IRapidResultModelCompareResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultNamedEntityResult"
+            "$ref": "#/components/schemas/IRapidResultModelFreeTextResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultLocateResult"
+            "$ref": "#/components/schemas/IRapidResultModelLineResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultLineResult"
+            "$ref": "#/components/schemas/IRapidResultModelLocateResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultFreeTextResult"
+            "$ref": "#/components/schemas/IRapidResultModelNamedEntityResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultCompareResult"
+            "$ref": "#/components/schemas/IRapidResultModelPolygonResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultSkipResult"
+            "$ref": "#/components/schemas/IRapidResultModelScrubResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultAttachCategoryResult"
+            "$ref": "#/components/schemas/IRapidResultModelSkipResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "$ref": "#/components/schemas/IRapidResultModelTranscriptionResultModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionResult": "#/components/schemas/IRapidResultTranscriptionResult",
-            "ScrubResult": "#/components/schemas/IRapidResultScrubResult",
-            "PolygonResult": "#/components/schemas/IRapidResultPolygonResult",
-            "NamedEntityResult": "#/components/schemas/IRapidResultNamedEntityResult",
-            "LocateResult": "#/components/schemas/IRapidResultLocateResult",
-            "LineResult": "#/components/schemas/IRapidResultLineResult",
-            "FreeTextResult": "#/components/schemas/IRapidResultFreeTextResult",
-            "CompareResult": "#/components/schemas/IRapidResultCompareResult",
-            "SkipResult": "#/components/schemas/IRapidResultSkipResult",
-            "AttachCategoryResult": "#/components/schemas/IRapidResultAttachCategoryResult",
-            "BoundingBoxResult": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "AttachCategoryResult": "#/components/schemas/IRapidResultModelAttachCategoryResultModel",
+            "BoundingBoxResult": "#/components/schemas/IRapidResultModelBoundingBoxResultModel",
+            "CompareResult": "#/components/schemas/IRapidResultModelCompareResultModel",
+            "FreeTextResult": "#/components/schemas/IRapidResultModelFreeTextResultModel",
+            "LineResult": "#/components/schemas/IRapidResultModelLineResultModel",
+            "LocateResult": "#/components/schemas/IRapidResultModelLocateResultModel",
+            "NamedEntityResult": "#/components/schemas/IRapidResultModelNamedEntityResultModel",
+            "PolygonResult": "#/components/schemas/IRapidResultModelPolygonResultModel",
+            "ScrubResult": "#/components/schemas/IRapidResultModelScrubResultModel",
+            "SkipResult": "#/components/schemas/IRapidResultModelSkipResultModel",
+            "TranscriptionResult": "#/components/schemas/IRapidResultModelTranscriptionResultModel"
           }
         }
       },
-      "IRapidResultAttachCategoryResult": {
+      "IRapidResultModelAttachCategoryResultModel": {
         "required": [
-          "category",
           "rapidId",
+          "category",
           "_t"
         ],
         "properties": {
@@ -2555,18 +2555,18 @@
             ],
             "type": "string"
           },
-          "category": {
+          "rapidId": {
             "type": "string"
           },
-          "rapidId": {
+          "category": {
             "type": "string"
           }
         }
       },
-      "IRapidResultBoundingBoxResult": {
+      "IRapidResultModelBoundingBoxResultModel": {
         "required": [
-          "boundingBoxes",
           "rapidId",
+          "boundingBoxes",
           "_t"
         ],
         "properties": {
@@ -2576,18 +2576,18 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "boundingBoxes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BoxShape"
+              "$ref": "#/components/schemas/BoundingBoxResultModel_Box"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultCompareResult": {
+      "IRapidResultModelCompareResultModel": {
         "required": [
           "rapidId",
           "_t"
@@ -2599,21 +2599,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "winners": {
             "type": "array",
             "items": {
               "type": "string"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultFreeTextResult": {
+      "IRapidResultModelFreeTextResultModel": {
         "required": [
-          "answer",
           "rapidId",
+          "answer",
           "_t"
         ],
         "properties": {
@@ -2623,18 +2623,18 @@
             ],
             "type": "string"
           },
-          "answer": {
+          "rapidId": {
             "type": "string"
           },
-          "rapidId": {
+          "answer": {
             "type": "string"
           }
         }
       },
-      "IRapidResultLineResult": {
+      "IRapidResultModelLineResultModel": {
         "required": [
-          "lines",
           "rapidId",
+          "lines",
           "_t"
         ],
         "properties": {
@@ -2644,21 +2644,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "lines": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_Line"
+              "$ref": "#/components/schemas/LineResultModel_Line"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultLocateResult": {
+      "IRapidResultModelLocateResultModel": {
         "required": [
-          "coordinates",
           "rapidId",
+          "coordinates",
           "_t"
         ],
         "properties": {
@@ -2668,21 +2668,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LocateCoordinate"
+              "$ref": "#/components/schemas/LocateCoordinateModel"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultNamedEntityResult": {
+      "IRapidResultModelNamedEntityResultModel": {
         "required": [
-          "classifications",
           "rapidId",
+          "classifications",
           "_t"
         ],
         "properties": {
@@ -2692,21 +2692,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "classifications": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NamedClassification"
+              "$ref": "#/components/schemas/NamedEntityResultModel_NamedClassification"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultPolygonResult": {
+      "IRapidResultModelPolygonResultModel": {
         "required": [
-          "shapes",
           "rapidId",
+          "shapes",
           "_t"
         ],
         "properties": {
@@ -2716,21 +2716,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "shapes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Shape"
+              "$ref": "#/components/schemas/PolygonResultModel_Shape"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultScrubResult": {
+      "IRapidResultModelScrubResultModel": {
         "required": [
-          "timestamps",
           "rapidId",
+          "timestamps",
           "_t"
         ],
         "properties": {
@@ -2740,19 +2740,19 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "timestamps": {
             "type": "array",
             "items": {
               "type": "integer",
               "format": "int32"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultSkipResult": {
+      "IRapidResultModelSkipResultModel": {
         "required": [
           "rapidId",
           "_t"
@@ -2769,10 +2769,10 @@
           }
         }
       },
-      "IRapidResultTranscriptionResult": {
+      "IRapidResultModelTranscriptionResultModel": {
         "required": [
-          "selectedWords",
           "rapidId",
+          "selectedWords",
           "_t"
         ],
         "properties": {
@@ -2782,47 +2782,47 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "selectedWords": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionResultModel_TranscriptionWord"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRefereeInfo": {
+      "IRefereeInfoModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRefereeInfoQuorumRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelNaiveRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoProbabilisticAttachCategoryRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelNeverEndingRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoNeverEndingRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoNaiveRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelQuorumRefereeInfoModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "QuorumRefereeInfo": "#/components/schemas/IRefereeInfoQuorumRefereeInfo",
-            "ProbabilisticAttachCategoryRefereeInfo": "#/components/schemas/IRefereeInfoProbabilisticAttachCategoryRefereeInfo",
-            "NeverEndingRefereeInfo": "#/components/schemas/IRefereeInfoNeverEndingRefereeInfo",
-            "NaiveRefereeInfo": "#/components/schemas/IRefereeInfoNaiveRefereeInfo"
+            "NaiveRefereeInfo": "#/components/schemas/IRefereeInfoModelNaiveRefereeInfoModel",
+            "NeverEndingRefereeInfo": "#/components/schemas/IRefereeInfoModelNeverEndingRefereeInfoModel",
+            "ProbabilisticAttachCategoryRefereeInfo": "#/components/schemas/IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel",
+            "QuorumRefereeInfo": "#/components/schemas/IRefereeInfoModelQuorumRefereeInfoModel"
           }
         }
       },
-      "IRefereeInfoNaiveRefereeInfo": {
+      "IRefereeInfoModelNaiveRefereeInfoModel": {
         "required": [
           "_t"
         ],
@@ -2843,7 +2843,7 @@
           }
         }
       },
-      "IRefereeInfoNeverEndingRefereeInfo": {
+      "IRefereeInfoModelNeverEndingRefereeInfoModel": {
         "required": [
           "_t"
         ],
@@ -2856,7 +2856,7 @@
           }
         }
       },
-      "IRefereeInfoProbabilisticAttachCategoryRefereeInfo": {
+      "IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel": {
         "required": [
           "threshold",
           "maxVotes",
@@ -2879,7 +2879,7 @@
           }
         }
       },
-      "IRefereeInfoQuorumRefereeInfo": {
+      "IRefereeInfoModelQuorumRefereeInfoModel": {
         "required": [
           "maxVotes",
           "threshold",
@@ -2911,191 +2911,6 @@
           "isValid": {
             "type": "boolean",
             "description": "Whether the rapid bag is valid."
-          }
-        }
-      },
-      "IValidationTruth": {
-        "required": [
-          "_t"
-        ],
-        "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/IValidationTruthTranscriptionTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthScrubTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthPolygonTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthNamedEntityTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthLocateBoxTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthLineTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthEmptyValidationTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthCompareTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthMultiCompareTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthSkipTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthAttachCategoryTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthBoundingBoxTruth"
-          }
-        ],
-        "discriminator": {
-          "propertyName": "_t",
-          "mapping": {
-            "TranscriptionTruth": "#/components/schemas/IValidationTruthTranscriptionTruth",
-            "ScrubTruth": "#/components/schemas/IValidationTruthScrubTruth",
-            "PolygonTruth": "#/components/schemas/IValidationTruthPolygonTruth",
-            "NamedEntityTruth": "#/components/schemas/IValidationTruthNamedEntityTruth",
-            "LocateBoxTruth": "#/components/schemas/IValidationTruthLocateBoxTruth",
-            "LineTruth": "#/components/schemas/IValidationTruthLineTruth",
-            "EmptyValidationTruth": "#/components/schemas/IValidationTruthEmptyValidationTruth",
-            "CompareTruth": "#/components/schemas/IValidationTruthCompareTruth",
-            "MultiCompareTruth": "#/components/schemas/IValidationTruthMultiCompareTruth",
-            "SkipTruth": "#/components/schemas/IValidationTruthSkipTruth",
-            "AttachCategoryTruth": "#/components/schemas/IValidationTruthAttachCategoryTruth",
-            "BoundingBoxTruth": "#/components/schemas/IValidationTruthBoundingBoxTruth"
-          }
-        }
-      },
-      "IValidationTruthAttachCategoryTruth": {
-        "required": [
-          "correctCategories",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "AttachCategoryTruth"
-            ],
-            "type": "string"
-          },
-          "correctCategories": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "IValidationTruthBoundingBoxTruth": {
-        "required": [
-          "xMin",
-          "yMin",
-          "xMax",
-          "yMax",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "BoundingBoxTruth"
-            ],
-            "type": "string"
-          },
-          "xMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "xMax": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMax": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "IValidationTruthCompareTruth": {
-        "required": [
-          "winnerId",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "CompareTruth"
-            ],
-            "type": "string"
-          },
-          "winnerId": {
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthEmptyValidationTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "EmptyValidationTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthLineTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "LineTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthLocateBoxTruth": {
-        "required": [
-          "boundingBoxes",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "LocateBoxTruth"
-            ],
-            "type": "string"
-          },
-          "boundingBoxes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BoxShape"
-            }
-          },
-          "requiredPrecision": {
-            "type": "number",
-            "format": "double"
-          },
-          "requiredCompleteness": {
-            "type": "number",
-            "format": "double"
           }
         }
       },
@@ -3295,7 +3110,7 @@
           "boundingBoxes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BoxShape"
+              "$ref": "#/components/schemas/LocateBoxTruthModel_Box"
             }
           },
           "requiredPrecision": {
@@ -3346,7 +3161,7 @@
           "classifications": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NamedClassification"
+              "$ref": "#/components/schemas/NamedEntityTruthModel_NamedClassification"
             }
           }
         }
@@ -3379,7 +3194,7 @@
           "validRanges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScrubRange"
+              "$ref": "#/components/schemas/ScrubTruthModel_ScrubRange"
             }
           }
         }
@@ -3412,7 +3227,7 @@
           "correctWords": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionTruthModel_TranscriptionWord"
             }
           },
           "strictGrading": {
@@ -3429,128 +3244,7 @@
           }
         }
       },
-      "IValidationTruthMultiCompareTruth": {
-        "required": [
-          "correctCombinations",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "MultiCompareTruth"
-            ],
-            "type": "string"
-          },
-          "correctCombinations": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "IValidationTruthNamedEntityTruth": {
-        "required": [
-          "classifications",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "NamedEntityTruth"
-            ],
-            "type": "string"
-          },
-          "classifications": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NamedClassification"
-            }
-          }
-        }
-      },
-      "IValidationTruthPolygonTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "PolygonTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthScrubTruth": {
-        "required": [
-          "validRanges",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "ScrubTruth"
-            ],
-            "type": "string"
-          },
-          "validRanges": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ScrubRange"
-            }
-          }
-        }
-      },
-      "IValidationTruthSkipTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "SkipTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthTranscriptionTruth": {
-        "required": [
-          "correctWords",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "TranscriptionTruth"
-            ],
-            "type": "string"
-          },
-          "correctWords": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
-            }
-          },
-          "strictGrading": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "requiredPrecision": {
-            "type": "number",
-            "format": "double"
-          },
-          "requiredCompleteness": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "LineResult_Line": {
+      "LineResultModel_Line": {
         "required": [
           "size",
           "points"
@@ -3564,12 +3258,12 @@
           "points": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_LinePoint"
+              "$ref": "#/components/schemas/LineResultModel_LinePoint"
             }
           }
         }
       },
-      "LineResult_LinePoint": {
+      "LineResultModel_LinePoint": {
         "required": [
           "x",
           "y"
@@ -3586,7 +3280,28 @@
           }
         }
       },
-      "LocateCoordinate": {
+      "LocateBoxTruthModel_Box": {
+        "type": "object",
+        "properties": {
+          "xMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "xMax": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMax": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "LocateCoordinateModel": {
         "required": [
           "x",
           "y"
@@ -3629,7 +3344,7 @@
           "type": "string"
         }
       },
-      "NamedClassification": {
+      "NamedEntityResultModel_NamedClassification": {
         "required": [
           "start",
           "end",
@@ -3650,7 +3365,28 @@
           }
         }
       },
-      "PolygonResult_Coordinate": {
+      "NamedEntityTruthModel_NamedClassification": {
+        "required": [
+          "start",
+          "end",
+          "classification"
+        ],
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "classification": {
+            "type": "string"
+          }
+        }
+      },
+      "PolygonResultModel_Coordinate": {
         "required": [
           "x",
           "y"
@@ -3667,7 +3403,7 @@
           }
         }
       },
-      "PolygonResult_Shape": {
+      "PolygonResultModel_Shape": {
         "required": [
           "edges"
         ],
@@ -3676,7 +3412,7 @@
           "edges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Coordinate"
+              "$ref": "#/components/schemas/PolygonResultModel_Coordinate"
             }
           }
         }
@@ -3706,7 +3442,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -3714,7 +3450,7 @@
           "referee": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRefereeInfo"
+                "$ref": "#/components/schemas/IRefereeInfoModel"
               }
             ],
             "description": "The referee that created the rapid."
@@ -3730,7 +3466,7 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
@@ -3746,7 +3482,7 @@
           "truth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The optional validation truth of the rapid."
@@ -3901,7 +3637,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -3919,7 +3655,7 @@
           "truth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The derived validation truth for the rapid."
@@ -3959,7 +3695,7 @@
           }
         }
       },
-      "RapidIssue": {
+      "RapidIssueModel": {
         "enum": [
           "Other",
           "CannotSubmit",
@@ -3973,7 +3709,7 @@
           "MyAnswerIsCorrect"
         ]
       },
-      "RapidState": {
+      "RapidStateModel": {
         "enum": [
           "Labeling",
           "Paused",
@@ -3993,7 +3729,7 @@
           "issue": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidIssue"
+                "$ref": "#/components/schemas/RapidIssueModel"
               }
             ],
             "description": "A streamlined enum representing common issues."
@@ -4015,7 +3751,7 @@
           }
         }
       },
-      "ScrubRange": {
+      "ScrubTruthModel_ScrubRange": {
         "required": [
           "start",
           "end"
@@ -4064,7 +3800,7 @@
           "validationTruth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The validation truth applied, if any."
@@ -4084,7 +3820,39 @@
           }
         }
       },
-      "TranscriptionWord": {
+      "TranscriptionPayloadModel_TranscriptionWord": {
+        "required": [
+          "word",
+          "wordIndex"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TranscriptionResultModel_TranscriptionWord": {
+        "required": [
+          "word",
+          "wordIndex"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TranscriptionTruthModel_TranscriptionWord": {
         "required": [
           "word",
           "wordIndex"

--- a/openapi/schemas/rapidata.filtered.openapi.json
+++ b/openapi/schemas/rapidata.filtered.openapi.json
@@ -21908,6 +21908,21 @@
               "LineExampleTruth"
             ],
             "type": "string"
+          },
+          "boundingBoxes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExampleBoxShape"
+            },
+            "nullable": true
+          },
+          "requiredPrecision": {
+            "type": "number",
+            "format": "double"
+          },
+          "requiredCompleteness": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -32913,7 +32928,7 @@
           "result": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidResult"
+                "$ref": "#/components/schemas/IRapidResultModel"
               }
             ],
             "description": "The result submitted by the user."
@@ -32934,7 +32949,7 @@
           "validationTruth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The validation truth applied to the response, if any."
@@ -32954,7 +32969,7 @@
           }
         }
       },
-      "BoxShape": {
+      "BoundingBoxResultModel_Box": {
         "type": "object",
         "properties": {
           "xMin": {
@@ -32975,7 +32990,7 @@
           }
         }
       },
-      "ClassifyPayload": {
+      "ClassifyPayloadModel": {
         "required": [
           "categories",
           "title"
@@ -32985,7 +33000,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyPayloadModel_Category"
             }
           },
           "title": {
@@ -32993,10 +33008,9 @@
           }
         }
       },
-      "ClassifyPayload_Category": {
+      "ClassifyPayloadModel_Category": {
         "required": [
-          "label",
-          "value"
+          "label"
         ],
         "type": "object",
         "properties": {
@@ -33004,7 +33018,8 @@
             "type": "string"
           },
           "value": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -33022,7 +33037,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ClassifyPayload"
+                "$ref": "#/components/schemas/ClassifyPayloadModel"
               }
             ],
             "description": "The payload for the classification."
@@ -33097,7 +33112,7 @@
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/GetGlobalResponsesEndpoint_Response"
+                  "$ref": "#/components/schemas/GetGlobalResponsesEndpoint_Output_Response"
                 }
               }
             ],
@@ -33105,7 +33120,7 @@
           }
         }
       },
-      "GetGlobalResponsesEndpoint_Response": {
+      "GetGlobalResponsesEndpoint_Output_Response": {
         "required": [
           "id",
           "userId",
@@ -33162,7 +33177,7 @@
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/GetResponsesForRapidResult_Response"
+                  "$ref": "#/components/schemas/GetResponsesForRapidEndpoint_Output_Response"
                 }
               }
             ],
@@ -33171,14 +33186,14 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
           }
         }
       },
-      "GetResponsesForRapidResult_Response": {
+      "GetResponsesForRapidEndpoint_Output_Response": {
         "required": [
           "id",
           "userId",
@@ -33200,7 +33215,7 @@
             "type": "string"
           },
           "result": {
-            "$ref": "#/components/schemas/IRapidResult"
+            "$ref": "#/components/schemas/IRapidResultModel"
           },
           "userScore": {
             "type": "number",
@@ -33231,60 +33246,60 @@
           }
         }
       },
-      "IRapidPayload": {
+      "IRapidPayloadModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelComparePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLinePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLocatePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadClassifyPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelScrubPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload",
-            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
-            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
-            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
-            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
-            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
-            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
-            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
-            "ClassifyPayload": "#/components/schemas/IRapidPayloadClassifyPayload",
-            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel",
+            "ClassifyPayload": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel",
+            "ComparePayload": "#/components/schemas/IRapidPayloadModelComparePayloadModel",
+            "FreeTextPayload": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel",
+            "LinePayload": "#/components/schemas/IRapidPayloadModelLinePayloadModel",
+            "LocatePayload": "#/components/schemas/IRapidPayloadModelLocatePayloadModel",
+            "NamedEntityPayload": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel",
+            "PolygonPayload": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel",
+            "ScrubPayload": "#/components/schemas/IRapidPayloadModelScrubPayloadModel",
+            "TranscriptionPayload": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         }
       },
-      "IRapidPayloadBoundingBoxPayload": {
+      "IRapidPayloadModelBoundingBoxPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33301,7 +33316,7 @@
           }
         }
       },
-      "IRapidPayloadClassifyPayload": {
+      "IRapidPayloadModelClassifyPayloadModel": {
         "required": [
           "categories",
           "title",
@@ -33317,7 +33332,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyPayloadModel_Category"
             }
           },
           "title": {
@@ -33325,7 +33340,7 @@
           }
         }
       },
-      "IRapidPayloadComparePayload": {
+      "IRapidPayloadModelComparePayloadModel": {
         "required": [
           "criteria",
           "_t"
@@ -33342,7 +33357,7 @@
           }
         }
       },
-      "IRapidPayloadFreeTextPayload": {
+      "IRapidPayloadModelFreeTextPayloadModel": {
         "required": [
           "question",
           "_t"
@@ -33366,7 +33381,7 @@
           }
         }
       },
-      "IRapidPayloadLinePayload": {
+      "IRapidPayloadModelLinePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33383,7 +33398,7 @@
           }
         }
       },
-      "IRapidPayloadLocatePayload": {
+      "IRapidPayloadModelLocatePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33400,7 +33415,7 @@
           }
         }
       },
-      "IRapidPayloadNamedEntityPayload": {
+      "IRapidPayloadModelNamedEntityPayloadModel": {
         "required": [
           "target",
           "classes",
@@ -33424,7 +33439,7 @@
           }
         }
       },
-      "IRapidPayloadPolygonPayload": {
+      "IRapidPayloadModelPolygonPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33441,7 +33456,7 @@
           }
         }
       },
-      "IRapidPayloadScrubPayload": {
+      "IRapidPayloadModelScrubPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33458,7 +33473,7 @@
           }
         }
       },
-      "IRapidPayloadTranscriptionPayload": {
+      "IRapidPayloadModelTranscriptionPayloadModel": {
         "required": [
           "title",
           "transcription",
@@ -33477,72 +33492,72 @@
           "transcription": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionPayloadModel_TranscriptionWord"
             }
           }
         }
       },
-      "IRapidResult": {
+      "IRapidResultModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidResultTranscriptionResult"
+            "$ref": "#/components/schemas/IRapidResultModelAttachCategoryResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultScrubResult"
+            "$ref": "#/components/schemas/IRapidResultModelBoundingBoxResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultPolygonResult"
+            "$ref": "#/components/schemas/IRapidResultModelCompareResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultNamedEntityResult"
+            "$ref": "#/components/schemas/IRapidResultModelFreeTextResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultLocateResult"
+            "$ref": "#/components/schemas/IRapidResultModelLineResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultLineResult"
+            "$ref": "#/components/schemas/IRapidResultModelLocateResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultFreeTextResult"
+            "$ref": "#/components/schemas/IRapidResultModelNamedEntityResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultCompareResult"
+            "$ref": "#/components/schemas/IRapidResultModelPolygonResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultSkipResult"
+            "$ref": "#/components/schemas/IRapidResultModelScrubResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultAttachCategoryResult"
+            "$ref": "#/components/schemas/IRapidResultModelSkipResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "$ref": "#/components/schemas/IRapidResultModelTranscriptionResultModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionResult": "#/components/schemas/IRapidResultTranscriptionResult",
-            "ScrubResult": "#/components/schemas/IRapidResultScrubResult",
-            "PolygonResult": "#/components/schemas/IRapidResultPolygonResult",
-            "NamedEntityResult": "#/components/schemas/IRapidResultNamedEntityResult",
-            "LocateResult": "#/components/schemas/IRapidResultLocateResult",
-            "LineResult": "#/components/schemas/IRapidResultLineResult",
-            "FreeTextResult": "#/components/schemas/IRapidResultFreeTextResult",
-            "CompareResult": "#/components/schemas/IRapidResultCompareResult",
-            "SkipResult": "#/components/schemas/IRapidResultSkipResult",
-            "AttachCategoryResult": "#/components/schemas/IRapidResultAttachCategoryResult",
-            "BoundingBoxResult": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "AttachCategoryResult": "#/components/schemas/IRapidResultModelAttachCategoryResultModel",
+            "BoundingBoxResult": "#/components/schemas/IRapidResultModelBoundingBoxResultModel",
+            "CompareResult": "#/components/schemas/IRapidResultModelCompareResultModel",
+            "FreeTextResult": "#/components/schemas/IRapidResultModelFreeTextResultModel",
+            "LineResult": "#/components/schemas/IRapidResultModelLineResultModel",
+            "LocateResult": "#/components/schemas/IRapidResultModelLocateResultModel",
+            "NamedEntityResult": "#/components/schemas/IRapidResultModelNamedEntityResultModel",
+            "PolygonResult": "#/components/schemas/IRapidResultModelPolygonResultModel",
+            "ScrubResult": "#/components/schemas/IRapidResultModelScrubResultModel",
+            "SkipResult": "#/components/schemas/IRapidResultModelSkipResultModel",
+            "TranscriptionResult": "#/components/schemas/IRapidResultModelTranscriptionResultModel"
           }
         }
       },
-      "IRapidResultAttachCategoryResult": {
+      "IRapidResultModelAttachCategoryResultModel": {
         "required": [
-          "category",
           "rapidId",
+          "category",
           "_t"
         ],
         "properties": {
@@ -33552,18 +33567,18 @@
             ],
             "type": "string"
           },
-          "category": {
+          "rapidId": {
             "type": "string"
           },
-          "rapidId": {
+          "category": {
             "type": "string"
           }
         }
       },
-      "IRapidResultBoundingBoxResult": {
+      "IRapidResultModelBoundingBoxResultModel": {
         "required": [
-          "boundingBoxes",
           "rapidId",
+          "boundingBoxes",
           "_t"
         ],
         "properties": {
@@ -33573,18 +33588,18 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "boundingBoxes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BoxShape"
+              "$ref": "#/components/schemas/BoundingBoxResultModel_Box"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultCompareResult": {
+      "IRapidResultModelCompareResultModel": {
         "required": [
           "rapidId",
           "_t"
@@ -33596,21 +33611,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "winners": {
             "type": "array",
             "items": {
               "type": "string"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultFreeTextResult": {
+      "IRapidResultModelFreeTextResultModel": {
         "required": [
-          "answer",
           "rapidId",
+          "answer",
           "_t"
         ],
         "properties": {
@@ -33620,18 +33635,18 @@
             ],
             "type": "string"
           },
-          "answer": {
+          "rapidId": {
             "type": "string"
           },
-          "rapidId": {
+          "answer": {
             "type": "string"
           }
         }
       },
-      "IRapidResultLineResult": {
+      "IRapidResultModelLineResultModel": {
         "required": [
-          "lines",
           "rapidId",
+          "lines",
           "_t"
         ],
         "properties": {
@@ -33641,21 +33656,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "lines": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_Line"
+              "$ref": "#/components/schemas/LineResultModel_Line"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultLocateResult": {
+      "IRapidResultModelLocateResultModel": {
         "required": [
-          "coordinates",
           "rapidId",
+          "coordinates",
           "_t"
         ],
         "properties": {
@@ -33665,21 +33680,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LocateCoordinate"
+              "$ref": "#/components/schemas/LocateCoordinateModel"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultNamedEntityResult": {
+      "IRapidResultModelNamedEntityResultModel": {
         "required": [
-          "classifications",
           "rapidId",
+          "classifications",
           "_t"
         ],
         "properties": {
@@ -33689,21 +33704,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "classifications": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NamedClassification"
+              "$ref": "#/components/schemas/NamedEntityResultModel_NamedClassification"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultPolygonResult": {
+      "IRapidResultModelPolygonResultModel": {
         "required": [
-          "shapes",
           "rapidId",
+          "shapes",
           "_t"
         ],
         "properties": {
@@ -33713,21 +33728,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "shapes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Shape"
+              "$ref": "#/components/schemas/PolygonResultModel_Shape"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultScrubResult": {
+      "IRapidResultModelScrubResultModel": {
         "required": [
-          "timestamps",
           "rapidId",
+          "timestamps",
           "_t"
         ],
         "properties": {
@@ -33737,19 +33752,19 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "timestamps": {
             "type": "array",
             "items": {
               "type": "integer",
               "format": "int32"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultSkipResult": {
+      "IRapidResultModelSkipResultModel": {
         "required": [
           "rapidId",
           "_t"
@@ -33766,10 +33781,10 @@
           }
         }
       },
-      "IRapidResultTranscriptionResult": {
+      "IRapidResultModelTranscriptionResultModel": {
         "required": [
-          "selectedWords",
           "rapidId",
+          "selectedWords",
           "_t"
         ],
         "properties": {
@@ -33779,47 +33794,47 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "selectedWords": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionResultModel_TranscriptionWord"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRefereeInfo": {
+      "IRefereeInfoModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRefereeInfoQuorumRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelNaiveRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoProbabilisticAttachCategoryRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelNeverEndingRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoNeverEndingRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoNaiveRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelQuorumRefereeInfoModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "QuorumRefereeInfo": "#/components/schemas/IRefereeInfoQuorumRefereeInfo",
-            "ProbabilisticAttachCategoryRefereeInfo": "#/components/schemas/IRefereeInfoProbabilisticAttachCategoryRefereeInfo",
-            "NeverEndingRefereeInfo": "#/components/schemas/IRefereeInfoNeverEndingRefereeInfo",
-            "NaiveRefereeInfo": "#/components/schemas/IRefereeInfoNaiveRefereeInfo"
+            "NaiveRefereeInfo": "#/components/schemas/IRefereeInfoModelNaiveRefereeInfoModel",
+            "NeverEndingRefereeInfo": "#/components/schemas/IRefereeInfoModelNeverEndingRefereeInfoModel",
+            "ProbabilisticAttachCategoryRefereeInfo": "#/components/schemas/IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel",
+            "QuorumRefereeInfo": "#/components/schemas/IRefereeInfoModelQuorumRefereeInfoModel"
           }
         }
       },
-      "IRefereeInfoNaiveRefereeInfo": {
+      "IRefereeInfoModelNaiveRefereeInfoModel": {
         "required": [
           "_t"
         ],
@@ -33840,7 +33855,7 @@
           }
         }
       },
-      "IRefereeInfoNeverEndingRefereeInfo": {
+      "IRefereeInfoModelNeverEndingRefereeInfoModel": {
         "required": [
           "_t"
         ],
@@ -33853,7 +33868,7 @@
           }
         }
       },
-      "IRefereeInfoProbabilisticAttachCategoryRefereeInfo": {
+      "IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel": {
         "required": [
           "threshold",
           "maxVotes",
@@ -33876,7 +33891,7 @@
           }
         }
       },
-      "IRefereeInfoQuorumRefereeInfo": {
+      "IRefereeInfoModelQuorumRefereeInfoModel": {
         "required": [
           "maxVotes",
           "threshold",
@@ -33908,191 +33923,6 @@
           "isValid": {
             "type": "boolean",
             "description": "Whether the rapid bag is valid."
-          }
-        }
-      },
-      "IValidationTruth": {
-        "required": [
-          "_t"
-        ],
-        "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/IValidationTruthTranscriptionTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthScrubTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthPolygonTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthNamedEntityTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthLocateBoxTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthLineTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthEmptyValidationTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthCompareTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthMultiCompareTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthSkipTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthAttachCategoryTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthBoundingBoxTruth"
-          }
-        ],
-        "discriminator": {
-          "propertyName": "_t",
-          "mapping": {
-            "TranscriptionTruth": "#/components/schemas/IValidationTruthTranscriptionTruth",
-            "ScrubTruth": "#/components/schemas/IValidationTruthScrubTruth",
-            "PolygonTruth": "#/components/schemas/IValidationTruthPolygonTruth",
-            "NamedEntityTruth": "#/components/schemas/IValidationTruthNamedEntityTruth",
-            "LocateBoxTruth": "#/components/schemas/IValidationTruthLocateBoxTruth",
-            "LineTruth": "#/components/schemas/IValidationTruthLineTruth",
-            "EmptyValidationTruth": "#/components/schemas/IValidationTruthEmptyValidationTruth",
-            "CompareTruth": "#/components/schemas/IValidationTruthCompareTruth",
-            "MultiCompareTruth": "#/components/schemas/IValidationTruthMultiCompareTruth",
-            "SkipTruth": "#/components/schemas/IValidationTruthSkipTruth",
-            "AttachCategoryTruth": "#/components/schemas/IValidationTruthAttachCategoryTruth",
-            "BoundingBoxTruth": "#/components/schemas/IValidationTruthBoundingBoxTruth"
-          }
-        }
-      },
-      "IValidationTruthAttachCategoryTruth": {
-        "required": [
-          "correctCategories",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "AttachCategoryTruth"
-            ],
-            "type": "string"
-          },
-          "correctCategories": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "IValidationTruthBoundingBoxTruth": {
-        "required": [
-          "xMin",
-          "yMin",
-          "xMax",
-          "yMax",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "BoundingBoxTruth"
-            ],
-            "type": "string"
-          },
-          "xMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "xMax": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMax": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "IValidationTruthCompareTruth": {
-        "required": [
-          "winnerId",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "CompareTruth"
-            ],
-            "type": "string"
-          },
-          "winnerId": {
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthEmptyValidationTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "EmptyValidationTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthLineTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "LineTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthLocateBoxTruth": {
-        "required": [
-          "boundingBoxes",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "LocateBoxTruth"
-            ],
-            "type": "string"
-          },
-          "boundingBoxes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BoxShape"
-            }
-          },
-          "requiredPrecision": {
-            "type": "number",
-            "format": "double"
-          },
-          "requiredCompleteness": {
-            "type": "number",
-            "format": "double"
           }
         }
       },
@@ -34292,7 +34122,7 @@
           "boundingBoxes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BoxShape"
+              "$ref": "#/components/schemas/LocateBoxTruthModel_Box"
             }
           },
           "requiredPrecision": {
@@ -34343,7 +34173,7 @@
           "classifications": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NamedClassification"
+              "$ref": "#/components/schemas/NamedEntityTruthModel_NamedClassification"
             }
           }
         }
@@ -34376,7 +34206,7 @@
           "validRanges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScrubRange"
+              "$ref": "#/components/schemas/ScrubTruthModel_ScrubRange"
             }
           }
         }
@@ -34409,7 +34239,7 @@
           "correctWords": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionTruthModel_TranscriptionWord"
             }
           },
           "strictGrading": {
@@ -34426,128 +34256,7 @@
           }
         }
       },
-      "IValidationTruthMultiCompareTruth": {
-        "required": [
-          "correctCombinations",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "MultiCompareTruth"
-            ],
-            "type": "string"
-          },
-          "correctCombinations": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "IValidationTruthNamedEntityTruth": {
-        "required": [
-          "classifications",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "NamedEntityTruth"
-            ],
-            "type": "string"
-          },
-          "classifications": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NamedClassification"
-            }
-          }
-        }
-      },
-      "IValidationTruthPolygonTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "PolygonTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthScrubTruth": {
-        "required": [
-          "validRanges",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "ScrubTruth"
-            ],
-            "type": "string"
-          },
-          "validRanges": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ScrubRange"
-            }
-          }
-        }
-      },
-      "IValidationTruthSkipTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "SkipTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthTranscriptionTruth": {
-        "required": [
-          "correctWords",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "TranscriptionTruth"
-            ],
-            "type": "string"
-          },
-          "correctWords": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
-            }
-          },
-          "strictGrading": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "requiredPrecision": {
-            "type": "number",
-            "format": "double"
-          },
-          "requiredCompleteness": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "LineResult_Line": {
+      "LineResultModel_Line": {
         "required": [
           "size",
           "points"
@@ -34561,12 +34270,12 @@
           "points": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_LinePoint"
+              "$ref": "#/components/schemas/LineResultModel_LinePoint"
             }
           }
         }
       },
-      "LineResult_LinePoint": {
+      "LineResultModel_LinePoint": {
         "required": [
           "x",
           "y"
@@ -34583,7 +34292,28 @@
           }
         }
       },
-      "LocateCoordinate": {
+      "LocateBoxTruthModel_Box": {
+        "type": "object",
+        "properties": {
+          "xMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "xMax": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMax": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "LocateCoordinateModel": {
         "required": [
           "x",
           "y"
@@ -34600,7 +34330,7 @@
           }
         }
       },
-      "NamedClassification": {
+      "NamedEntityResultModel_NamedClassification": {
         "required": [
           "start",
           "end",
@@ -34621,7 +34351,28 @@
           }
         }
       },
-      "PolygonResult_Coordinate": {
+      "NamedEntityTruthModel_NamedClassification": {
+        "required": [
+          "start",
+          "end",
+          "classification"
+        ],
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "classification": {
+            "type": "string"
+          }
+        }
+      },
+      "PolygonResultModel_Coordinate": {
         "required": [
           "x",
           "y"
@@ -34638,7 +34389,7 @@
           }
         }
       },
-      "PolygonResult_Shape": {
+      "PolygonResultModel_Shape": {
         "required": [
           "edges"
         ],
@@ -34647,7 +34398,7 @@
           "edges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Coordinate"
+              "$ref": "#/components/schemas/PolygonResultModel_Coordinate"
             }
           }
         }
@@ -34677,7 +34428,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -34685,7 +34436,7 @@
           "referee": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRefereeInfo"
+                "$ref": "#/components/schemas/IRefereeInfoModel"
               }
             ],
             "description": "The referee that created the rapid."
@@ -34701,7 +34452,7 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
@@ -34717,7 +34468,7 @@
           "truth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The optional validation truth of the rapid."
@@ -34872,7 +34623,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -34890,7 +34641,7 @@
           "truth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The derived validation truth for the rapid."
@@ -34930,7 +34681,7 @@
           }
         }
       },
-      "RapidIssue": {
+      "RapidIssueModel": {
         "enum": [
           "Other",
           "CannotSubmit",
@@ -34944,7 +34695,7 @@
           "MyAnswerIsCorrect"
         ]
       },
-      "RapidState": {
+      "RapidStateModel": {
         "enum": [
           "Labeling",
           "Paused",
@@ -34964,7 +34715,7 @@
           "issue": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidIssue"
+                "$ref": "#/components/schemas/RapidIssueModel"
               }
             ],
             "description": "A streamlined enum representing common issues."
@@ -34986,7 +34737,7 @@
           }
         }
       },
-      "ScrubRange": {
+      "ScrubTruthModel_ScrubRange": {
         "required": [
           "start",
           "end"
@@ -35035,7 +34786,7 @@
           "validationTruth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The validation truth applied, if any."
@@ -35055,7 +34806,39 @@
           }
         }
       },
-      "TranscriptionWord": {
+      "TranscriptionPayloadModel_TranscriptionWord": {
+        "required": [
+          "word",
+          "wordIndex"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TranscriptionResultModel_TranscriptionWord": {
+        "required": [
+          "word",
+          "wordIndex"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TranscriptionTruthModel_TranscriptionWord": {
         "required": [
           "word",
           "wordIndex"
@@ -35157,7 +34940,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload to use for the rapid."
@@ -35394,7 +35177,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -35435,7 +35218,7 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
@@ -35732,6 +35515,42 @@
         }
       },
       "AttachCategoryWorkflowRapidBlueprintModel_Category": {
+        "required": [
+          "label",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "BoxShape": {
+        "type": "object",
+        "properties": {
+          "xMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "xMax": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMax": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ClassifyCategory": {
         "required": [
           "label",
           "value"
@@ -36386,6 +36205,566 @@
           }
         }
       },
+      "IRapidPayload": {
+        "required": [
+          "_t"
+        ],
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadClassifyPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "_t",
+          "mapping": {
+            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload",
+            "ClassifyPayload": "#/components/schemas/IRapidPayloadClassifyPayload",
+            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
+            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
+            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
+            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
+            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
+            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
+            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
+            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+          }
+        }
+      },
+      "IRapidPayloadBoundingBoxPayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "BoundingBoxPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadClassifyPayload": {
+        "required": [
+          "categories",
+          "title",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ClassifyPayload"
+            ],
+            "type": "string"
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClassifyCategory"
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadComparePayload": {
+        "required": [
+          "criteria",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ComparePayload"
+            ],
+            "type": "string"
+          },
+          "criteria": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadFreeTextPayload": {
+        "required": [
+          "question",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "FreeTextPayload"
+            ],
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "shouldValidateResponse": {
+            "type": "boolean"
+          },
+          "validationSystemPrompt": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "IRapidPayloadLinePayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LinePayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadLocatePayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LocatePayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadNamedEntityPayload": {
+        "required": [
+          "target",
+          "classes",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "NamedEntityPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "classes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "IRapidPayloadPolygonPayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "PolygonPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadScrubPayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ScrubPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadTranscriptionPayload": {
+        "required": [
+          "title",
+          "transcription",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "TranscriptionPayload"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "transcription": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionWord"
+            }
+          }
+        }
+      },
+      "IRapidResult": {
+        "required": [
+          "_t"
+        ],
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IRapidResultAttachCategoryResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultBoundingBoxResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultCompareResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultFreeTextResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultLineResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultLocateResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultNamedEntityResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultPolygonResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultScrubResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultSkipResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultTranscriptionResult"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "_t",
+          "mapping": {
+            "AttachCategoryResult": "#/components/schemas/IRapidResultAttachCategoryResult",
+            "BoundingBoxResult": "#/components/schemas/IRapidResultBoundingBoxResult",
+            "CompareResult": "#/components/schemas/IRapidResultCompareResult",
+            "FreeTextResult": "#/components/schemas/IRapidResultFreeTextResult",
+            "LineResult": "#/components/schemas/IRapidResultLineResult",
+            "LocateResult": "#/components/schemas/IRapidResultLocateResult",
+            "NamedEntityResult": "#/components/schemas/IRapidResultNamedEntityResult",
+            "PolygonResult": "#/components/schemas/IRapidResultPolygonResult",
+            "ScrubResult": "#/components/schemas/IRapidResultScrubResult",
+            "SkipResult": "#/components/schemas/IRapidResultSkipResult",
+            "TranscriptionResult": "#/components/schemas/IRapidResultTranscriptionResult"
+          }
+        }
+      },
+      "IRapidResultAttachCategoryResult": {
+        "required": [
+          "category",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "AttachCategoryResult"
+            ],
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultBoundingBoxResult": {
+        "required": [
+          "boundingBoxes",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "BoundingBoxResult"
+            ],
+            "type": "string"
+          },
+          "boundingBoxes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BoxShape"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultCompareResult": {
+        "required": [
+          "winners",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "CompareResult"
+            ],
+            "type": "string"
+          },
+          "winners": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultFreeTextResult": {
+        "required": [
+          "answer",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "FreeTextResult"
+            ],
+            "type": "string"
+          },
+          "answer": {
+            "type": "string"
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultLineResult": {
+        "required": [
+          "lines",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LineResult"
+            ],
+            "type": "string"
+          },
+          "lines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Line"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultLocateResult": {
+        "required": [
+          "coordinates",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LocateResult"
+            ],
+            "type": "string"
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocateCoordinate"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultNamedEntityResult": {
+        "required": [
+          "classifications",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "NamedEntityResult"
+            ],
+            "type": "string"
+          },
+          "classifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NamedClassification"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultPolygonResult": {
+        "required": [
+          "shapes",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "PolygonResult"
+            ],
+            "type": "string"
+          },
+          "shapes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PolygonShape"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultScrubResult": {
+        "required": [
+          "timestamps",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ScrubResult"
+            ],
+            "type": "string"
+          },
+          "timestamps": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultSkipResult": {
+        "required": [
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "SkipResult"
+            ],
+            "type": "string"
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultTranscriptionResult": {
+        "required": [
+          "selectedWords",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "TranscriptionResult"
+            ],
+            "type": "string"
+          },
+          "selectedWords": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionWord"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
       "IRefereeConfigModel": {
         "required": [
           "_t"
@@ -36991,6 +37370,96 @@
           }
         }
       },
+      "Line": {
+        "required": [
+          "points"
+        ],
+        "type": "object",
+        "properties": {
+          "size": {
+            "type": "number",
+            "format": "double"
+          },
+          "points": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LinePoint"
+            }
+          }
+        }
+      },
+      "LinePoint": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "LocateCoordinate": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "NamedClassification": {
+        "required": [
+          "classification"
+        ],
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "classification": {
+            "type": "string"
+          }
+        }
+      },
+      "PolygonCoordinate": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "PolygonShape": {
+        "required": [
+          "edges"
+        ],
+        "type": "object",
+        "properties": {
+          "edges": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PolygonCoordinate"
+            }
+          }
+        }
+      },
       "QueryWorkflowsEndpoint_Output": {
         "required": [
           "workflow"
@@ -37040,11 +37509,37 @@
           }
         }
       },
+      "RapidState": {
+        "enum": [
+          "Labeling",
+          "Paused",
+          "Incomplete",
+          "Flagged",
+          "Done",
+          "None",
+          "Rejected"
+        ]
+      },
       "SortDirection": {
         "enum": [
           "Asc",
           "Desc"
         ]
+      },
+      "TranscriptionWord": {
+        "required": [
+          "word"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
       },
       "WorkflowState": {
         "enum": [

--- a/openapi/schemas/rapidata.openapi.json
+++ b/openapi/schemas/rapidata.openapi.json
@@ -21963,6 +21963,21 @@
               "LineExampleTruth"
             ],
             "type": "string"
+          },
+          "boundingBoxes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExampleBoxShape"
+            },
+            "nullable": true
+          },
+          "requiredPrecision": {
+            "type": "number",
+            "format": "double"
+          },
+          "requiredCompleteness": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -32968,7 +32983,7 @@
           "result": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidResult"
+                "$ref": "#/components/schemas/IRapidResultModel"
               }
             ],
             "description": "The result submitted by the user."
@@ -32989,7 +33004,7 @@
           "validationTruth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The validation truth applied to the response, if any."
@@ -33009,7 +33024,7 @@
           }
         }
       },
-      "BoxShape": {
+      "BoundingBoxResultModel_Box": {
         "type": "object",
         "properties": {
           "xMin": {
@@ -33030,7 +33045,7 @@
           }
         }
       },
-      "ClassifyPayload": {
+      "ClassifyPayloadModel": {
         "required": [
           "categories",
           "title"
@@ -33040,7 +33055,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyPayloadModel_Category"
             }
           },
           "title": {
@@ -33048,10 +33063,9 @@
           }
         }
       },
-      "ClassifyPayload_Category": {
+      "ClassifyPayloadModel_Category": {
         "required": [
-          "label",
-          "value"
+          "label"
         ],
         "type": "object",
         "properties": {
@@ -33059,7 +33073,8 @@
             "type": "string"
           },
           "value": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -33077,7 +33092,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ClassifyPayload"
+                "$ref": "#/components/schemas/ClassifyPayloadModel"
               }
             ],
             "description": "The payload for the classification."
@@ -33152,7 +33167,7 @@
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/GetGlobalResponsesEndpoint_Response"
+                  "$ref": "#/components/schemas/GetGlobalResponsesEndpoint_Output_Response"
                 }
               }
             ],
@@ -33160,7 +33175,7 @@
           }
         }
       },
-      "GetGlobalResponsesEndpoint_Response": {
+      "GetGlobalResponsesEndpoint_Output_Response": {
         "required": [
           "id",
           "userId",
@@ -33217,7 +33232,7 @@
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/GetResponsesForRapidResult_Response"
+                  "$ref": "#/components/schemas/GetResponsesForRapidEndpoint_Output_Response"
                 }
               }
             ],
@@ -33226,14 +33241,14 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
           }
         }
       },
-      "GetResponsesForRapidResult_Response": {
+      "GetResponsesForRapidEndpoint_Output_Response": {
         "required": [
           "id",
           "userId",
@@ -33255,7 +33270,7 @@
             "type": "string"
           },
           "result": {
-            "$ref": "#/components/schemas/IRapidResult"
+            "$ref": "#/components/schemas/IRapidResultModel"
           },
           "userScore": {
             "type": "number",
@@ -33286,60 +33301,60 @@
           }
         }
       },
-      "IRapidPayload": {
+      "IRapidPayloadModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelComparePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLinePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLocatePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadClassifyPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelScrubPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload",
-            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
-            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
-            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
-            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
-            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
-            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
-            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
-            "ClassifyPayload": "#/components/schemas/IRapidPayloadClassifyPayload",
-            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel",
+            "ClassifyPayload": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel",
+            "ComparePayload": "#/components/schemas/IRapidPayloadModelComparePayloadModel",
+            "FreeTextPayload": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel",
+            "LinePayload": "#/components/schemas/IRapidPayloadModelLinePayloadModel",
+            "LocatePayload": "#/components/schemas/IRapidPayloadModelLocatePayloadModel",
+            "NamedEntityPayload": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel",
+            "PolygonPayload": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel",
+            "ScrubPayload": "#/components/schemas/IRapidPayloadModelScrubPayloadModel",
+            "TranscriptionPayload": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         }
       },
-      "IRapidPayloadBoundingBoxPayload": {
+      "IRapidPayloadModelBoundingBoxPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33356,7 +33371,7 @@
           }
         }
       },
-      "IRapidPayloadClassifyPayload": {
+      "IRapidPayloadModelClassifyPayloadModel": {
         "required": [
           "categories",
           "title",
@@ -33372,7 +33387,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyPayloadModel_Category"
             }
           },
           "title": {
@@ -33380,7 +33395,7 @@
           }
         }
       },
-      "IRapidPayloadComparePayload": {
+      "IRapidPayloadModelComparePayloadModel": {
         "required": [
           "criteria",
           "_t"
@@ -33397,7 +33412,7 @@
           }
         }
       },
-      "IRapidPayloadFreeTextPayload": {
+      "IRapidPayloadModelFreeTextPayloadModel": {
         "required": [
           "question",
           "_t"
@@ -33421,7 +33436,7 @@
           }
         }
       },
-      "IRapidPayloadLinePayload": {
+      "IRapidPayloadModelLinePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33438,7 +33453,7 @@
           }
         }
       },
-      "IRapidPayloadLocatePayload": {
+      "IRapidPayloadModelLocatePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33455,7 +33470,7 @@
           }
         }
       },
-      "IRapidPayloadNamedEntityPayload": {
+      "IRapidPayloadModelNamedEntityPayloadModel": {
         "required": [
           "target",
           "classes",
@@ -33479,7 +33494,7 @@
           }
         }
       },
-      "IRapidPayloadPolygonPayload": {
+      "IRapidPayloadModelPolygonPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33496,7 +33511,7 @@
           }
         }
       },
-      "IRapidPayloadScrubPayload": {
+      "IRapidPayloadModelScrubPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -33513,7 +33528,7 @@
           }
         }
       },
-      "IRapidPayloadTranscriptionPayload": {
+      "IRapidPayloadModelTranscriptionPayloadModel": {
         "required": [
           "title",
           "transcription",
@@ -33532,72 +33547,72 @@
           "transcription": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionPayloadModel_TranscriptionWord"
             }
           }
         }
       },
-      "IRapidResult": {
+      "IRapidResultModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidResultTranscriptionResult"
+            "$ref": "#/components/schemas/IRapidResultModelAttachCategoryResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultScrubResult"
+            "$ref": "#/components/schemas/IRapidResultModelBoundingBoxResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultPolygonResult"
+            "$ref": "#/components/schemas/IRapidResultModelCompareResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultNamedEntityResult"
+            "$ref": "#/components/schemas/IRapidResultModelFreeTextResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultLocateResult"
+            "$ref": "#/components/schemas/IRapidResultModelLineResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultLineResult"
+            "$ref": "#/components/schemas/IRapidResultModelLocateResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultFreeTextResult"
+            "$ref": "#/components/schemas/IRapidResultModelNamedEntityResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultCompareResult"
+            "$ref": "#/components/schemas/IRapidResultModelPolygonResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultSkipResult"
+            "$ref": "#/components/schemas/IRapidResultModelScrubResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultAttachCategoryResult"
+            "$ref": "#/components/schemas/IRapidResultModelSkipResultModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "$ref": "#/components/schemas/IRapidResultModelTranscriptionResultModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionResult": "#/components/schemas/IRapidResultTranscriptionResult",
-            "ScrubResult": "#/components/schemas/IRapidResultScrubResult",
-            "PolygonResult": "#/components/schemas/IRapidResultPolygonResult",
-            "NamedEntityResult": "#/components/schemas/IRapidResultNamedEntityResult",
-            "LocateResult": "#/components/schemas/IRapidResultLocateResult",
-            "LineResult": "#/components/schemas/IRapidResultLineResult",
-            "FreeTextResult": "#/components/schemas/IRapidResultFreeTextResult",
-            "CompareResult": "#/components/schemas/IRapidResultCompareResult",
-            "SkipResult": "#/components/schemas/IRapidResultSkipResult",
-            "AttachCategoryResult": "#/components/schemas/IRapidResultAttachCategoryResult",
-            "BoundingBoxResult": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "AttachCategoryResult": "#/components/schemas/IRapidResultModelAttachCategoryResultModel",
+            "BoundingBoxResult": "#/components/schemas/IRapidResultModelBoundingBoxResultModel",
+            "CompareResult": "#/components/schemas/IRapidResultModelCompareResultModel",
+            "FreeTextResult": "#/components/schemas/IRapidResultModelFreeTextResultModel",
+            "LineResult": "#/components/schemas/IRapidResultModelLineResultModel",
+            "LocateResult": "#/components/schemas/IRapidResultModelLocateResultModel",
+            "NamedEntityResult": "#/components/schemas/IRapidResultModelNamedEntityResultModel",
+            "PolygonResult": "#/components/schemas/IRapidResultModelPolygonResultModel",
+            "ScrubResult": "#/components/schemas/IRapidResultModelScrubResultModel",
+            "SkipResult": "#/components/schemas/IRapidResultModelSkipResultModel",
+            "TranscriptionResult": "#/components/schemas/IRapidResultModelTranscriptionResultModel"
           }
         }
       },
-      "IRapidResultAttachCategoryResult": {
+      "IRapidResultModelAttachCategoryResultModel": {
         "required": [
-          "category",
           "rapidId",
+          "category",
           "_t"
         ],
         "properties": {
@@ -33607,18 +33622,18 @@
             ],
             "type": "string"
           },
-          "category": {
+          "rapidId": {
             "type": "string"
           },
-          "rapidId": {
+          "category": {
             "type": "string"
           }
         }
       },
-      "IRapidResultBoundingBoxResult": {
+      "IRapidResultModelBoundingBoxResultModel": {
         "required": [
-          "boundingBoxes",
           "rapidId",
+          "boundingBoxes",
           "_t"
         ],
         "properties": {
@@ -33628,18 +33643,18 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "boundingBoxes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BoxShape"
+              "$ref": "#/components/schemas/BoundingBoxResultModel_Box"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultCompareResult": {
+      "IRapidResultModelCompareResultModel": {
         "required": [
           "rapidId",
           "_t"
@@ -33651,21 +33666,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "winners": {
             "type": "array",
             "items": {
               "type": "string"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultFreeTextResult": {
+      "IRapidResultModelFreeTextResultModel": {
         "required": [
-          "answer",
           "rapidId",
+          "answer",
           "_t"
         ],
         "properties": {
@@ -33675,18 +33690,18 @@
             ],
             "type": "string"
           },
-          "answer": {
+          "rapidId": {
             "type": "string"
           },
-          "rapidId": {
+          "answer": {
             "type": "string"
           }
         }
       },
-      "IRapidResultLineResult": {
+      "IRapidResultModelLineResultModel": {
         "required": [
-          "lines",
           "rapidId",
+          "lines",
           "_t"
         ],
         "properties": {
@@ -33696,21 +33711,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "lines": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_Line"
+              "$ref": "#/components/schemas/LineResultModel_Line"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultLocateResult": {
+      "IRapidResultModelLocateResultModel": {
         "required": [
-          "coordinates",
           "rapidId",
+          "coordinates",
           "_t"
         ],
         "properties": {
@@ -33720,21 +33735,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LocateCoordinate"
+              "$ref": "#/components/schemas/LocateCoordinateModel"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultNamedEntityResult": {
+      "IRapidResultModelNamedEntityResultModel": {
         "required": [
-          "classifications",
           "rapidId",
+          "classifications",
           "_t"
         ],
         "properties": {
@@ -33744,21 +33759,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "classifications": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NamedClassification"
+              "$ref": "#/components/schemas/NamedEntityResultModel_NamedClassification"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultPolygonResult": {
+      "IRapidResultModelPolygonResultModel": {
         "required": [
-          "shapes",
           "rapidId",
+          "shapes",
           "_t"
         ],
         "properties": {
@@ -33768,21 +33783,21 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "shapes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Shape"
+              "$ref": "#/components/schemas/PolygonResultModel_Shape"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultScrubResult": {
+      "IRapidResultModelScrubResultModel": {
         "required": [
-          "timestamps",
           "rapidId",
+          "timestamps",
           "_t"
         ],
         "properties": {
@@ -33792,19 +33807,19 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "timestamps": {
             "type": "array",
             "items": {
               "type": "integer",
               "format": "int32"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRapidResultSkipResult": {
+      "IRapidResultModelSkipResultModel": {
         "required": [
           "rapidId",
           "_t"
@@ -33821,10 +33836,10 @@
           }
         }
       },
-      "IRapidResultTranscriptionResult": {
+      "IRapidResultModelTranscriptionResultModel": {
         "required": [
-          "selectedWords",
           "rapidId",
+          "selectedWords",
           "_t"
         ],
         "properties": {
@@ -33834,47 +33849,47 @@
             ],
             "type": "string"
           },
+          "rapidId": {
+            "type": "string"
+          },
           "selectedWords": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionResultModel_TranscriptionWord"
             }
-          },
-          "rapidId": {
-            "type": "string"
           }
         }
       },
-      "IRefereeInfo": {
+      "IRefereeInfoModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRefereeInfoQuorumRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelNaiveRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoProbabilisticAttachCategoryRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelNeverEndingRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoNeverEndingRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel"
           },
           {
-            "$ref": "#/components/schemas/IRefereeInfoNaiveRefereeInfo"
+            "$ref": "#/components/schemas/IRefereeInfoModelQuorumRefereeInfoModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "QuorumRefereeInfo": "#/components/schemas/IRefereeInfoQuorumRefereeInfo",
-            "ProbabilisticAttachCategoryRefereeInfo": "#/components/schemas/IRefereeInfoProbabilisticAttachCategoryRefereeInfo",
-            "NeverEndingRefereeInfo": "#/components/schemas/IRefereeInfoNeverEndingRefereeInfo",
-            "NaiveRefereeInfo": "#/components/schemas/IRefereeInfoNaiveRefereeInfo"
+            "NaiveRefereeInfo": "#/components/schemas/IRefereeInfoModelNaiveRefereeInfoModel",
+            "NeverEndingRefereeInfo": "#/components/schemas/IRefereeInfoModelNeverEndingRefereeInfoModel",
+            "ProbabilisticAttachCategoryRefereeInfo": "#/components/schemas/IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel",
+            "QuorumRefereeInfo": "#/components/schemas/IRefereeInfoModelQuorumRefereeInfoModel"
           }
         }
       },
-      "IRefereeInfoNaiveRefereeInfo": {
+      "IRefereeInfoModelNaiveRefereeInfoModel": {
         "required": [
           "_t"
         ],
@@ -33895,7 +33910,7 @@
           }
         }
       },
-      "IRefereeInfoNeverEndingRefereeInfo": {
+      "IRefereeInfoModelNeverEndingRefereeInfoModel": {
         "required": [
           "_t"
         ],
@@ -33908,7 +33923,7 @@
           }
         }
       },
-      "IRefereeInfoProbabilisticAttachCategoryRefereeInfo": {
+      "IRefereeInfoModelProbabilisticAttachCategoryRefereeInfoModel": {
         "required": [
           "threshold",
           "maxVotes",
@@ -33931,7 +33946,7 @@
           }
         }
       },
-      "IRefereeInfoQuorumRefereeInfo": {
+      "IRefereeInfoModelQuorumRefereeInfoModel": {
         "required": [
           "maxVotes",
           "threshold",
@@ -33963,191 +33978,6 @@
           "isValid": {
             "type": "boolean",
             "description": "Whether the rapid bag is valid."
-          }
-        }
-      },
-      "IValidationTruth": {
-        "required": [
-          "_t"
-        ],
-        "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/IValidationTruthTranscriptionTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthScrubTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthPolygonTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthNamedEntityTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthLocateBoxTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthLineTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthEmptyValidationTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthCompareTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthMultiCompareTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthSkipTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthAttachCategoryTruth"
-          },
-          {
-            "$ref": "#/components/schemas/IValidationTruthBoundingBoxTruth"
-          }
-        ],
-        "discriminator": {
-          "propertyName": "_t",
-          "mapping": {
-            "TranscriptionTruth": "#/components/schemas/IValidationTruthTranscriptionTruth",
-            "ScrubTruth": "#/components/schemas/IValidationTruthScrubTruth",
-            "PolygonTruth": "#/components/schemas/IValidationTruthPolygonTruth",
-            "NamedEntityTruth": "#/components/schemas/IValidationTruthNamedEntityTruth",
-            "LocateBoxTruth": "#/components/schemas/IValidationTruthLocateBoxTruth",
-            "LineTruth": "#/components/schemas/IValidationTruthLineTruth",
-            "EmptyValidationTruth": "#/components/schemas/IValidationTruthEmptyValidationTruth",
-            "CompareTruth": "#/components/schemas/IValidationTruthCompareTruth",
-            "MultiCompareTruth": "#/components/schemas/IValidationTruthMultiCompareTruth",
-            "SkipTruth": "#/components/schemas/IValidationTruthSkipTruth",
-            "AttachCategoryTruth": "#/components/schemas/IValidationTruthAttachCategoryTruth",
-            "BoundingBoxTruth": "#/components/schemas/IValidationTruthBoundingBoxTruth"
-          }
-        }
-      },
-      "IValidationTruthAttachCategoryTruth": {
-        "required": [
-          "correctCategories",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "AttachCategoryTruth"
-            ],
-            "type": "string"
-          },
-          "correctCategories": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "IValidationTruthBoundingBoxTruth": {
-        "required": [
-          "xMin",
-          "yMin",
-          "xMax",
-          "yMax",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "BoundingBoxTruth"
-            ],
-            "type": "string"
-          },
-          "xMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "xMax": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMax": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "IValidationTruthCompareTruth": {
-        "required": [
-          "winnerId",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "CompareTruth"
-            ],
-            "type": "string"
-          },
-          "winnerId": {
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthEmptyValidationTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "EmptyValidationTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthLineTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "LineTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthLocateBoxTruth": {
-        "required": [
-          "boundingBoxes",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "LocateBoxTruth"
-            ],
-            "type": "string"
-          },
-          "boundingBoxes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BoxShape"
-            }
-          },
-          "requiredPrecision": {
-            "type": "number",
-            "format": "double"
-          },
-          "requiredCompleteness": {
-            "type": "number",
-            "format": "double"
           }
         }
       },
@@ -34347,7 +34177,7 @@
           "boundingBoxes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BoxShape"
+              "$ref": "#/components/schemas/LocateBoxTruthModel_Box"
             }
           },
           "requiredPrecision": {
@@ -34398,7 +34228,7 @@
           "classifications": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NamedClassification"
+              "$ref": "#/components/schemas/NamedEntityTruthModel_NamedClassification"
             }
           }
         }
@@ -34431,7 +34261,7 @@
           "validRanges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScrubRange"
+              "$ref": "#/components/schemas/ScrubTruthModel_ScrubRange"
             }
           }
         }
@@ -34464,7 +34294,7 @@
           "correctWords": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionTruthModel_TranscriptionWord"
             }
           },
           "strictGrading": {
@@ -34481,128 +34311,7 @@
           }
         }
       },
-      "IValidationTruthMultiCompareTruth": {
-        "required": [
-          "correctCombinations",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "MultiCompareTruth"
-            ],
-            "type": "string"
-          },
-          "correctCombinations": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "IValidationTruthNamedEntityTruth": {
-        "required": [
-          "classifications",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "NamedEntityTruth"
-            ],
-            "type": "string"
-          },
-          "classifications": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NamedClassification"
-            }
-          }
-        }
-      },
-      "IValidationTruthPolygonTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "PolygonTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthScrubTruth": {
-        "required": [
-          "validRanges",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "ScrubTruth"
-            ],
-            "type": "string"
-          },
-          "validRanges": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ScrubRange"
-            }
-          }
-        }
-      },
-      "IValidationTruthSkipTruth": {
-        "required": [
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "SkipTruth"
-            ],
-            "type": "string"
-          }
-        }
-      },
-      "IValidationTruthTranscriptionTruth": {
-        "required": [
-          "correctWords",
-          "_t"
-        ],
-        "properties": {
-          "_t": {
-            "enum": [
-              "TranscriptionTruth"
-            ],
-            "type": "string"
-          },
-          "correctWords": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
-            }
-          },
-          "strictGrading": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "requiredPrecision": {
-            "type": "number",
-            "format": "double"
-          },
-          "requiredCompleteness": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "LineResult_Line": {
+      "LineResultModel_Line": {
         "required": [
           "size",
           "points"
@@ -34616,12 +34325,12 @@
           "points": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_LinePoint"
+              "$ref": "#/components/schemas/LineResultModel_LinePoint"
             }
           }
         }
       },
-      "LineResult_LinePoint": {
+      "LineResultModel_LinePoint": {
         "required": [
           "x",
           "y"
@@ -34638,7 +34347,28 @@
           }
         }
       },
-      "LocateCoordinate": {
+      "LocateBoxTruthModel_Box": {
+        "type": "object",
+        "properties": {
+          "xMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "xMax": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMax": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "LocateCoordinateModel": {
         "required": [
           "x",
           "y"
@@ -34655,7 +34385,7 @@
           }
         }
       },
-      "NamedClassification": {
+      "NamedEntityResultModel_NamedClassification": {
         "required": [
           "start",
           "end",
@@ -34676,7 +34406,28 @@
           }
         }
       },
-      "PolygonResult_Coordinate": {
+      "NamedEntityTruthModel_NamedClassification": {
+        "required": [
+          "start",
+          "end",
+          "classification"
+        ],
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "classification": {
+            "type": "string"
+          }
+        }
+      },
+      "PolygonResultModel_Coordinate": {
         "required": [
           "x",
           "y"
@@ -34693,7 +34444,7 @@
           }
         }
       },
-      "PolygonResult_Shape": {
+      "PolygonResultModel_Shape": {
         "required": [
           "edges"
         ],
@@ -34702,7 +34453,7 @@
           "edges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Coordinate"
+              "$ref": "#/components/schemas/PolygonResultModel_Coordinate"
             }
           }
         }
@@ -34732,7 +34483,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -34740,7 +34491,7 @@
           "referee": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRefereeInfo"
+                "$ref": "#/components/schemas/IRefereeInfoModel"
               }
             ],
             "description": "The referee that created the rapid."
@@ -34756,7 +34507,7 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
@@ -34772,7 +34523,7 @@
           "truth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The optional validation truth of the rapid."
@@ -34927,7 +34678,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -34945,7 +34696,7 @@
           "truth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The derived validation truth for the rapid."
@@ -34985,7 +34736,7 @@
           }
         }
       },
-      "RapidIssue": {
+      "RapidIssueModel": {
         "enum": [
           "Other",
           "CannotSubmit",
@@ -34999,7 +34750,7 @@
           "MyAnswerIsCorrect"
         ]
       },
-      "RapidState": {
+      "RapidStateModel": {
         "enum": [
           "Labeling",
           "Paused",
@@ -35019,7 +34770,7 @@
           "issue": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidIssue"
+                "$ref": "#/components/schemas/RapidIssueModel"
               }
             ],
             "description": "A streamlined enum representing common issues."
@@ -35041,7 +34792,7 @@
           }
         }
       },
-      "ScrubRange": {
+      "ScrubTruthModel_ScrubRange": {
         "required": [
           "start",
           "end"
@@ -35090,7 +34841,7 @@
           "validationTruth": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IValidationTruth"
+                "$ref": "#/components/schemas/IValidationTruthModel"
               }
             ],
             "description": "The validation truth applied, if any."
@@ -35110,7 +34861,39 @@
           }
         }
       },
-      "TranscriptionWord": {
+      "TranscriptionPayloadModel_TranscriptionWord": {
+        "required": [
+          "word",
+          "wordIndex"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TranscriptionResultModel_TranscriptionWord": {
+        "required": [
+          "word",
+          "wordIndex"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TranscriptionTruthModel_TranscriptionWord": {
         "required": [
           "word",
           "wordIndex"
@@ -35212,7 +34995,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload to use for the rapid."
@@ -35449,7 +35232,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -35490,7 +35273,7 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
@@ -35787,6 +35570,42 @@
         }
       },
       "AttachCategoryWorkflowRapidBlueprintModel_Category": {
+        "required": [
+          "label",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "BoxShape": {
+        "type": "object",
+        "properties": {
+          "xMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "xMax": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMax": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ClassifyCategory": {
         "required": [
           "label",
           "value"
@@ -36441,6 +36260,566 @@
           }
         }
       },
+      "IRapidPayload": {
+        "required": [
+          "_t"
+        ],
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadClassifyPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "_t",
+          "mapping": {
+            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload",
+            "ClassifyPayload": "#/components/schemas/IRapidPayloadClassifyPayload",
+            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
+            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
+            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
+            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
+            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
+            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
+            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
+            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+          }
+        }
+      },
+      "IRapidPayloadBoundingBoxPayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "BoundingBoxPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadClassifyPayload": {
+        "required": [
+          "categories",
+          "title",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ClassifyPayload"
+            ],
+            "type": "string"
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClassifyCategory"
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadComparePayload": {
+        "required": [
+          "criteria",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ComparePayload"
+            ],
+            "type": "string"
+          },
+          "criteria": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadFreeTextPayload": {
+        "required": [
+          "question",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "FreeTextPayload"
+            ],
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "shouldValidateResponse": {
+            "type": "boolean"
+          },
+          "validationSystemPrompt": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "IRapidPayloadLinePayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LinePayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadLocatePayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LocatePayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadNamedEntityPayload": {
+        "required": [
+          "target",
+          "classes",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "NamedEntityPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "classes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "IRapidPayloadPolygonPayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "PolygonPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadScrubPayload": {
+        "required": [
+          "target",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ScrubPayload"
+            ],
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidPayloadTranscriptionPayload": {
+        "required": [
+          "title",
+          "transcription",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "TranscriptionPayload"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "transcription": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionWord"
+            }
+          }
+        }
+      },
+      "IRapidResult": {
+        "required": [
+          "_t"
+        ],
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IRapidResultAttachCategoryResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultBoundingBoxResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultCompareResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultFreeTextResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultLineResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultLocateResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultNamedEntityResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultPolygonResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultScrubResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultSkipResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultTranscriptionResult"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "_t",
+          "mapping": {
+            "AttachCategoryResult": "#/components/schemas/IRapidResultAttachCategoryResult",
+            "BoundingBoxResult": "#/components/schemas/IRapidResultBoundingBoxResult",
+            "CompareResult": "#/components/schemas/IRapidResultCompareResult",
+            "FreeTextResult": "#/components/schemas/IRapidResultFreeTextResult",
+            "LineResult": "#/components/schemas/IRapidResultLineResult",
+            "LocateResult": "#/components/schemas/IRapidResultLocateResult",
+            "NamedEntityResult": "#/components/schemas/IRapidResultNamedEntityResult",
+            "PolygonResult": "#/components/schemas/IRapidResultPolygonResult",
+            "ScrubResult": "#/components/schemas/IRapidResultScrubResult",
+            "SkipResult": "#/components/schemas/IRapidResultSkipResult",
+            "TranscriptionResult": "#/components/schemas/IRapidResultTranscriptionResult"
+          }
+        }
+      },
+      "IRapidResultAttachCategoryResult": {
+        "required": [
+          "category",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "AttachCategoryResult"
+            ],
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultBoundingBoxResult": {
+        "required": [
+          "boundingBoxes",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "BoundingBoxResult"
+            ],
+            "type": "string"
+          },
+          "boundingBoxes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BoxShape"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultCompareResult": {
+        "required": [
+          "winners",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "CompareResult"
+            ],
+            "type": "string"
+          },
+          "winners": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultFreeTextResult": {
+        "required": [
+          "answer",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "FreeTextResult"
+            ],
+            "type": "string"
+          },
+          "answer": {
+            "type": "string"
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultLineResult": {
+        "required": [
+          "lines",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LineResult"
+            ],
+            "type": "string"
+          },
+          "lines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Line"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultLocateResult": {
+        "required": [
+          "coordinates",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "LocateResult"
+            ],
+            "type": "string"
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocateCoordinate"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultNamedEntityResult": {
+        "required": [
+          "classifications",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "NamedEntityResult"
+            ],
+            "type": "string"
+          },
+          "classifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NamedClassification"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultPolygonResult": {
+        "required": [
+          "shapes",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "PolygonResult"
+            ],
+            "type": "string"
+          },
+          "shapes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PolygonShape"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultScrubResult": {
+        "required": [
+          "timestamps",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ScrubResult"
+            ],
+            "type": "string"
+          },
+          "timestamps": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultSkipResult": {
+        "required": [
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "SkipResult"
+            ],
+            "type": "string"
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
+      "IRapidResultTranscriptionResult": {
+        "required": [
+          "selectedWords",
+          "rapidId",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "TranscriptionResult"
+            ],
+            "type": "string"
+          },
+          "selectedWords": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionWord"
+            }
+          },
+          "rapidId": {
+            "type": "string"
+          }
+        }
+      },
       "IRefereeConfigModel": {
         "required": [
           "_t"
@@ -37046,6 +37425,96 @@
           }
         }
       },
+      "Line": {
+        "required": [
+          "points"
+        ],
+        "type": "object",
+        "properties": {
+          "size": {
+            "type": "number",
+            "format": "double"
+          },
+          "points": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LinePoint"
+            }
+          }
+        }
+      },
+      "LinePoint": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "LocateCoordinate": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "NamedClassification": {
+        "required": [
+          "classification"
+        ],
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "end": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "classification": {
+            "type": "string"
+          }
+        }
+      },
+      "PolygonCoordinate": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "PolygonShape": {
+        "required": [
+          "edges"
+        ],
+        "type": "object",
+        "properties": {
+          "edges": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PolygonCoordinate"
+            }
+          }
+        }
+      },
       "QueryWorkflowsEndpoint_Output": {
         "required": [
           "workflow"
@@ -37095,11 +37564,37 @@
           }
         }
       },
+      "RapidState": {
+        "enum": [
+          "Labeling",
+          "Paused",
+          "Incomplete",
+          "Flagged",
+          "Done",
+          "None",
+          "Rejected"
+        ]
+      },
       "SortDirection": {
         "enum": [
           "Asc",
           "Desc"
         ]
+      },
+      "TranscriptionWord": {
+        "required": [
+          "word"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
       },
       "WorkflowState": {
         "enum": [

--- a/openapi/schemas/validation.openapi.json
+++ b/openapi/schemas/validation.openapi.json
@@ -1282,7 +1282,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload to use for the rapid."
@@ -1345,31 +1345,9 @@
           "type": "string"
         }
       },
-      "BoxShape": {
-        "type": "object",
-        "properties": {
-          "xMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMin": {
-            "type": "number",
-            "format": "double"
-          },
-          "xMax": {
-            "type": "number",
-            "format": "double"
-          },
-          "yMax": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "ClassifyPayload_Category": {
+      "ClassifyPayloadModel_Category": {
         "required": [
-          "label",
-          "value"
+          "label"
         ],
         "type": "object",
         "properties": {
@@ -1377,7 +1355,8 @@
             "type": "string"
           },
           "value": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -1578,7 +1557,7 @@
           "payload": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/IRapidPayload"
+                "$ref": "#/components/schemas/IRapidPayloadModel"
               }
             ],
             "description": "The payload of the rapid."
@@ -1619,7 +1598,7 @@
           "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RapidState"
+                "$ref": "#/components/schemas/RapidStateModel"
               }
             ],
             "description": "The state of the rapid."
@@ -2242,60 +2221,60 @@
           }
         }
       },
-      "IRapidPayload": {
+      "IRapidPayloadModel": {
         "required": [
           "_t"
         ],
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelComparePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLinePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelLocatePayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadClassifyPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelScrubPayloadModel"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "$ref": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload",
-            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
-            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
-            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
-            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
-            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
-            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
-            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
-            "ClassifyPayload": "#/components/schemas/IRapidPayloadClassifyPayload",
-            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadModelBoundingBoxPayloadModel",
+            "ClassifyPayload": "#/components/schemas/IRapidPayloadModelClassifyPayloadModel",
+            "ComparePayload": "#/components/schemas/IRapidPayloadModelComparePayloadModel",
+            "FreeTextPayload": "#/components/schemas/IRapidPayloadModelFreeTextPayloadModel",
+            "LinePayload": "#/components/schemas/IRapidPayloadModelLinePayloadModel",
+            "LocatePayload": "#/components/schemas/IRapidPayloadModelLocatePayloadModel",
+            "NamedEntityPayload": "#/components/schemas/IRapidPayloadModelNamedEntityPayloadModel",
+            "PolygonPayload": "#/components/schemas/IRapidPayloadModelPolygonPayloadModel",
+            "ScrubPayload": "#/components/schemas/IRapidPayloadModelScrubPayloadModel",
+            "TranscriptionPayload": "#/components/schemas/IRapidPayloadModelTranscriptionPayloadModel"
           }
         }
       },
-      "IRapidPayloadBoundingBoxPayload": {
+      "IRapidPayloadModelBoundingBoxPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2312,7 +2291,7 @@
           }
         }
       },
-      "IRapidPayloadClassifyPayload": {
+      "IRapidPayloadModelClassifyPayloadModel": {
         "required": [
           "categories",
           "title",
@@ -2328,7 +2307,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyPayloadModel_Category"
             }
           },
           "title": {
@@ -2336,7 +2315,7 @@
           }
         }
       },
-      "IRapidPayloadComparePayload": {
+      "IRapidPayloadModelComparePayloadModel": {
         "required": [
           "criteria",
           "_t"
@@ -2353,7 +2332,7 @@
           }
         }
       },
-      "IRapidPayloadFreeTextPayload": {
+      "IRapidPayloadModelFreeTextPayloadModel": {
         "required": [
           "question",
           "_t"
@@ -2377,7 +2356,7 @@
           }
         }
       },
-      "IRapidPayloadLinePayload": {
+      "IRapidPayloadModelLinePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2394,7 +2373,7 @@
           }
         }
       },
-      "IRapidPayloadLocatePayload": {
+      "IRapidPayloadModelLocatePayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2411,7 +2390,7 @@
           }
         }
       },
-      "IRapidPayloadNamedEntityPayload": {
+      "IRapidPayloadModelNamedEntityPayloadModel": {
         "required": [
           "target",
           "classes",
@@ -2435,7 +2414,7 @@
           }
         }
       },
-      "IRapidPayloadPolygonPayload": {
+      "IRapidPayloadModelPolygonPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2452,7 +2431,7 @@
           }
         }
       },
-      "IRapidPayloadScrubPayload": {
+      "IRapidPayloadModelScrubPayloadModel": {
         "required": [
           "target",
           "_t"
@@ -2469,7 +2448,7 @@
           }
         }
       },
-      "IRapidPayloadTranscriptionPayload": {
+      "IRapidPayloadModelTranscriptionPayloadModel": {
         "required": [
           "title",
           "transcription",
@@ -2488,7 +2467,7 @@
           "transcription": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionPayloadModel_TranscriptionWord"
             }
           }
         }
@@ -2689,7 +2668,7 @@
           "boundingBoxes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BoxShape"
+              "$ref": "#/components/schemas/LocateBoxTruthModel_Box"
             }
           },
           "requiredPrecision": {
@@ -2740,7 +2719,7 @@
           "classifications": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NamedClassification"
+              "$ref": "#/components/schemas/NamedEntityTruthModel_NamedClassification"
             }
           }
         }
@@ -2773,7 +2752,7 @@
           "validRanges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScrubRange"
+              "$ref": "#/components/schemas/ScrubTruthModel_ScrubRange"
             }
           }
         }
@@ -2806,7 +2785,7 @@
           "correctWords": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TranscriptionWord"
+              "$ref": "#/components/schemas/TranscriptionTruthModel_TranscriptionWord"
             }
           },
           "strictGrading": {
@@ -2818,6 +2797,27 @@
             "format": "double"
           },
           "requiredCompleteness": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "LocateBoxTruthModel_Box": {
+        "type": "object",
+        "properties": {
+          "xMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMin": {
+            "type": "number",
+            "format": "double"
+          },
+          "xMax": {
+            "type": "number",
+            "format": "double"
+          },
+          "yMax": {
             "type": "number",
             "format": "double"
           }
@@ -2849,7 +2849,7 @@
           "type": "string"
         }
       },
-      "NamedClassification": {
+      "NamedEntityTruthModel_NamedClassification": {
         "required": [
           "start",
           "end",
@@ -3012,7 +3012,7 @@
           "type": "string"
         }
       },
-      "RapidState": {
+      "RapidStateModel": {
         "enum": [
           "Labeling",
           "Paused",
@@ -3023,7 +3023,7 @@
           "Rejected"
         ]
       },
-      "ScrubRange": {
+      "ScrubTruthModel_ScrubRange": {
         "required": [
           "start",
           "end"
@@ -3040,7 +3040,23 @@
           }
         }
       },
-      "TranscriptionWord": {
+      "TranscriptionPayloadModel_TranscriptionWord": {
+        "required": [
+          "word",
+          "wordIndex"
+        ],
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          },
+          "wordIndex": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TranscriptionTruthModel_TranscriptionWord": {
         "required": [
           "word",
           "wordIndex"

--- a/openapi/schemas/workflow.openapi.json
+++ b/openapi/schemas/workflow.openapi.json
@@ -1057,7 +1057,7 @@
           }
         }
       },
-      "ClassifyPayload_Category": {
+      "ClassifyCategory": {
         "required": [
           "label",
           "value"
@@ -2166,49 +2166,49 @@
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
           },
           {
             "$ref": "#/components/schemas/IRapidPayloadClassifyPayload"
           },
           {
-            "$ref": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "$ref": "#/components/schemas/IRapidPayloadComparePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadFreeTextPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadLinePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadLocatePayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadNamedEntityPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadPolygonPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadScrubPayload"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidPayloadTranscriptionPayload"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload",
-            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
-            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
-            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
-            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
-            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
-            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
-            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
+            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload",
             "ClassifyPayload": "#/components/schemas/IRapidPayloadClassifyPayload",
-            "BoundingBoxPayload": "#/components/schemas/IRapidPayloadBoundingBoxPayload"
+            "ComparePayload": "#/components/schemas/IRapidPayloadComparePayload",
+            "FreeTextPayload": "#/components/schemas/IRapidPayloadFreeTextPayload",
+            "LinePayload": "#/components/schemas/IRapidPayloadLinePayload",
+            "LocatePayload": "#/components/schemas/IRapidPayloadLocatePayload",
+            "NamedEntityPayload": "#/components/schemas/IRapidPayloadNamedEntityPayload",
+            "PolygonPayload": "#/components/schemas/IRapidPayloadPolygonPayload",
+            "ScrubPayload": "#/components/schemas/IRapidPayloadScrubPayload",
+            "TranscriptionPayload": "#/components/schemas/IRapidPayloadTranscriptionPayload"
           }
         }
       },
@@ -2245,7 +2245,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ClassifyPayload_Category"
+              "$ref": "#/components/schemas/ClassifyCategory"
             }
           },
           "title": {
@@ -2417,53 +2417,53 @@
         "type": "object",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IRapidResultTranscriptionResult"
+            "$ref": "#/components/schemas/IRapidResultAttachCategoryResult"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultScrubResult"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidResultPolygonResult"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidResultNamedEntityResult"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidResultLocateResult"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidResultLineResult"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidResultFreeTextResult"
+            "$ref": "#/components/schemas/IRapidResultBoundingBoxResult"
           },
           {
             "$ref": "#/components/schemas/IRapidResultCompareResult"
           },
           {
+            "$ref": "#/components/schemas/IRapidResultFreeTextResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultLineResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultLocateResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultNamedEntityResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultPolygonResult"
+          },
+          {
+            "$ref": "#/components/schemas/IRapidResultScrubResult"
+          },
+          {
             "$ref": "#/components/schemas/IRapidResultSkipResult"
           },
           {
-            "$ref": "#/components/schemas/IRapidResultAttachCategoryResult"
-          },
-          {
-            "$ref": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "$ref": "#/components/schemas/IRapidResultTranscriptionResult"
           }
         ],
         "discriminator": {
           "propertyName": "_t",
           "mapping": {
-            "TranscriptionResult": "#/components/schemas/IRapidResultTranscriptionResult",
-            "ScrubResult": "#/components/schemas/IRapidResultScrubResult",
-            "PolygonResult": "#/components/schemas/IRapidResultPolygonResult",
-            "NamedEntityResult": "#/components/schemas/IRapidResultNamedEntityResult",
-            "LocateResult": "#/components/schemas/IRapidResultLocateResult",
-            "LineResult": "#/components/schemas/IRapidResultLineResult",
-            "FreeTextResult": "#/components/schemas/IRapidResultFreeTextResult",
-            "CompareResult": "#/components/schemas/IRapidResultCompareResult",
-            "SkipResult": "#/components/schemas/IRapidResultSkipResult",
             "AttachCategoryResult": "#/components/schemas/IRapidResultAttachCategoryResult",
-            "BoundingBoxResult": "#/components/schemas/IRapidResultBoundingBoxResult"
+            "BoundingBoxResult": "#/components/schemas/IRapidResultBoundingBoxResult",
+            "CompareResult": "#/components/schemas/IRapidResultCompareResult",
+            "FreeTextResult": "#/components/schemas/IRapidResultFreeTextResult",
+            "LineResult": "#/components/schemas/IRapidResultLineResult",
+            "LocateResult": "#/components/schemas/IRapidResultLocateResult",
+            "NamedEntityResult": "#/components/schemas/IRapidResultNamedEntityResult",
+            "PolygonResult": "#/components/schemas/IRapidResultPolygonResult",
+            "ScrubResult": "#/components/schemas/IRapidResultScrubResult",
+            "SkipResult": "#/components/schemas/IRapidResultSkipResult",
+            "TranscriptionResult": "#/components/schemas/IRapidResultTranscriptionResult"
           }
         }
       },
@@ -2514,6 +2514,7 @@
       },
       "IRapidResultCompareResult": {
         "required": [
+          "winners",
           "rapidId",
           "_t"
         ],
@@ -2572,7 +2573,7 @@
           "lines": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_Line"
+              "$ref": "#/components/schemas/Line"
             }
           },
           "rapidId": {
@@ -2644,7 +2645,7 @@
           "shapes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Shape"
+              "$ref": "#/components/schemas/PolygonShape"
             }
           },
           "rapidId": {
@@ -3323,9 +3324,8 @@
           }
         }
       },
-      "LineResult_Line": {
+      "Line": {
         "required": [
-          "size",
           "points"
         ],
         "type": "object",
@@ -3337,16 +3337,12 @@
           "points": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LineResult_LinePoint"
+              "$ref": "#/components/schemas/LinePoint"
             }
           }
         }
       },
-      "LineResult_LinePoint": {
-        "required": [
-          "x",
-          "y"
-        ],
+      "LinePoint": {
         "type": "object",
         "properties": {
           "x": {
@@ -3360,10 +3356,6 @@
         }
       },
       "LocateCoordinate": {
-        "required": [
-          "x",
-          "y"
-        ],
         "type": "object",
         "properties": {
           "x": {
@@ -3384,8 +3376,6 @@
       },
       "NamedClassification": {
         "required": [
-          "start",
-          "end",
           "classification"
         ],
         "type": "object",
@@ -3403,11 +3393,7 @@
           }
         }
       },
-      "PolygonResult_Coordinate": {
-        "required": [
-          "x",
-          "y"
-        ],
+      "PolygonCoordinate": {
         "type": "object",
         "properties": {
           "x": {
@@ -3420,7 +3406,7 @@
           }
         }
       },
-      "PolygonResult_Shape": {
+      "PolygonShape": {
         "required": [
           "edges"
         ],
@@ -3429,7 +3415,7 @@
           "edges": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PolygonResult_Coordinate"
+              "$ref": "#/components/schemas/PolygonCoordinate"
             }
           }
         }
@@ -3502,8 +3488,7 @@
       },
       "TranscriptionWord": {
         "required": [
-          "word",
-          "wordIndex"
+          "word"
         ],
         "type": "object",
         "properties": {

--- a/src/rapidata/api_client/models/i_example_truth_line_example_truth.py
+++ b/src/rapidata/api_client/models/i_example_truth_line_example_truth.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from rapidata.api_client.models.example_box_shape import ExampleBoxShape
 from pydantic import ValidationError
 from rapidata.api_client.lazy_model import LazyValidatedModel
 from typing import Optional, Set
@@ -29,7 +30,10 @@ class IExampleTruthLineExampleTruth(LazyValidatedModel):
     IExampleTruthLineExampleTruth
     """ # noqa: E501
     t: StrictStr = Field(alias="_t")
-    __properties: ClassVar[List[str]] = ["_t"]
+    bounding_boxes: Optional[List[ExampleBoxShape]] = Field(default=None, alias="boundingBoxes")
+    required_precision: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, alias="requiredPrecision")
+    required_completeness: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, alias="requiredCompleteness")
+    __properties: ClassVar[List[str]] = ["_t", "boundingBoxes", "requiredPrecision", "requiredCompleteness"]
 
     @field_validator('t')
     def t_validate_enum(cls, value):
@@ -73,6 +77,13 @@ class IExampleTruthLineExampleTruth(LazyValidatedModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of each item in bounding_boxes (list)
+        _items = []
+        if self.bounding_boxes:
+            for _item_bounding_boxes in self.bounding_boxes:
+                if _item_bounding_boxes:
+                    _items.append(_item_bounding_boxes.to_dict())
+            _dict['boundingBoxes'] = _items
         return _dict
 
     @classmethod
@@ -85,7 +96,10 @@ class IExampleTruthLineExampleTruth(LazyValidatedModel):
             return cls.model_validate(obj)
 
         _data = {
-            "_t": obj.get("_t")
+            "_t": obj.get("_t"),
+            "boundingBoxes": [ExampleBoxShape.from_dict(_item) for _item in obj["boundingBoxes"]] if obj.get("boundingBoxes") is not None else None,
+            "requiredPrecision": obj.get("requiredPrecision"),
+            "requiredCompleteness": obj.get("requiredCompleteness")
         }
         try:
             _obj = cls.model_validate(_data)

--- a/src/rapidata/rapidata_client/audience/audience_example_handler.py
+++ b/src/rapidata/rapidata_client/audience/audience_example_handler.py
@@ -13,17 +13,37 @@ from rapidata.api_client.models.i_example_payload_classify_example_payload impor
     IExamplePayloadClassifyExamplePayload,
 )
 from rapidata.api_client.models.example_category import ExampleCategory
+from rapidata.api_client.models.example_transcription_word import ExampleTranscriptionWord
 from rapidata.api_client.models.i_example_payload_compare_example_payload import (
     IExamplePayloadCompareExamplePayload,
 )
 from rapidata.api_client.models.i_example_truth_compare_example_truth import (
     IExampleTruthCompareExampleTruth,
 )
+from rapidata.api_client.models.i_example_payload_line_example_payload import (
+    IExamplePayloadLineExamplePayload,
+)
+from rapidata.api_client.models.i_example_truth_line_example_truth import (
+    IExampleTruthLineExampleTruth,
+)
+from rapidata.api_client.models.i_example_payload_locate_example_payload import (
+    IExamplePayloadLocateExamplePayload,
+)
+from rapidata.api_client.models.i_example_truth_locate_example_truth import (
+    IExampleTruthLocateExampleTruth,
+)
+from rapidata.api_client.models.i_example_payload_transcription_example_payload import (
+    IExamplePayloadTranscriptionExamplePayload,
+)
+from rapidata.api_client.models.i_example_truth_transcription_example_truth import (
+    IExampleTruthTranscriptionExampleTruth,
+)
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.api_client.models.i_example_payload import IExamplePayload
 from rapidata.api_client.models.i_example_truth import IExampleTruth
 from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.datapoints._asset_mapper import AssetMapper
+from rapidata.rapidata_client.validation.rapids.box import Box, calculate_boxes_coverage
 
 
 class AudienceExampleHandler:
@@ -187,6 +207,269 @@ class AudienceExampleHandler:
                 ),
                 explanation=explanation,
                 randomCorrectProbability=0.5,
+                featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
+            ),
+        )
+
+    def add_locate_example(
+        self,
+        instruction: str,
+        truth: list[Box],
+        datapoint: str,
+        required_precision: float | None = None,
+        required_completeness: float | None = None,
+        context: str | None = None,
+        media_context: str | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> None:
+        """Add a locate example to the audience.
+
+        Args:
+            instruction (str): Instruction shown to the labeler — what to locate.
+            truth (list[Box]): The bounding boxes that mark the correct regions.
+                The labeler's coordinate must fall inside at least one box.
+            datapoint (str): The image (URL or path) to use as the example.
+            required_precision (float, optional): Minimum fraction of the
+                labeler's coordinates that must fall inside the boxes. Defaults
+                to None (uses the platform's default).
+            required_completeness (float, optional): Minimum fraction of boxes
+                that must each contain at least one labeler coordinate. Defaults
+                to None.
+            context (str, optional): Extra text shown to the labeler. Defaults to None.
+            media_context (str, optional): Extra media (URL/path) shown alongside the
+                instruction. Defaults to None.
+            explanation (str, optional): Shown if the labeler answers wrong. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): Settings applied as feature
+                flags on the example. Defaults to None.
+        """
+        from rapidata.api_client.models.add_example_to_audience_endpoint_input import (
+            AddExampleToAudienceEndpointInput,
+        )
+
+        if not truth:
+            raise ValueError("Locate example requires at least one box in truth")
+
+        uploaded_name = self._asset_uploader.upload_asset(datapoint)
+        asset_input = self._asset_mapper.create_existing_asset_input(uploaded_name)
+
+        payload = IExamplePayload(
+            actual_instance=IExamplePayloadLocateExamplePayload(
+                _t="LocateExamplePayload", target=instruction
+            )
+        )
+        model_truth = IExampleTruth(
+            actual_instance=IExampleTruthLocateExampleTruth(
+                _t="LocateExampleTruth",
+                boundingBoxes=[box.to_model() for box in truth],
+                requiredPrecision=required_precision,
+                requiredCompleteness=required_completeness,
+            )
+        )
+
+        self._openapi_service.audience.examples_api.audience_audience_id_example_post(
+            audience_id=self._audience_id,
+            add_example_to_audience_endpoint_input=AddExampleToAudienceEndpointInput(
+                asset=asset_input,
+                payload=payload,
+                truth=model_truth,
+                context=context,
+                contextAsset=(
+                    self._asset_mapper.create_existing_asset_input(
+                        self._asset_uploader.upload_asset(media_context)
+                    )
+                    if media_context
+                    else None
+                ),
+                explanation=explanation,
+                randomCorrectProbability=calculate_boxes_coverage(truth),
+                featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
+            ),
+        )
+
+    def add_line_example(
+        self,
+        instruction: str,
+        datapoint: str,
+        truth: list[Box] | None = None,
+        required_precision: float | None = None,
+        required_completeness: float | None = None,
+        context: str | None = None,
+        media_context: str | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> None:
+        """Add a line (draw-a-line) example to the audience.
+
+        Args:
+            instruction (str): Instruction shown to the labeler — what to draw a line through.
+            datapoint (str): The image (URL or path) to use as the example.
+            truth (list[Box], optional): Optional bounding boxes the line must pass through.
+                When omitted (or empty), line examples are scored by annotator consensus
+                rather than against a ground truth. When provided, line points are graded
+                against the union of the boxes (precision + completeness, same as Locate).
+                Defaults to None.
+            required_precision (float, optional): Minimum fraction of line points that must
+                fall inside the boxes. Ignored when ``truth`` is omitted. Defaults to None.
+            required_completeness (float, optional): Minimum fraction of boxes that must
+                each contain at least one line point. Ignored when ``truth`` is omitted.
+                Defaults to None.
+            context (str, optional): Extra text shown to the labeler. Defaults to None.
+            media_context (str, optional): Extra media (URL/path) shown alongside the
+                instruction. Defaults to None.
+            explanation (str, optional): Shown if the labeler answers wrong. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): Settings applied as feature
+                flags on the example. Defaults to None.
+        """
+        from rapidata.api_client.models.add_example_to_audience_endpoint_input import (
+            AddExampleToAudienceEndpointInput,
+        )
+
+        uploaded_name = self._asset_uploader.upload_asset(datapoint)
+        asset_input = self._asset_mapper.create_existing_asset_input(uploaded_name)
+
+        payload = IExamplePayload(
+            actual_instance=IExamplePayloadLineExamplePayload(
+                _t="LineExamplePayload", target=instruction
+            )
+        )
+
+        # Narrow `truth` once so pyright sees `boxes` as list[Box] below.
+        boxes: list[Box] = truth if truth else []
+        has_boxes = len(boxes) > 0
+        model_truth = IExampleTruth(
+            actual_instance=IExampleTruthLineExampleTruth(
+                _t="LineExampleTruth",
+                boundingBoxes=[box.to_model() for box in boxes] if has_boxes else None,
+                requiredPrecision=required_precision if has_boxes else None,
+                requiredCompleteness=required_completeness if has_boxes else None,
+            )
+        )
+
+        # When boxes are provided, use the union-area as the random baseline
+        # (matches Locate). When none, line examples have no scorable ground
+        # truth — pick a small but non-zero number so the example still has
+        # recruiting weight (matches the dashboard form).
+        random_correct_probability = (
+            calculate_boxes_coverage(boxes) if has_boxes else 0.1
+        )
+
+        self._openapi_service.audience.examples_api.audience_audience_id_example_post(
+            audience_id=self._audience_id,
+            add_example_to_audience_endpoint_input=AddExampleToAudienceEndpointInput(
+                asset=asset_input,
+                payload=payload,
+                truth=model_truth,
+                context=context,
+                contextAsset=(
+                    self._asset_mapper.create_existing_asset_input(
+                        self._asset_uploader.upload_asset(media_context)
+                    )
+                    if media_context
+                    else None
+                ),
+                explanation=explanation,
+                randomCorrectProbability=random_correct_probability,
+                featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
+            ),
+        )
+
+    def add_transcription_example(
+        self,
+        instruction: str,
+        sentence: str,
+        truth: list[int],
+        datapoint: str,
+        required_precision: float | None = None,
+        required_completeness: float | None = None,
+        strict_grading: bool | None = None,
+        context: str | None = None,
+        media_context: str | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> None:
+        """Add a transcription (select-correct-words) example to the audience.
+
+        Args:
+            instruction (str): Instruction shown to the labeler.
+            sentence (str): The full transcription, split into words on whitespace.
+                Each whitespace-separated token becomes one selectable word.
+            truth (list[int]): Indices of the words (0-based, in the order they
+                appear in ``sentence``) that must be selected for a correct answer.
+            datapoint (str): The audio asset (URL or path) being transcribed.
+            required_precision (float, optional): Minimum fraction of selected words
+                that must be correct. Defaults to None.
+            required_completeness (float, optional): Minimum fraction of correct words
+                that must be selected. Defaults to None.
+            strict_grading (bool, optional): When True, missing required words are
+                penalised more harshly. Defaults to None.
+            context (str, optional): Extra text shown to the labeler. Defaults to None.
+            media_context (str, optional): Extra media (URL/path) shown alongside the
+                instruction. Defaults to None.
+            explanation (str, optional): Shown if the labeler answers wrong. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): Settings applied as feature
+                flags on the example. Defaults to None.
+        """
+        from rapidata.api_client.models.add_example_to_audience_endpoint_input import (
+            AddExampleToAudienceEndpointInput,
+        )
+
+        words = sentence.split(" ")
+        if not words:
+            raise ValueError("Transcription example requires a non-empty sentence")
+        if not truth:
+            raise ValueError("Transcription example requires at least one truth index")
+        for index in truth:
+            if index < 0 or index >= len(words):
+                raise ValueError(
+                    f"Truth index {index} is out of range for sentence with "
+                    f"{len(words)} words"
+                )
+
+        transcription_words = [
+            ExampleTranscriptionWord(word=word, wordIndex=i)
+            for i, word in enumerate(words)
+        ]
+        correct_words = [
+            ExampleTranscriptionWord(word=words[i], wordIndex=i) for i in truth
+        ]
+
+        uploaded_name = self._asset_uploader.upload_asset(datapoint)
+        asset_input = self._asset_mapper.create_existing_asset_input(uploaded_name)
+
+        payload = IExamplePayload(
+            actual_instance=IExamplePayloadTranscriptionExamplePayload(
+                _t="TranscriptionExamplePayload",
+                title=instruction,
+                transcription=transcription_words,
+            )
+        )
+        model_truth = IExampleTruth(
+            actual_instance=IExampleTruthTranscriptionExampleTruth(
+                _t="TranscriptionExampleTruth",
+                correctWords=correct_words,
+                strictGrading=strict_grading,
+                requiredPrecision=required_precision,
+                requiredCompleteness=required_completeness,
+            )
+        )
+
+        self._openapi_service.audience.examples_api.audience_audience_id_example_post(
+            audience_id=self._audience_id,
+            add_example_to_audience_endpoint_input=AddExampleToAudienceEndpointInput(
+                asset=asset_input,
+                payload=payload,
+                truth=model_truth,
+                context=context,
+                contextAsset=(
+                    self._asset_mapper.create_existing_asset_input(
+                        self._asset_uploader.upload_asset(media_context)
+                    )
+                    if media_context
+                    else None
+                ),
+                explanation=explanation,
+                randomCorrectProbability=len(correct_words) / len(transcription_words),
                 featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
             ),
         )

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     )
     from rapidata.rapidata_client.job.rapidata_job import RapidataJob
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
+    from rapidata.rapidata_client.validation.rapids.box import Box
     from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
     import pandas as pd
 
@@ -239,6 +240,179 @@ class RapidataAudience:
                 media_context,
                 explanation,
                 settings,
+            )
+            self._try_start_recruiting()
+            return self
+
+    def add_locate_example(
+        self,
+        instruction: str,
+        truth: list[Box],
+        datapoint: str,
+        required_precision: float | None = None,
+        required_completeness: float | None = None,
+        context: str | None = None,
+        media_context: str | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> RapidataAudience:
+        """Add a locate training example to this audience.
+
+        Annotators will be asked to click inside one of the regions described
+        by ``truth``. Their coordinate must fall in at least one of the boxes
+        for the example to be marked correct.
+
+        Args:
+            instruction (str): The instruction for what the labeler should locate.
+            truth (list[Box]): The bounding boxes that mark the correct regions.
+            datapoint (str): The image (URL or path) to use as the example.
+            required_precision (float, optional): Minimum fraction of the labeler's
+                coordinates that must fall inside the boxes. Defaults to None.
+            required_completeness (float, optional): Minimum fraction of boxes that
+                must each contain at least one labeler coordinate. Defaults to None.
+            context (str, optional): Additional text context. Defaults to None.
+            media_context (str, optional): Additional media (URL/path). Defaults to None.
+            explanation (str, optional): An explanation shown if wrong. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): Settings applied as feature
+                flags. Defaults to None.
+
+        Returns:
+            RapidataAudience: The audience instance (self) for method chaining.
+        """
+        with tracer.start_as_current_span("RapidataAudience.add_locate_example"):
+            logger.debug(
+                f"Adding locate example to audience: {self.id} with instruction: {instruction}, truth: {truth}, datapoint: {datapoint}"
+            )
+            self._example_handler.add_locate_example(
+                instruction=instruction,
+                truth=truth,
+                datapoint=datapoint,
+                required_precision=required_precision,
+                required_completeness=required_completeness,
+                context=context,
+                media_context=media_context,
+                explanation=explanation,
+                settings=settings,
+            )
+            self._try_start_recruiting()
+            return self
+
+    def add_line_example(
+        self,
+        instruction: str,
+        datapoint: str,
+        truth: list[Box] | None = None,
+        required_precision: float | None = None,
+        required_completeness: float | None = None,
+        context: str | None = None,
+        media_context: str | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> RapidataAudience:
+        """Add a line (draw-a-line) training example to this audience.
+
+        Annotators will be asked to draw a line through a region of the
+        image. When ``truth`` is omitted, line examples are scored by
+        annotator consensus rather than against a ground truth. When provided,
+        the line points are graded against the union of the boxes (precision +
+        completeness, same as Locate).
+
+        Args:
+            instruction (str): The instruction for what the labeler should draw a line through.
+            datapoint (str): The image (URL or path) to use as the example.
+            truth (list[Box], optional): Optional bounding boxes the line must pass
+                through. Omit (or pass an empty list) to score by consensus only.
+                Defaults to None.
+            required_precision (float, optional): Minimum fraction of line points that
+                must fall inside the boxes. Ignored when ``truth`` is omitted. Defaults
+                to None.
+            required_completeness (float, optional): Minimum fraction of boxes that
+                must each contain at least one line point. Ignored when ``truth`` is
+                omitted. Defaults to None.
+            context (str, optional): Additional text context. Defaults to None.
+            media_context (str, optional): Additional media (URL/path). Defaults to None.
+            explanation (str, optional): An explanation shown if wrong. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): Settings applied as feature
+                flags. Defaults to None.
+
+        Returns:
+            RapidataAudience: The audience instance (self) for method chaining.
+        """
+        with tracer.start_as_current_span("RapidataAudience.add_line_example"):
+            logger.debug(
+                f"Adding line example to audience: {self.id} with instruction: {instruction}, truth: {truth}, datapoint: {datapoint}"
+            )
+            self._example_handler.add_line_example(
+                instruction=instruction,
+                datapoint=datapoint,
+                truth=truth,
+                required_precision=required_precision,
+                required_completeness=required_completeness,
+                context=context,
+                media_context=media_context,
+                explanation=explanation,
+                settings=settings,
+            )
+            self._try_start_recruiting()
+            return self
+
+    def add_transcription_example(
+        self,
+        instruction: str,
+        sentence: str,
+        truth: list[int],
+        datapoint: str,
+        required_precision: float | None = None,
+        required_completeness: float | None = None,
+        strict_grading: bool | None = None,
+        context: str | None = None,
+        media_context: str | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> RapidataAudience:
+        """Add a transcription (select-correct-words) training example to this audience.
+
+        Annotators will be shown the audio and the full transcription, and asked
+        to click the words that must appear in a correct answer.
+
+        Args:
+            instruction (str): The instruction shown to the labeler.
+            sentence (str): The full transcription, split into words on whitespace.
+                Each whitespace-separated token becomes one selectable word.
+            truth (list[int]): Indices of the words (0-based) that must be selected
+                for a correct answer.
+            datapoint (str): The audio asset (URL or path) being transcribed.
+            required_precision (float, optional): Minimum fraction of selected words
+                that must be correct. Defaults to None.
+            required_completeness (float, optional): Minimum fraction of correct words
+                that must be selected. Defaults to None.
+            strict_grading (bool, optional): When True, missing required words are
+                penalised more harshly. Defaults to None.
+            context (str, optional): Additional text context. Defaults to None.
+            media_context (str, optional): Additional media (URL/path). Defaults to None.
+            explanation (str, optional): An explanation shown if wrong. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): Settings applied as feature
+                flags. Defaults to None.
+
+        Returns:
+            RapidataAudience: The audience instance (self) for method chaining.
+        """
+        with tracer.start_as_current_span("RapidataAudience.add_transcription_example"):
+            logger.debug(
+                f"Adding transcription example to audience: {self.id} with instruction: {instruction}, sentence: {sentence}, truth: {truth}, datapoint: {datapoint}"
+            )
+            self._example_handler.add_transcription_example(
+                instruction=instruction,
+                sentence=sentence,
+                truth=truth,
+                datapoint=datapoint,
+                required_precision=required_precision,
+                required_completeness=required_completeness,
+                strict_grading=strict_grading,
+                context=context,
+                media_context=media_context,
+                explanation=explanation,
+                settings=settings,
             )
             self._try_start_recruiting()
             return self

--- a/src/rapidata/rapidata_client/validation/rapids/box.py
+++ b/src/rapidata/rapidata_client/validation/rapids/box.py
@@ -40,3 +40,60 @@ class Box(BaseModel):
             xMax=self.x_max * 100,
             yMax=self.y_max * 100,
         )
+
+
+def calculate_boxes_coverage(boxes: list[Box]) -> float:
+    """Compute the union area of ``boxes`` as a 0–1 ratio of the asset.
+
+    Used as the ``random_correct_probability`` baseline when boxes are the
+    ground truth (Locate / Line audience examples, Locate / Line rapids).
+
+    Coordinates are in [0, 1] image-ratio space (matching ``Box``); overlaps
+    are not double-counted.
+
+    Args:
+        boxes: Boxes to union. Empty list returns 0.
+
+    Returns:
+        Coverage ratio in [0.0, 1.0].
+    """
+    if not boxes:
+        return 0.0
+
+    events: list[tuple[float, str, int]] = []
+    for i, box in enumerate(boxes):
+        events.append((box.x_min, "start", i))
+        events.append((box.x_max, "end", i))
+
+    events.sort(key=lambda e: (e[0], e[1] == "end"))
+
+    total_area = 0.0
+    active_boxes: set[int] = set()
+    prev_x = 0.0
+
+    for x, event_type, box_id in events:
+        if active_boxes and x > prev_x:
+            y_intervals = [(boxes[i].y_min, boxes[i].y_max) for i in active_boxes]
+            y_intervals.sort()
+
+            merged_intervals: list[tuple[float, float]] = []
+            for start, end in y_intervals:
+                if merged_intervals and start <= merged_intervals[-1][1]:
+                    merged_intervals[-1] = (
+                        merged_intervals[-1][0],
+                        max(merged_intervals[-1][1], end),
+                    )
+                else:
+                    merged_intervals.append((start, end))
+
+            y_coverage = sum(end - start for start, end in merged_intervals)
+            total_area += (x - prev_x) * y_coverage
+
+        if event_type == "start":
+            active_boxes.add(box_id)
+        else:
+            active_boxes.discard(box_id)
+
+        prev_x = x
+
+    return total_area

--- a/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
     from rapidata.service.openapi_service import OpenAPIService
 
-from rapidata.rapidata_client.validation.rapids.box import Box
+from rapidata.rapidata_client.validation.rapids.box import Box, calculate_boxes_coverage
 
 
 class RapidsManager:
@@ -412,66 +412,9 @@ class RapidsManager:
         )
 
     def _calculate_boxes_coverage(self, boxes: list[Box]) -> float:
-        """
-        Calculate the ratio of area covered by a list of boxes.
-
-        Args:
-            boxes: List of Box objects with coordinates in range [0, 1]
-
-        Returns:
-            float: Coverage ratio between 0.0 and 1.0
-        """
-        if not boxes:
-            return 0.0
-
-        # Convert boxes to intervals for sweep line algorithm
-        events = []
-
-        # Create events for x-coordinates
-        for i, box in enumerate(boxes):
-            events.append((box.x_min, "start", i, box))
-            events.append((box.x_max, "end", i, box))
-
-        # Sort events by x-coordinate
-        events.sort(key=lambda x: (x[0], x[1] == "end"))
-
-        total_area = 0.0
-        active_boxes = set()
-        prev_x = 0.0
-
-        for x, event_type, box_id, box in events:
-            # Calculate area for the previous x-interval
-            if active_boxes and x > prev_x:
-                # Merge y-intervals for active boxes
-                y_intervals = [(boxes[i].y_min, boxes[i].y_max) for i in active_boxes]
-                y_intervals.sort()
-
-                # Merge overlapping y-intervals
-                merged_intervals = []
-                for start, end in y_intervals:
-                    if merged_intervals and start <= merged_intervals[-1][1]:
-                        # Overlapping intervals - merge them
-                        merged_intervals[-1] = (
-                            merged_intervals[-1][0],
-                            max(merged_intervals[-1][1], end),
-                        )
-                    else:
-                        # Non-overlapping interval
-                        merged_intervals.append((start, end))
-
-                # Calculate total y-coverage for this x-interval
-                y_coverage = sum(end - start for start, end in merged_intervals)
-                total_area += (x - prev_x) * y_coverage
-
-            # Update active boxes
-            if event_type == "start":
-                active_boxes.add(box_id)
-            else:
-                active_boxes.discard(box_id)
-
-            prev_x = x
-
-        return total_area
+        """Deprecated alias — use ``calculate_boxes_coverage`` from
+        ``rapidata_client.validation.rapids.box`` instead."""
+        return calculate_boxes_coverage(boxes)
 
     @staticmethod
     def _calculate_coverage_ratio(


### PR DESCRIPTION
## Summary

The Rapidata dashboard now offers Locate / Line / Transcription audience types alongside the existing Classify and Compare ([app-frontend#2342](https://github.com/RapidataAI/app-frontend/pull/2342), with the LineExampleTruth multi-box backend support landing in [rapidata-backend#3992](https://github.com/RapidataAI/rapidata-backend/pull/3992) + [rapidata-backend#4051](https://github.com/RapidataAI/rapidata-backend/pull/4051)). The Python SDK only had typed helpers for Classify and Compare — adding the missing three so the SDK matches the dashboard's surface and the dashboard's "Create it with Python" snippet on those forms can point at a real public method.

## What's new

Three typed methods on `RapidataAudience`, each calling through to a matching method on `AudienceExampleHandler`:

```py
audience.add_locate_example(
    instruction="Click the dog's face",
    truth=[Box(x_min=0.3, y_min=0.2, x_max=0.55, y_max=0.45)],
    datapoint="https://assets.rapidata.ai/dog.jpg",
)

audience.add_line_example(
    instruction="Trace the horizon line",
    datapoint="https://assets.rapidata.ai/landscape.jpg",
    truth=[Box(x_min=0.0, y_min=0.45, x_max=1.0, y_max=0.55)],  # optional
)

audience.add_transcription_example(
    instruction="Select the words actually spoken",
    sentence="the quick brown fox jumps over the lazy dog",
    truth=[1, 2, 3],  # word indices
    datapoint="https://assets.rapidata.ai/fox.mp3",
)
```

All three:
- mirror the keyword-arg shape of the existing `add_classification_example` / `add_compare_example` (same `context`, `media_context`, `explanation`, `settings`),
- compute a sensible `randomCorrectProbability` (`calculate_boxes_coverage(truth)` for Locate, same for Line when boxes are given, `0.1` flat for Line when not, `len(correct) / len(total)` for Transcription),
- run through `_try_start_recruiting` after the example is added.

## Refactors / housekeeping

- `validation.rapids.box`: extracted `calculate_boxes_coverage` from the private `RapidsManager._calculate_boxes_coverage` so both the rapid and audience layers can reuse the union-area sweep-line. The old method on `RapidsManager` is kept as a thin alias so any external callers (and any docs that reference it) keep working.
- `IExampleTruthLineExampleTruth` codegen now carries `boundingBoxes` / `requiredPrecision` / `requiredCompleteness` (matching prod after rapidata-backend#4051). The local generator-cli can't materialise Java in this dev environment, so the model file was hand-patched in the same shape the generator would produce; the next CI regen will overwrite it idempotently.
- Schema files refreshed from prod via `bash openapi/generate-schema.sh`.

## Docs

- `docs/audiences.md`: added a method-picker table for all five example types and a runnable snippet showing the three new helpers. Updated the existing 'settings' note to reflect that all `add_*_example` helpers accept `settings`, not just classify/compare.

## Test plan

- [x] `pyright src/rapidata/rapidata_client` — no new errors above main's baseline (the 3 remaining errors are pre-existing missing-import warnings for `pandas` / `pydantic` in this isolated environment).
- [ ] Smoke: `audience.add_locate_example(...)` against a staging audience, verify the resulting rapid carries a `LocateBoxTruth` with the expected boxes and `requiredPrecision` / `requiredCompleteness` propagated.
- [ ] Smoke: `audience.add_line_example(..., truth=None)` and `audience.add_line_example(..., truth=[Box(...)])` and verify both round-trip — the first produces an empty `LineTruth`, the second a `BoundingBoxTruth` (per the rapidata-backend#4051 mapping).
- [ ] Smoke: `audience.add_transcription_example(...)` and verify `correctWords` reach the rapid as `TranscriptionTruth.correctWords`.

🔗 Session: [session-2de1ad62](https://session-2de1ad62.poseidon.rapidata.internal/)