### PR TITLE
feat(datapoints): support multiple images per media_context

### DIFF
--- a/docs/job_definition_parameters.md
+++ b/docs/job_definition_parameters.md
@@ -165,18 +165,18 @@ contexts=["A cat sitting on a red couch", "A blue car in the rain"]
 
 | Property | Value |
 |----------|-------|
-| **Type** | `Optional[list[str] \| list[list[str]]]` |
+| **Type** | `Optional[list[list[str]]]` |
 | **Required** | No |
 | **Default** | `None` |
 
 Media URLs shown as reference context alongside each datapoint. Useful when you need to show one or more reference images / videos alongside the item being evaluated.
 
-**Constraints:** If provided, must have the same length as `datapoints`. Pass a flat list (one media context per datapoint) **or** a list of lists (multiple media contexts per datapoint) — the two shapes cannot be mixed inside the same call.
+**Constraints:** If provided, must have the same length as `datapoints`. Each entry is itself a list of media URLs / paths. Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos.
 
 ```python
-# One reference image per datapoint
+# One reference image per datapoint (each inner list has one entry)
 datapoints=["edited1.jpg", "edited2.jpg"],
-media_contexts=["original1.jpg", "original2.jpg"]
+media_contexts=[["original1.jpg"], ["original2.jpg"]]
 
 # Multiple reference images per datapoint
 datapoints=["edited1.jpg", "edited2.jpg"],
@@ -185,6 +185,8 @@ media_contexts=[
     ["original2_a.jpg", "original2_b.jpg"],
 ]
 ```
+
+> A flat `list[str]` is still accepted for backward compatibility — it triggers a deprecation warning and each string is automatically wrapped in a single-element list.
 
 ---
 

--- a/docs/job_definition_parameters.md
+++ b/docs/job_definition_parameters.md
@@ -165,18 +165,25 @@ contexts=["A cat sitting on a red couch", "A blue car in the rain"]
 
 | Property | Value |
 |----------|-------|
-| **Type** | `Optional[list[str]]` |
+| **Type** | `Optional[list[str] \| list[list[str]]]` |
 | **Required** | No |
 | **Default** | `None` |
 
-Media URLs shown as reference context alongside each datapoint. Useful when you need to show a reference image or video alongside the item being evaluated.
+Media URLs shown as reference context alongside each datapoint. Useful when you need to show one or more reference images / videos alongside the item being evaluated.
 
-**Constraints:** If provided, must have the same length as `datapoints`.
+**Constraints:** If provided, must have the same length as `datapoints`. Pass a flat list (one media context per datapoint) **or** a list of lists (multiple media contexts per datapoint) — the two shapes cannot be mixed inside the same call.
 
 ```python
-# Show original image as context while evaluating edited versions
+# One reference image per datapoint
 datapoints=["edited1.jpg", "edited2.jpg"],
 media_contexts=["original1.jpg", "original2.jpg"]
+
+# Multiple reference images per datapoint
+datapoints=["edited1.jpg", "edited2.jpg"],
+media_contexts=[
+    ["original1_a.jpg", "original1_b.jpg"],
+    ["original2_a.jpg", "original2_b.jpg"],
+]
 ```
 
 ---

--- a/docs/job_definition_parameters.md
+++ b/docs/job_definition_parameters.md
@@ -169,9 +169,9 @@ contexts=["A cat sitting on a red couch", "A blue car in the rain"]
 | **Required** | No |
 | **Default** | `None` |
 
-Media URLs shown as reference context alongside each datapoint. Useful when you need to show one or more reference images / videos alongside the item being evaluated.
+Image URLs shown as reference context alongside each datapoint. Useful when you need to show one or more reference images alongside the item being evaluated.
 
-**Constraints:** If provided, must have the same length as `datapoints`. Each entry is itself a list of media URLs / paths. Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos.
+**Constraints:** If provided, must have the same length as `datapoints`. Each entry is itself a list of image URLs / paths. Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
 
 ```python
 # One reference image per datapoint (each inner list has one entry)
@@ -185,8 +185,6 @@ media_contexts=[
     ["original2_a.jpg", "original2_b.jpg"],
 ]
 ```
-
-> A flat `list[str]` is still accepted for backward compatibility — it triggers a deprecation warning and each string is automatically wrapped in a single-element list.
 
 ---
 

--- a/src/rapidata/rapidata_client/audience/audience_example_handler.py
+++ b/src/rapidata/rapidata_client/audience/audience_example_handler.py
@@ -46,7 +46,7 @@ class AudienceExampleHandler:
         truth: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> None:
@@ -59,7 +59,7 @@ class AudienceExampleHandler:
             truth (list[str]): The correct answers to the question.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
             settings (Sequence[RapidataSetting], optional): The list of settings to apply to the example as feature flags. Controls how the example is rendered to the labeler (e.g. ``NoShuffleSetting`` to keep the order of answer options). Defaults to None.
         """
@@ -120,7 +120,7 @@ class AudienceExampleHandler:
         datapoint: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> None:
@@ -132,7 +132,7 @@ class AudienceExampleHandler:
             datapoint (list[str]): The two assets that the labeler will be comparing.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
             settings (Sequence[RapidataSetting], optional): The list of settings to apply to the example as feature flags. Controls how the example is rendered to the labeler (e.g. ``ComparePanoramaSetting`` to render panoramic images). Defaults to None.
         """
@@ -189,21 +189,20 @@ class AudienceExampleHandler:
         )
 
     def _upload_and_map_media_context(
-        self, media_context: str | list[str]
+        self, media_context: list[str]
     ) -> "IAssetInput":
         """Upload media context asset(s) and map to IAssetInput.
 
-        Accepts either a single string (one image) or a list of strings
-        (multiple images shown as media context).
+        ``media_context`` is always a list. A single-element list is sent as a
+        plain ``ExistingAssetInput``; two or more entries are bundled into a
+        ``MultiAssetInput``.
         """
-        if isinstance(media_context, list):
-            uploaded_names = [
-                self._asset_uploader.upload_asset(mc) for mc in media_context
-            ]
-            return self._asset_mapper.create_existing_asset_input(uploaded_names)
-        else:
-            uploaded_name = self._asset_uploader.upload_asset(media_context)
-            return self._asset_mapper.create_existing_asset_input(uploaded_name)
+        uploaded_names = [
+            self._asset_uploader.upload_asset(mc) for mc in media_context
+        ]
+        if len(uploaded_names) == 1:
+            return self._asset_mapper.create_existing_asset_input(uploaded_names[0])
+        return self._asset_mapper.create_existing_asset_input(uploaded_names)
 
     def _add_rapid_example(self, rapid: Rapid) -> None:
         """Add a rapid example to the audience (private method).

--- a/src/rapidata/rapidata_client/audience/audience_example_handler.py
+++ b/src/rapidata/rapidata_client/audience/audience_example_handler.py
@@ -38,6 +38,19 @@ class AudienceExampleHandler:
         self._asset_uploader = AssetUploader(openapi_service)
         self._asset_mapper = AssetMapper()
 
+    def _upload_and_map_asset(self, asset: str | list[str]) -> "IAssetInput":
+        """Upload asset(s) and map to IAssetInput.
+
+        Used both for the main example asset and for ``media_context``. A
+        single string is sent as a plain ``ExistingAssetInput``; a list is
+        bundled into a ``MultiAssetInput``.
+        """
+        if isinstance(asset, list):
+            uploaded_names = [self._asset_uploader.upload_asset(a) for a in asset]
+            return self._asset_mapper.create_existing_asset_input(uploaded_names)
+        uploaded_name = self._asset_uploader.upload_asset(asset)
+        return self._asset_mapper.create_existing_asset_input(uploaded_name)
+
     def add_classification_example(
         self,
         instruction: str,
@@ -59,7 +72,7 @@ class AudienceExampleHandler:
             truth (list[str]): The correct answers to the question.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
             settings (Sequence[RapidataSetting], optional): The list of settings to apply to the example as feature flags. Controls how the example is rendered to the labeler (e.g. ``NoShuffleSetting`` to keep the order of answer options). Defaults to None.
         """
@@ -74,8 +87,7 @@ class AudienceExampleHandler:
             raise ValueError("Truth must be part of the answer options")
 
         if data_type == "media":
-            uploaded_name = self._asset_uploader.upload_asset(datapoint)
-            asset_input = self._asset_mapper.create_existing_asset_input(uploaded_name)
+            asset_input = self._upload_and_map_asset(datapoint)
         else:
             asset_input = self._asset_mapper.create_text_input(datapoint)
 
@@ -103,7 +115,7 @@ class AudienceExampleHandler:
                 truth=model_truth,
                 context=context,
                 contextAsset=(
-                    self._upload_and_map_media_context(media_context)
+                    self._upload_and_map_asset(media_context)
                     if media_context
                     else None
                 ),
@@ -132,7 +144,7 @@ class AudienceExampleHandler:
             datapoint (list[str]): The two assets that the labeler will be comparing.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
             settings (Sequence[RapidataSetting], optional): The list of settings to apply to the example as feature flags. Controls how the example is rendered to the labeler (e.g. ``ComparePanoramaSetting`` to render panoramic images). Defaults to None.
         """
@@ -178,7 +190,7 @@ class AudienceExampleHandler:
                 truth=model_truth,
                 context=context,
                 contextAsset=(
-                    self._upload_and_map_media_context(media_context)
+                    self._upload_and_map_asset(media_context)
                     if media_context
                     else None
                 ),
@@ -187,22 +199,6 @@ class AudienceExampleHandler:
                 featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
             ),
         )
-
-    def _upload_and_map_media_context(
-        self, media_context: list[str]
-    ) -> "IAssetInput":
-        """Upload media context asset(s) and map to IAssetInput.
-
-        ``media_context`` is always a list. A single-element list is sent as a
-        plain ``ExistingAssetInput``; two or more entries are bundled into a
-        ``MultiAssetInput``.
-        """
-        uploaded_names = [
-            self._asset_uploader.upload_asset(mc) for mc in media_context
-        ]
-        if len(uploaded_names) == 1:
-            return self._asset_mapper.create_existing_asset_input(uploaded_names[0])
-        return self._asset_mapper.create_existing_asset_input(uploaded_names)
 
     def _add_rapid_example(self, rapid: Rapid) -> None:
         """Add a rapid example to the audience (private method).
@@ -216,25 +212,14 @@ class AudienceExampleHandler:
 
         # Handle asset uploading based on data type
         if rapid.data_type == "media":
-            if isinstance(rapid.asset, list):
-                uploaded_names = [
-                    self._asset_uploader.upload_asset(asset) for asset in rapid.asset
-                ]
-                asset_input = self._asset_mapper.create_existing_asset_input(
-                    uploaded_names
-                )
-            else:
-                uploaded_name = self._asset_uploader.upload_asset(rapid.asset)
-                asset_input = self._asset_mapper.create_existing_asset_input(
-                    uploaded_name
-                )
+            asset_input = self._upload_and_map_asset(rapid.asset)
         else:
             asset_input = self._asset_mapper.create_text_input(rapid.asset)
 
         # Handle media context if present
         context_asset = None
         if rapid.media_context:
-            context_asset = self._upload_and_map_media_context(rapid.media_context)
+            context_asset = self._upload_and_map_asset(rapid.media_context)
 
         # Convert IValidationTruthModel to IExampleTruth
         # Both types are structurally identical (same JSON schema), differing only in class names

--- a/src/rapidata/rapidata_client/audience/audience_example_handler.py
+++ b/src/rapidata/rapidata_client/audience/audience_example_handler.py
@@ -5,7 +5,6 @@ from typing import Literal, TYPE_CHECKING, Any, Sequence, cast
 if TYPE_CHECKING:
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
     from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
-    from rapidata.api_client.models.i_asset_input import IAssetInput
 
 from rapidata.api_client.models.i_example_truth_classify_example_truth import (
     IExampleTruthClassifyExampleTruth,
@@ -37,19 +36,6 @@ class AudienceExampleHandler:
         self._audience_id = audience_id
         self._asset_uploader = AssetUploader(openapi_service)
         self._asset_mapper = AssetMapper()
-
-    def _upload_and_map_asset(self, asset: str | list[str]) -> "IAssetInput":
-        """Upload asset(s) and map to IAssetInput.
-
-        Used both for the main example asset and for ``media_context``. A
-        single string is sent as a plain ``ExistingAssetInput``; a list is
-        bundled into a ``MultiAssetInput``.
-        """
-        if isinstance(asset, list):
-            uploaded_names = [self._asset_uploader.upload_asset(a) for a in asset]
-            return self._asset_mapper.create_existing_asset_input(uploaded_names)
-        uploaded_name = self._asset_uploader.upload_asset(asset)
-        return self._asset_mapper.create_existing_asset_input(uploaded_name)
 
     def add_classification_example(
         self,
@@ -87,7 +73,7 @@ class AudienceExampleHandler:
             raise ValueError("Truth must be part of the answer options")
 
         if data_type == "media":
-            asset_input = self._upload_and_map_asset(datapoint)
+            asset_input = self._asset_uploader.upload_and_map_asset(datapoint)
         else:
             asset_input = self._asset_mapper.create_text_input(datapoint)
 
@@ -115,7 +101,7 @@ class AudienceExampleHandler:
                 truth=model_truth,
                 context=context,
                 contextAsset=(
-                    self._upload_and_map_asset(media_context)
+                    self._asset_uploader.upload_and_map_asset(media_context)
                     if media_context
                     else None
                 ),
@@ -190,7 +176,7 @@ class AudienceExampleHandler:
                 truth=model_truth,
                 context=context,
                 contextAsset=(
-                    self._upload_and_map_asset(media_context)
+                    self._asset_uploader.upload_and_map_asset(media_context)
                     if media_context
                     else None
                 ),
@@ -212,14 +198,14 @@ class AudienceExampleHandler:
 
         # Handle asset uploading based on data type
         if rapid.data_type == "media":
-            asset_input = self._upload_and_map_asset(rapid.asset)
+            asset_input = self._asset_uploader.upload_and_map_asset(rapid.asset)
         else:
             asset_input = self._asset_mapper.create_text_input(rapid.asset)
 
         # Handle media context if present
         context_asset = None
         if rapid.media_context:
-            context_asset = self._upload_and_map_asset(rapid.media_context)
+            context_asset = self._asset_uploader.upload_and_map_asset(rapid.media_context)
 
         # Convert IValidationTruthModel to IExampleTruth
         # Both types are structurally identical (same JSON schema), differing only in class names

--- a/src/rapidata/rapidata_client/audience/audience_example_handler.py
+++ b/src/rapidata/rapidata_client/audience/audience_example_handler.py
@@ -5,6 +5,7 @@ from typing import Literal, TYPE_CHECKING, Any, Sequence, cast
 if TYPE_CHECKING:
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
     from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+    from rapidata.api_client.models.i_asset_input import IAssetInput
 
 from rapidata.api_client.models.i_example_truth_classify_example_truth import (
     IExampleTruthClassifyExampleTruth,
@@ -45,7 +46,7 @@ class AudienceExampleHandler:
         truth: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> None:
@@ -58,7 +59,7 @@ class AudienceExampleHandler:
             truth (list[str]): The correct answers to the question.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
+            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
             settings (Sequence[RapidataSetting], optional): The list of settings to apply to the example as feature flags. Controls how the example is rendered to the labeler (e.g. ``NoShuffleSetting`` to keep the order of answer options). Defaults to None.
         """
@@ -102,9 +103,7 @@ class AudienceExampleHandler:
                 truth=model_truth,
                 context=context,
                 contextAsset=(
-                    self._asset_mapper.create_existing_asset_input(
-                        self._asset_uploader.upload_asset(media_context)
-                    )
+                    self._upload_and_map_media_context(media_context)
                     if media_context
                     else None
                 ),
@@ -121,7 +120,7 @@ class AudienceExampleHandler:
         datapoint: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> None:
@@ -133,7 +132,7 @@ class AudienceExampleHandler:
             datapoint (list[str]): The two assets that the labeler will be comparing.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
+            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
             settings (Sequence[RapidataSetting], optional): The list of settings to apply to the example as feature flags. Controls how the example is rendered to the labeler (e.g. ``ComparePanoramaSetting`` to render panoramic images). Defaults to None.
         """
@@ -179,9 +178,7 @@ class AudienceExampleHandler:
                 truth=model_truth,
                 context=context,
                 contextAsset=(
-                    self._asset_mapper.create_existing_asset_input(
-                        self._asset_uploader.upload_asset(media_context)
-                    )
+                    self._upload_and_map_media_context(media_context)
                     if media_context
                     else None
                 ),
@@ -190,6 +187,23 @@ class AudienceExampleHandler:
                 featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
             ),
         )
+
+    def _upload_and_map_media_context(
+        self, media_context: str | list[str]
+    ) -> "IAssetInput":
+        """Upload media context asset(s) and map to IAssetInput.
+
+        Accepts either a single string (one image) or a list of strings
+        (multiple images shown as media context).
+        """
+        if isinstance(media_context, list):
+            uploaded_names = [
+                self._asset_uploader.upload_asset(mc) for mc in media_context
+            ]
+            return self._asset_mapper.create_existing_asset_input(uploaded_names)
+        else:
+            uploaded_name = self._asset_uploader.upload_asset(media_context)
+            return self._asset_mapper.create_existing_asset_input(uploaded_name)
 
     def _add_rapid_example(self, rapid: Rapid) -> None:
         """Add a rapid example to the audience (private method).
@@ -221,9 +235,7 @@ class AudienceExampleHandler:
         # Handle media context if present
         context_asset = None
         if rapid.media_context:
-            context_asset = self._asset_mapper.create_existing_asset_input(
-                self._asset_uploader.upload_asset(rapid.media_context)
-            )
+            context_asset = self._upload_and_map_media_context(rapid.media_context)
 
         # Convert IValidationTruthModel to IExampleTruth
         # Both types are structurally identical (same JSON schema), differing only in class names

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -154,7 +154,7 @@ class RapidataAudience:
         truth: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> RapidataAudience:
@@ -170,7 +170,7 @@ class RapidataAudience:
             truth (list[str]): The correct answer(s) for this training example.
             data_type (Literal["media", "text"], optional): The data type of the datapoint. Defaults to "media".
             context (str, optional): Additional text context to display with the example. Defaults to None.
-            media_context (str, optional): Additional media (URL or path) to display with the example. Defaults to None.
+            media_context (str | list[str], optional): Additional media (URL or path) to display with the example. Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): An explanation of why the truth is correct. Defaults to None.
             settings (Sequence[RapidataSetting], optional): Settings applied as feature flags on this example. Use the same ``RapidataSetting`` subclasses available on jobs/orders (e.g. ``NoShuffleSetting``, ``MarkdownSetting``) so the qualification example matches how the actual task will be rendered. Defaults to None.
 
@@ -204,7 +204,7 @@ class RapidataAudience:
         datapoint: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> RapidataAudience:
@@ -219,7 +219,7 @@ class RapidataAudience:
             datapoint (list[str]): A list of exactly two datapoints (URLs or paths) to compare.
             data_type (Literal["media", "text"], optional): The data type of the datapoints. Defaults to "media".
             context (str, optional): Additional text context to display with the example. Defaults to None.
-            media_context (str, optional): Additional media (URL or path) to display with the example. Defaults to None.
+            media_context (str | list[str], optional): Additional media (URL or path) to display with the example. Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): An explanation of why the truth is correct. Defaults to None.
             settings (Sequence[RapidataSetting], optional): Settings applied as feature flags on this example. Use the same ``RapidataSetting`` subclasses available on jobs/orders (e.g. ``AllowNeitherBothSetting``, ``ComparePanoramaSetting``) so the qualification example matches how the actual task will be rendered. Defaults to None.
 

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -6,6 +6,30 @@ from rapidata.rapidata_client.audience.audience_example_handler import (
     AudienceExampleHandler,
 )
 
+
+def _coerce_media_context(
+    media_context: str | list[str] | None,
+) -> list[str] | None:
+    """Normalize a singular ``media_context`` argument to ``list[str] | None``.
+
+    Accepts ``str`` for backward compatibility — emits a deprecation warning
+    and wraps it in a single-element list so downstream code only ever has to
+    deal with ``list[str]``.
+    """
+    if media_context is None:
+        return None
+    if isinstance(media_context, str):
+        if media_context == "":
+            raise ValueError(
+                "media_context cannot be an empty string. If not needed, set to None."
+            )
+        logger.warning(
+            "Passing a string for media_context is deprecated; pass a list of strings instead. "
+            "Wrapping the value in a single-element list."
+        )
+        return [media_context]
+    return media_context
+
 if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
     from rapidata.rapidata_client.filter import RapidataFilter
@@ -154,7 +178,7 @@ class RapidataAudience:
         truth: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> RapidataAudience:
@@ -170,13 +194,14 @@ class RapidataAudience:
             truth (list[str]): The correct answer(s) for this training example.
             data_type (Literal["media", "text"], optional): The data type of the datapoint. Defaults to "media".
             context (str, optional): Additional text context to display with the example. Defaults to None.
-            media_context (str | list[str], optional): Additional media (URL or path) to display with the example. Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): Additional media (URLs or paths) to display with the example. Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): An explanation of why the truth is correct. Defaults to None.
             settings (Sequence[RapidataSetting], optional): Settings applied as feature flags on this example. Use the same ``RapidataSetting`` subclasses available on jobs/orders (e.g. ``NoShuffleSetting``, ``MarkdownSetting``) so the qualification example matches how the actual task will be rendered. Defaults to None.
 
         Returns:
             RapidataAudience: The audience instance (self) for method chaining.
         """
+        media_context = _coerce_media_context(media_context)
         with tracer.start_as_current_span(
             "RapidataAudience.add_classification_example"
         ):
@@ -204,7 +229,7 @@ class RapidataAudience:
         datapoint: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> RapidataAudience:
@@ -219,13 +244,14 @@ class RapidataAudience:
             datapoint (list[str]): A list of exactly two datapoints (URLs or paths) to compare.
             data_type (Literal["media", "text"], optional): The data type of the datapoints. Defaults to "media".
             context (str, optional): Additional text context to display with the example. Defaults to None.
-            media_context (str | list[str], optional): Additional media (URL or path) to display with the example. Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): Additional media (URLs or paths) to display with the example. Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): An explanation of why the truth is correct. Defaults to None.
             settings (Sequence[RapidataSetting], optional): Settings applied as feature flags on this example. Use the same ``RapidataSetting`` subclasses available on jobs/orders (e.g. ``AllowNeitherBothSetting``, ``ComparePanoramaSetting``) so the qualification example matches how the actual task will be rendered. Defaults to None.
 
         Returns:
             RapidataAudience: The audience instance (self) for method chaining.
         """
+        media_context = _coerce_media_context(media_context)
         with tracer.start_as_current_span("RapidataAudience.add_compare_example"):
             logger.debug(
                 f"Adding compare example to audience: {self.id} with instruction: {instruction}, truth: {truth}, datapoint: {datapoint}, data_type: {data_type}, context: {context}, media_context: {media_context}, explanation: {explanation}, settings: {settings}"

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -5,30 +5,7 @@ from rapidata.rapidata_client.config import logger, tracer, managed_print
 from rapidata.rapidata_client.audience.audience_example_handler import (
     AudienceExampleHandler,
 )
-
-
-def _coerce_media_context(
-    media_context: str | list[str] | None,
-) -> list[str] | None:
-    """Normalize a singular ``media_context`` argument to ``list[str] | None``.
-
-    Accepts ``str`` for backward compatibility — emits a deprecation warning
-    and wraps it in a single-element list so downstream code only ever has to
-    deal with ``list[str]``.
-    """
-    if media_context is None:
-        return None
-    if isinstance(media_context, str):
-        if media_context == "":
-            raise ValueError(
-                "media_context cannot be an empty string. If not needed, set to None."
-            )
-        logger.warning(
-            "Passing a string for media_context is deprecated; pass a list of strings instead. "
-            "Wrapping the value in a single-element list."
-        )
-        return [media_context]
-    return media_context
+from rapidata.rapidata_client.datapoints._datapoint import coerce_media_context
 
 if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
@@ -194,14 +171,14 @@ class RapidataAudience:
             truth (list[str]): The correct answer(s) for this training example.
             data_type (Literal["media", "text"], optional): The data type of the datapoint. Defaults to "media".
             context (str, optional): Additional text context to display with the example. Defaults to None.
-            media_context (list[str], optional): Additional media (URLs or paths) to display with the example. Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): Additional image URLs / paths to display with the example. Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): An explanation of why the truth is correct. Defaults to None.
             settings (Sequence[RapidataSetting], optional): Settings applied as feature flags on this example. Use the same ``RapidataSetting`` subclasses available on jobs/orders (e.g. ``NoShuffleSetting``, ``MarkdownSetting``) so the qualification example matches how the actual task will be rendered. Defaults to None.
 
         Returns:
             RapidataAudience: The audience instance (self) for method chaining.
         """
-        media_context = _coerce_media_context(media_context)
+        media_context = coerce_media_context(media_context)
         with tracer.start_as_current_span(
             "RapidataAudience.add_classification_example"
         ):
@@ -244,14 +221,14 @@ class RapidataAudience:
             datapoint (list[str]): A list of exactly two datapoints (URLs or paths) to compare.
             data_type (Literal["media", "text"], optional): The data type of the datapoints. Defaults to "media".
             context (str, optional): Additional text context to display with the example. Defaults to None.
-            media_context (list[str], optional): Additional media (URLs or paths) to display with the example. Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): Additional image URLs / paths to display with the example. Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): An explanation of why the truth is correct. Defaults to None.
             settings (Sequence[RapidataSetting], optional): Settings applied as feature flags on this example. Use the same ``RapidataSetting`` subclasses available on jobs/orders (e.g. ``AllowNeitherBothSetting``, ``ComparePanoramaSetting``) so the qualification example matches how the actual task will be rendered. Defaults to None.
 
         Returns:
             RapidataAudience: The audience instance (self) for method chaining.
         """
-        media_context = _coerce_media_context(media_context)
+        media_context = coerce_media_context(media_context)
         with tracer.start_as_current_span("RapidataAudience.add_compare_example"):
             logger.debug(
                 f"Adding compare example to audience: {self.id} with instruction: {instruction}, truth: {truth}, datapoint: {datapoint}, data_type: {data_type}, context: {context}, media_context: {media_context}, explanation: {explanation}, settings: {settings}"

--- a/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
@@ -43,10 +43,9 @@ def extract_assets_from_datapoint(datapoint: Datapoint) -> set[str]:
     # media_context is always a media asset regardless of data_type
     # Skip for grouped datapoints — their context is uploaded at group level
     if datapoint.media_context and datapoint.group is None:
-        if isinstance(datapoint.media_context, list):
-            assets.update(datapoint.media_context)
-        else:
-            assets.add(datapoint.media_context)
+        # media_context is always a list of strings (the model coerces legacy
+        # single strings into a list at validation time).
+        assets.update(datapoint.media_context)
 
     return assets
 

--- a/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
@@ -43,7 +43,10 @@ def extract_assets_from_datapoint(datapoint: Datapoint) -> set[str]:
     # media_context is always a media asset regardless of data_type
     # Skip for grouped datapoints — their context is uploaded at group level
     if datapoint.media_context and datapoint.group is None:
-        assets.add(datapoint.media_context)
+        if isinstance(datapoint.media_context, list):
+            assets.update(datapoint.media_context)
+        else:
+            assets.add(datapoint.media_context)
 
     return assets
 

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -138,36 +138,12 @@ class AssetUploader:
         Used both for main datapoint/example assets and for ``media_context``.
         A single string is returned as a plain ``ExistingAssetInput``; a list
         is bundled into a ``MultiAssetInput``.
-
-        Callers that also need to know which uploaded name corresponds to
-        each original path (e.g. compare-rapid truth translation) should use
-        :meth:`upload_and_map_asset_with_mapping` instead.
-        """
-        return self.upload_and_map_asset_with_mapping(asset)[0]
-
-    def upload_and_map_asset_with_mapping(
-        self, asset: str | list[str]
-    ) -> tuple[IAssetInput, dict[str, str]]:
-        """Upload asset(s) and return the ``IAssetInput`` plus a path->name map.
-
-        The second tuple element maps each original asset path to its
-        uploaded name. Callers that translate IDs across the upload boundary
-        (e.g. compare-rapid ``winnerId`` / ``correctCombinations``) need it;
-        most callers can ignore it and use :meth:`upload_and_map_asset`.
         """
         if isinstance(asset, list):
-            asset_to_uploaded = {a: self.upload_asset(a) for a in asset}
-            uploaded_names = list(asset_to_uploaded.values())
-            return (
-                AssetMapper.create_existing_asset_input(uploaded_names),
-                asset_to_uploaded,
-            )
+            uploaded_names = [self.upload_asset(a) for a in asset]
+            return AssetMapper.create_existing_asset_input(uploaded_names)
 
-        uploaded_name = self.upload_asset(asset)
-        return (
-            AssetMapper.create_existing_asset_input(uploaded_name),
-            {asset: uploaded_name},
-        )
+        return AssetMapper.create_existing_asset_input(self.upload_asset(asset))
 
     def clear_cache(self) -> None:
         """Clear both URL and file caches."""

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -4,8 +4,10 @@ import re
 import os
 import threading
 
+from rapidata.api_client.models.i_asset_input import IAssetInput
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.config import logger, rapidata_config, tracer
+from rapidata.rapidata_client.datapoints._asset_mapper import AssetMapper
 from rapidata.rapidata_client.datapoints._single_flight_cache import SingleFlightCache
 from diskcache import FanoutCache
 
@@ -129,6 +131,43 @@ class AssetUploader:
             return self._upload_url_asset(asset)
 
         return self._upload_file_asset(asset)
+
+    def upload_and_map_asset(self, asset: str | list[str]) -> IAssetInput:
+        """Upload asset(s) and wrap the result in an ``IAssetInput``.
+
+        Used both for main datapoint/example assets and for ``media_context``.
+        A single string is returned as a plain ``ExistingAssetInput``; a list
+        is bundled into a ``MultiAssetInput``.
+
+        Callers that also need to know which uploaded name corresponds to
+        each original path (e.g. compare-rapid truth translation) should use
+        :meth:`upload_and_map_asset_with_mapping` instead.
+        """
+        return self.upload_and_map_asset_with_mapping(asset)[0]
+
+    def upload_and_map_asset_with_mapping(
+        self, asset: str | list[str]
+    ) -> tuple[IAssetInput, dict[str, str]]:
+        """Upload asset(s) and return the ``IAssetInput`` plus a path->name map.
+
+        The second tuple element maps each original asset path to its
+        uploaded name. Callers that translate IDs across the upload boundary
+        (e.g. compare-rapid ``winnerId`` / ``correctCombinations``) need it;
+        most callers can ignore it and use :meth:`upload_and_map_asset`.
+        """
+        if isinstance(asset, list):
+            asset_to_uploaded = {a: self.upload_asset(a) for a in asset}
+            uploaded_names = list(asset_to_uploaded.values())
+            return (
+                AssetMapper.create_existing_asset_input(uploaded_names),
+                asset_to_uploaded,
+            )
+
+        uploaded_name = self.upload_asset(asset)
+        return (
+            AssetMapper.create_existing_asset_input(uploaded_name),
+            {asset: uploaded_name},
+        )
 
     def clear_cache(self) -> None:
         """Clear both URL and file caches."""

--- a/src/rapidata/rapidata_client/datapoints/_datapoint.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint.py
@@ -20,7 +20,7 @@ class Datapoint(BaseModel):
     asset: str | list[str]
     data_type: Literal["text", "media"]
     context: str | None = None
-    media_context: str | None = None
+    media_context: str | list[str] | None = None
     sentence: str | None = None
     private_metadata: dict[str, str] | None = None
     group: str | None = None
@@ -36,10 +36,25 @@ class Datapoint(BaseModel):
 
     @field_validator("media_context")
     @classmethod
-    def media_context_not_empty(cls, v: str | None) -> str | None:
-        if v is not None and v == "":
+    def media_context_not_empty(
+        cls, v: str | list[str] | None
+    ) -> str | list[str] | None:
+        if v is None:
+            return v
+        if isinstance(v, str):
+            if v == "":
+                raise ValueError(
+                    "media_context cannot be an empty string. If not needed, set to None."
+                )
+            return v
+        # list[str] case
+        if len(v) == 0:
             raise ValueError(
-                "media_context cannot be an empty string. If not needed, set to None."
+                "media_context cannot be an empty list. If not needed, set to None."
+            )
+        if any(not isinstance(item, str) or item == "" for item in v):
+            raise ValueError(
+                "Every entry in a media_context list must be a non-empty string."
             )
         return v
 

--- a/src/rapidata/rapidata_client/datapoints/_datapoint.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint.py
@@ -16,6 +16,42 @@ if TYPE_CHECKING:
     from rapidata.api_client.models.prompt_type import PromptType
 
 
+def coerce_media_context(value: object) -> list[str] | None:
+    """Normalize a ``media_context`` value to ``list[str] | None``.
+
+    Accepts ``str`` for backward compatibility — emits a deprecation warning
+    and wraps it in a single-element list so the rest of the SDK only ever
+    has to deal with ``list[str]``. This is the single source of truth for
+    media_context coercion; both the ``Datapoint`` and ``Rapid`` field
+    validators delegate to it, as do the audience public APIs.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if value == "":
+            raise ValueError(
+                "media_context cannot be an empty string. If not needed, set to None."
+            )
+        logger.warning(
+            "Passing a string for media_context is deprecated; pass a list of strings instead. "
+            "Wrapping the value in a single-element list."
+        )
+        return [value]
+    if isinstance(value, list):
+        if len(value) == 0:
+            raise ValueError(
+                "media_context cannot be an empty list. If not needed, set to None."
+            )
+        if any(not isinstance(item, str) or item == "" for item in value):
+            raise ValueError(
+                "Every entry in a media_context list must be a non-empty string."
+            )
+        return value
+    raise ValueError(
+        f"media_context must be a list of strings or None, got {type(value).__name__}."
+    )
+
+
 class Datapoint(BaseModel):
     asset: str | list[str]
     data_type: Literal["text", "media"]
@@ -37,37 +73,7 @@ class Datapoint(BaseModel):
     @field_validator("media_context", mode="before")
     @classmethod
     def media_context_normalize(cls, v: object) -> list[str] | None:
-        """Always store media_context as a list of strings.
-
-        Accepts ``str`` for backward compatibility — emits a deprecation
-        warning and wraps it in a single-element list so the rest of the
-        SDK only ever has to deal with ``list[str]``.
-        """
-        if v is None:
-            return None
-        if isinstance(v, str):
-            if v == "":
-                raise ValueError(
-                    "media_context cannot be an empty string. If not needed, set to None."
-                )
-            logger.warning(
-                "Passing a string for media_context is deprecated; pass a list of strings instead. "
-                "Wrapping the value in a single-element list."
-            )
-            return [v]
-        if isinstance(v, list):
-            if len(v) == 0:
-                raise ValueError(
-                    "media_context cannot be an empty list. If not needed, set to None."
-                )
-            if any(not isinstance(item, str) or item == "" for item in v):
-                raise ValueError(
-                    "Every entry in a media_context list must be a non-empty string."
-                )
-            return v
-        raise ValueError(
-            f"media_context must be a list of strings or None, got {type(v).__name__}."
-        )
+        return coerce_media_context(v)
 
     @field_validator("sentence")
     @classmethod

--- a/src/rapidata/rapidata_client/datapoints/_datapoint.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint.py
@@ -20,7 +20,7 @@ class Datapoint(BaseModel):
     asset: str | list[str]
     data_type: Literal["text", "media"]
     context: str | None = None
-    media_context: str | list[str] | None = None
+    media_context: list[str] | None = None
     sentence: str | None = None
     private_metadata: dict[str, str] | None = None
     group: str | None = None
@@ -34,29 +34,40 @@ class Datapoint(BaseModel):
             )
         return v
 
-    @field_validator("media_context")
+    @field_validator("media_context", mode="before")
     @classmethod
-    def media_context_not_empty(
-        cls, v: str | list[str] | None
-    ) -> str | list[str] | None:
+    def media_context_normalize(cls, v: object) -> list[str] | None:
+        """Always store media_context as a list of strings.
+
+        Accepts ``str`` for backward compatibility — emits a deprecation
+        warning and wraps it in a single-element list so the rest of the
+        SDK only ever has to deal with ``list[str]``.
+        """
         if v is None:
-            return v
+            return None
         if isinstance(v, str):
             if v == "":
                 raise ValueError(
                     "media_context cannot be an empty string. If not needed, set to None."
                 )
+            logger.warning(
+                "Passing a string for media_context is deprecated; pass a list of strings instead. "
+                "Wrapping the value in a single-element list."
+            )
+            return [v]
+        if isinstance(v, list):
+            if len(v) == 0:
+                raise ValueError(
+                    "media_context cannot be an empty list. If not needed, set to None."
+                )
+            if any(not isinstance(item, str) or item == "" for item in v):
+                raise ValueError(
+                    "Every entry in a media_context list must be a non-empty string."
+                )
             return v
-        # list[str] case
-        if len(v) == 0:
-            raise ValueError(
-                "media_context cannot be an empty list. If not needed, set to None."
-            )
-        if any(not isinstance(item, str) or item == "" for item in v):
-            raise ValueError(
-                "Every entry in a media_context list must be a non-empty string."
-            )
-        return v
+        raise ValueError(
+            f"media_context must be a list of strings or None, got {type(v).__name__}."
+        )
 
     @field_validator("sentence")
     @classmethod

--- a/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
@@ -31,21 +31,20 @@ class DatapointUploader:
             return self.asset_mapper.create_existing_asset_input(uploaded_name)
 
     def _upload_and_map_media_context(
-        self, media_context: str | list[str]
+        self, media_context: list[str]
     ) -> IAssetInput:
         """Upload media context asset(s) and map to IAssetInput.
 
-        Accepts either a single string (one image per datapoint) or a list of
-        strings (multiple images per datapoint, all shown as media context).
+        ``media_context`` is always a list. A single-element list is sent as a
+        plain ``ExistingAssetInput`` (preserving the legacy single-image
+        rendering); two or more entries are bundled into a ``MultiAssetInput``.
         """
-        if isinstance(media_context, list):
-            uploaded_names = [
-                self.asset_uploader.upload_asset(mc) for mc in media_context
-            ]
-            return self.asset_mapper.create_existing_asset_input(uploaded_names)
-        else:
-            uploaded_name = self.asset_uploader.upload_asset(media_context)
-            return self.asset_mapper.create_existing_asset_input(uploaded_name)
+        uploaded_names = [
+            self.asset_uploader.upload_asset(mc) for mc in media_context
+        ]
+        if len(uploaded_names) == 1:
+            return self.asset_mapper.create_existing_asset_input(uploaded_names[0])
+        return self.asset_mapper.create_existing_asset_input(uploaded_names)
 
     def upload_datapoint(
         self, datapoint: Datapoint, dataset_id: str, index: int

--- a/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from rapidata.api_client.models.create_datapoint_endpoint_output import (
         CreateDatapointEndpointOutput,
     )
-    from rapidata.api_client.models.i_asset_input import IAssetInput
 
 
 class DatapointUploader:
@@ -19,21 +18,6 @@ class DatapointUploader:
         self.openapi_service = openapi_service
         self.asset_uploader = AssetUploader(openapi_service)
         self.asset_mapper = AssetMapper()
-
-    def _upload_and_map_asset(self, asset: str | list[str]) -> IAssetInput:
-        """Upload asset(s) and map to IAssetInput.
-
-        Used both for the main datapoint asset and for ``media_context``. A
-        single string is sent as a plain ``ExistingAssetInput``; a list is
-        bundled into a ``MultiAssetInput``.
-        """
-
-        if isinstance(asset, list):
-            uploaded_names = [self.asset_uploader.upload_asset(a) for a in asset]
-            return self.asset_mapper.create_existing_asset_input(uploaded_names)
-        else:
-            uploaded_name = self.asset_uploader.upload_asset(asset)
-            return self.asset_mapper.create_existing_asset_input(uploaded_name)
 
     def upload_datapoint(
         self, datapoint: Datapoint, dataset_id: str, index: int
@@ -43,7 +27,7 @@ class DatapointUploader:
         )
 
         if datapoint.data_type == "media":
-            uploaded_asset = self._upload_and_map_asset(datapoint.asset)
+            uploaded_asset = self.asset_uploader.upload_and_map_asset(datapoint.asset)
         else:
             uploaded_asset = self.asset_mapper.create_text_input(datapoint.asset)
 
@@ -53,7 +37,7 @@ class DatapointUploader:
         context_asset = (
             None
             if has_group or not datapoint.media_context
-            else self._upload_and_map_asset(datapoint.media_context)
+            else self.asset_uploader.upload_and_map_asset(datapoint.media_context)
         )
 
         return self.openapi_service.dataset.datapoints_api.dataset_dataset_id_datapoint_post(

--- a/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
@@ -21,7 +21,12 @@ class DatapointUploader:
         self.asset_mapper = AssetMapper()
 
     def _upload_and_map_asset(self, asset: str | list[str]) -> IAssetInput:
-        """Upload asset(s) and map to IAssetInput."""
+        """Upload asset(s) and map to IAssetInput.
+
+        Used both for the main datapoint asset and for ``media_context``. A
+        single string is sent as a plain ``ExistingAssetInput``; a list is
+        bundled into a ``MultiAssetInput``.
+        """
 
         if isinstance(asset, list):
             uploaded_names = [self.asset_uploader.upload_asset(a) for a in asset]
@@ -29,22 +34,6 @@ class DatapointUploader:
         else:
             uploaded_name = self.asset_uploader.upload_asset(asset)
             return self.asset_mapper.create_existing_asset_input(uploaded_name)
-
-    def _upload_and_map_media_context(
-        self, media_context: list[str]
-    ) -> IAssetInput:
-        """Upload media context asset(s) and map to IAssetInput.
-
-        ``media_context`` is always a list. A single-element list is sent as a
-        plain ``ExistingAssetInput`` (preserving the legacy single-image
-        rendering); two or more entries are bundled into a ``MultiAssetInput``.
-        """
-        uploaded_names = [
-            self.asset_uploader.upload_asset(mc) for mc in media_context
-        ]
-        if len(uploaded_names) == 1:
-            return self.asset_mapper.create_existing_asset_input(uploaded_names[0])
-        return self.asset_mapper.create_existing_asset_input(uploaded_names)
 
     def upload_datapoint(
         self, datapoint: Datapoint, dataset_id: str, index: int
@@ -64,7 +53,7 @@ class DatapointUploader:
         context_asset = (
             None
             if has_group or not datapoint.media_context
-            else self._upload_and_map_media_context(datapoint.media_context)
+            else self._upload_and_map_asset(datapoint.media_context)
         )
 
         return self.openapi_service.dataset.datapoints_api.dataset_dataset_id_datapoint_post(

--- a/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
@@ -30,6 +30,23 @@ class DatapointUploader:
             uploaded_name = self.asset_uploader.upload_asset(asset)
             return self.asset_mapper.create_existing_asset_input(uploaded_name)
 
+    def _upload_and_map_media_context(
+        self, media_context: str | list[str]
+    ) -> IAssetInput:
+        """Upload media context asset(s) and map to IAssetInput.
+
+        Accepts either a single string (one image per datapoint) or a list of
+        strings (multiple images per datapoint, all shown as media context).
+        """
+        if isinstance(media_context, list):
+            uploaded_names = [
+                self.asset_uploader.upload_asset(mc) for mc in media_context
+            ]
+            return self.asset_mapper.create_existing_asset_input(uploaded_names)
+        else:
+            uploaded_name = self.asset_uploader.upload_asset(media_context)
+            return self.asset_mapper.create_existing_asset_input(uploaded_name)
+
     def upload_datapoint(
         self, datapoint: Datapoint, dataset_id: str, index: int
     ) -> CreateDatapointEndpointOutput:
@@ -48,9 +65,7 @@ class DatapointUploader:
         context_asset = (
             None
             if has_group or not datapoint.media_context
-            else self.asset_mapper.create_existing_asset_input(
-                self.asset_uploader.upload_asset(datapoint.media_context)
-            )
+            else self._upload_and_map_media_context(datapoint.media_context)
         )
 
         return self.openapi_service.dataset.datapoints_api.dataset_dataset_id_datapoint_post(

--- a/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
@@ -1,6 +1,72 @@
 from itertools import zip_longest
 from typing import Literal, cast, Iterable
 from rapidata.rapidata_client.datapoints._datapoint import Datapoint
+from rapidata.rapidata_client.config import logger
+
+
+def _normalize_media_contexts(
+    media_contexts: list[list[str]] | list[str] | None,
+) -> list[list[str]] | None:
+    """Normalize media_contexts to ``list[list[str]] | None``.
+
+    Accepts the legacy ``list[str]`` shape (one media context per datapoint)
+    by wrapping each string in a single-element list, after emitting a
+    deprecation warning. This way the rest of the pipeline only ever has
+    to deal with ``list[list[str]]``.
+    """
+    if media_contexts is None:
+        return None
+
+    if not isinstance(media_contexts, list):
+        raise ValueError(
+            "media_contexts must be a list of lists of strings or None, "
+            f"got {type(media_contexts).__name__}."
+        )
+
+    has_str = any(isinstance(mc, str) for mc in media_contexts)
+    has_list = any(isinstance(mc, list) for mc in media_contexts)
+    if has_str and has_list:
+        raise ValueError(
+            "media_contexts must be a list of lists of strings, not a mix of strings and lists."
+        )
+
+    if has_str:
+        logger.warning(
+            "Passing a flat list of strings for media_contexts is deprecated; "
+            "pass a list of lists of strings instead. Each string has been "
+            "wrapped in a single-element list."
+        )
+        normalized: list[list[str]] = []
+        for mc in media_contexts:
+            if not isinstance(mc, str):
+                raise ValueError(
+                    "media_contexts must be a list of lists of strings, "
+                    f"got element of type {type(mc).__name__}."
+                )
+            if mc == "":
+                raise ValueError(
+                    "media_contexts entries cannot be empty strings."
+                )
+            normalized.append([mc])
+        return normalized
+
+    # list[list[str]] case
+    for mc in media_contexts:
+        if not isinstance(mc, list):
+            raise ValueError(
+                "media_contexts must be a list of lists of strings, "
+                f"got element of type {type(mc).__name__}."
+            )
+        if len(mc) == 0:
+            raise ValueError(
+                "Each inner media_contexts list must contain at least one string. "
+                "Use None for the whole field if not needed."
+            )
+        if any(not isinstance(item, str) or item == "" for item in mc):
+            raise ValueError(
+                "Every entry in a media_contexts inner list must be a non-empty string."
+            )
+    return cast("list[list[str]]", media_contexts)
 
 
 class DatapointsValidator:
@@ -8,7 +74,7 @@ class DatapointsValidator:
     def validate_datapoints(
         datapoints: list[str] | list[list[str]],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         sentences: list[str] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
         groups: list[str] | None = None,
@@ -22,32 +88,10 @@ class DatapointsValidator:
             raise ValueError("Datapoints must be a list of strings")
         if contexts and len(contexts) != len(datapoints):
             raise ValueError("Number of contexts must match number of datapoints")
-        if media_contexts is not None:
-            if len(media_contexts) != len(datapoints):
-                raise ValueError(
-                    "Number of media contexts must match number of datapoints"
-                )
-            # Allow either list[str] (one image per datapoint) or
-            # list[list[str]] (multiple images per datapoint). Reject mixed input.
-            has_str = any(isinstance(mc, str) for mc in media_contexts)
-            has_list = any(isinstance(mc, list) for mc in media_contexts)
-            if has_str and has_list:
-                raise ValueError(
-                    "media_contexts must be either a list of strings or a list of lists of strings, not a mix."
-                )
-            if has_list:
-                for mc in media_contexts:
-                    if not isinstance(mc, list):
-                        # should not happen because of has_list/has_str check
-                        continue
-                    if len(mc) == 0:
-                        raise ValueError(
-                            "Each inner media_contexts list must contain at least one string. Use None for the whole field if not needed."
-                        )
-                    if any(not isinstance(item, str) or item == "" for item in mc):
-                        raise ValueError(
-                            "Every entry in a media_contexts inner list must be a non-empty string."
-                        )
+        if media_contexts is not None and len(media_contexts) != len(datapoints):
+            raise ValueError(
+                "Number of media contexts must match number of datapoints"
+            )
         if sentences and len(sentences) != len(datapoints):
             raise ValueError("Number of sentences must match number of datapoints")
         if private_metadata and len(private_metadata) != len(datapoints):
@@ -65,17 +109,20 @@ class DatapointsValidator:
     def map_datapoints(
         datapoints: list[str] | list[list[str]],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | list[str] | None = None,
         sentences: list[str] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
         groups: list[str] | None = None,
         data_type: Literal["text", "media"] = "media",
         multi_asset: bool = False,
     ) -> list[Datapoint]:
+        # Coerce legacy list[str] form once, here, so every consumer below
+        # only has to think about list[list[str]].
+        normalized_media_contexts = _normalize_media_contexts(media_contexts)
         DatapointsValidator.validate_datapoints(
             datapoints=datapoints,
             contexts=contexts,
-            media_contexts=media_contexts,
+            media_contexts=normalized_media_contexts,
             sentences=sentences,
             private_metadata=private_metadata,
             groups=groups,
@@ -92,11 +139,11 @@ class DatapointsValidator:
                 group=group,
             )
             for asset, context, media_context, sentence, private_tag, group in cast(
-                "Iterable[tuple[str | list[str], str | None, str | list[str] | None, str | None, dict[str, str] | None, str | None]]",  # because iterator only supports 5 arguments with specific type casting
+                "Iterable[tuple[str | list[str], str | None, list[str] | None, str | None, dict[str, str] | None, str | None]]",  # because iterator only supports 5 arguments with specific type casting
                 zip_longest(
                     datapoints,
                     contexts or [],
-                    media_contexts or [],
+                    normalized_media_contexts or [],
                     sentences or [],
                     private_metadata or [],
                     groups or [],

--- a/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
@@ -8,7 +8,7 @@ class DatapointsValidator:
     def validate_datapoints(
         datapoints: list[str] | list[list[str]],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         sentences: list[str] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
         groups: list[str] | None = None,
@@ -22,8 +22,32 @@ class DatapointsValidator:
             raise ValueError("Datapoints must be a list of strings")
         if contexts and len(contexts) != len(datapoints):
             raise ValueError("Number of contexts must match number of datapoints")
-        if media_contexts and len(media_contexts) != len(datapoints):
-            raise ValueError("Number of media contexts must match number of datapoints")
+        if media_contexts is not None:
+            if len(media_contexts) != len(datapoints):
+                raise ValueError(
+                    "Number of media contexts must match number of datapoints"
+                )
+            # Allow either list[str] (one image per datapoint) or
+            # list[list[str]] (multiple images per datapoint). Reject mixed input.
+            has_str = any(isinstance(mc, str) for mc in media_contexts)
+            has_list = any(isinstance(mc, list) for mc in media_contexts)
+            if has_str and has_list:
+                raise ValueError(
+                    "media_contexts must be either a list of strings or a list of lists of strings, not a mix."
+                )
+            if has_list:
+                for mc in media_contexts:
+                    if not isinstance(mc, list):
+                        # should not happen because of has_list/has_str check
+                        continue
+                    if len(mc) == 0:
+                        raise ValueError(
+                            "Each inner media_contexts list must contain at least one string. Use None for the whole field if not needed."
+                        )
+                    if any(not isinstance(item, str) or item == "" for item in mc):
+                        raise ValueError(
+                            "Every entry in a media_contexts inner list must be a non-empty string."
+                        )
         if sentences and len(sentences) != len(datapoints):
             raise ValueError("Number of sentences must match number of datapoints")
         if private_metadata and len(private_metadata) != len(datapoints):
@@ -41,7 +65,7 @@ class DatapointsValidator:
     def map_datapoints(
         datapoints: list[str] | list[list[str]],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         sentences: list[str] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
         groups: list[str] | None = None,
@@ -68,7 +92,7 @@ class DatapointsValidator:
                 group=group,
             )
             for asset, context, media_context, sentence, private_tag, group in cast(
-                "Iterable[tuple[str | list[str], str | None, str | None, str | None, dict[str, str] | None, str | None]]",  # because iterator only supports 5 arguments with specific type casting
+                "Iterable[tuple[str | list[str], str | None, str | list[str] | None, str | None, dict[str, str] | None, str | None]]",  # because iterator only supports 5 arguments with specific type casting
                 zip_longest(
                     datapoints,
                     contexts or [],

--- a/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoints_validator.py
@@ -1,72 +1,9 @@
 from itertools import zip_longest
 from typing import Literal, cast, Iterable
-from rapidata.rapidata_client.datapoints._datapoint import Datapoint
-from rapidata.rapidata_client.config import logger
-
-
-def _normalize_media_contexts(
-    media_contexts: list[list[str]] | list[str] | None,
-) -> list[list[str]] | None:
-    """Normalize media_contexts to ``list[list[str]] | None``.
-
-    Accepts the legacy ``list[str]`` shape (one media context per datapoint)
-    by wrapping each string in a single-element list, after emitting a
-    deprecation warning. This way the rest of the pipeline only ever has
-    to deal with ``list[list[str]]``.
-    """
-    if media_contexts is None:
-        return None
-
-    if not isinstance(media_contexts, list):
-        raise ValueError(
-            "media_contexts must be a list of lists of strings or None, "
-            f"got {type(media_contexts).__name__}."
-        )
-
-    has_str = any(isinstance(mc, str) for mc in media_contexts)
-    has_list = any(isinstance(mc, list) for mc in media_contexts)
-    if has_str and has_list:
-        raise ValueError(
-            "media_contexts must be a list of lists of strings, not a mix of strings and lists."
-        )
-
-    if has_str:
-        logger.warning(
-            "Passing a flat list of strings for media_contexts is deprecated; "
-            "pass a list of lists of strings instead. Each string has been "
-            "wrapped in a single-element list."
-        )
-        normalized: list[list[str]] = []
-        for mc in media_contexts:
-            if not isinstance(mc, str):
-                raise ValueError(
-                    "media_contexts must be a list of lists of strings, "
-                    f"got element of type {type(mc).__name__}."
-                )
-            if mc == "":
-                raise ValueError(
-                    "media_contexts entries cannot be empty strings."
-                )
-            normalized.append([mc])
-        return normalized
-
-    # list[list[str]] case
-    for mc in media_contexts:
-        if not isinstance(mc, list):
-            raise ValueError(
-                "media_contexts must be a list of lists of strings, "
-                f"got element of type {type(mc).__name__}."
-            )
-        if len(mc) == 0:
-            raise ValueError(
-                "Each inner media_contexts list must contain at least one string. "
-                "Use None for the whole field if not needed."
-            )
-        if any(not isinstance(item, str) or item == "" for item in mc):
-            raise ValueError(
-                "Every entry in a media_contexts inner list must be a non-empty string."
-            )
-    return cast("list[list[str]]", media_contexts)
+from rapidata.rapidata_client.datapoints._datapoint import (
+    Datapoint,
+    coerce_media_context,
+)
 
 
 class DatapointsValidator:
@@ -74,7 +11,7 @@ class DatapointsValidator:
     def validate_datapoints(
         datapoints: list[str] | list[list[str]],
         contexts: list[str] | None = None,
-        media_contexts: list[list[str]] | None = None,
+        media_contexts: list[list[str]] | list[str] | None = None,
         sentences: list[str] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
         groups: list[str] | None = None,
@@ -116,34 +53,36 @@ class DatapointsValidator:
         data_type: Literal["text", "media"] = "media",
         multi_asset: bool = False,
     ) -> list[Datapoint]:
-        # Coerce legacy list[str] form once, here, so every consumer below
-        # only has to think about list[list[str]].
-        normalized_media_contexts = _normalize_media_contexts(media_contexts)
         DatapointsValidator.validate_datapoints(
             datapoints=datapoints,
             contexts=contexts,
-            media_contexts=normalized_media_contexts,
+            media_contexts=media_contexts,
             sentences=sentences,
             private_metadata=private_metadata,
             groups=groups,
             multi_asset=multi_asset,
         )
+        # ``media_context`` may arrive as a ``str`` (legacy form, one media
+        # context per datapoint) or as a ``list[str]``. The same
+        # ``coerce_media_context`` helper that backs the Datapoint field
+        # validator handles both — calling it here narrows the static type
+        # so pyright is happy with the Datapoint constructor.
         return [
             Datapoint(
                 asset=asset,
                 data_type=data_type,
                 context=context,
-                media_context=media_context,
+                media_context=coerce_media_context(media_context),
                 sentence=sentence,
                 private_metadata=private_tag,
                 group=group,
             )
             for asset, context, media_context, sentence, private_tag, group in cast(
-                "Iterable[tuple[str | list[str], str | None, list[str] | None, str | None, dict[str, str] | None, str | None]]",  # because iterator only supports 5 arguments with specific type casting
+                "Iterable[tuple[str | list[str], str | None, str | list[str] | None, str | None, dict[str, str] | None, str | None]]",  # because iterator only supports 5 arguments with specific type casting
                 zip_longest(
                     datapoints,
                     contexts or [],
-                    normalized_media_contexts or [],
+                    media_contexts or [],
                     sentences or [],
                     private_metadata or [],
                     groups or [],

--- a/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
+++ b/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
@@ -419,7 +419,7 @@ class RapidataDataset:
         )
 
         # Collect unique groups (first occurrence per group wins for context)
-        groups: dict[str, tuple[str | None, str | list[str] | None]] = {}
+        groups: dict[str, tuple[str | None, list[str] | None]] = {}
         for dp in datapoints:
             if dp.group is not None and dp.group not in groups:
                 groups[dp.group] = (dp.context, dp.media_context)
@@ -427,24 +427,15 @@ class RapidataDataset:
         if not groups:
             return
 
-        asset_uploader = self.datapoint_uploader.asset_uploader
-        asset_mapper = self.datapoint_uploader.asset_mapper
-
         for group_id, (context, media_context) in groups.items():
             context_asset = None
             if media_context is not None:
-                if isinstance(media_context, list):
-                    uploaded_names = [
-                        asset_uploader.upload_asset(mc) for mc in media_context
-                    ]
-                    context_asset = asset_mapper.create_existing_asset_input(
-                        uploaded_names
-                    )
-                else:
-                    uploaded_name = asset_uploader.upload_asset(media_context)
-                    context_asset = asset_mapper.create_existing_asset_input(
-                        uploaded_name
-                    )
+                # media_context is always a list (Datapoint validator coerces).
+                # A single-element list is sent as ExistingAssetInput; multiple
+                # entries are bundled into a MultiAssetInput by the helper.
+                context_asset = self.datapoint_uploader._upload_and_map_media_context(
+                    media_context
+                )
 
             self.openapi_service.dataset.dataset_group_api.dataset_dataset_id_group_post(
                 dataset_id=self.id,

--- a/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
+++ b/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
@@ -434,8 +434,10 @@ class RapidataDataset:
                 # coerces). The shared upload+map helper bundles it into a
                 # MultiAssetInput (or ExistingAssetInput if a bare string slips
                 # through).
-                context_asset = self.datapoint_uploader._upload_and_map_asset(
-                    media_context
+                context_asset = (
+                    self.datapoint_uploader.asset_uploader.upload_and_map_asset(
+                        media_context
+                    )
                 )
 
             self.openapi_service.dataset.dataset_group_api.dataset_dataset_id_group_post(

--- a/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
+++ b/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
@@ -430,10 +430,11 @@ class RapidataDataset:
         for group_id, (context, media_context) in groups.items():
             context_asset = None
             if media_context is not None:
-                # media_context is always a list (Datapoint validator coerces).
-                # A single-element list is sent as ExistingAssetInput; multiple
-                # entries are bundled into a MultiAssetInput by the helper.
-                context_asset = self.datapoint_uploader._upload_and_map_media_context(
+                # media_context is always a list (the Datapoint validator
+                # coerces). The shared upload+map helper bundles it into a
+                # MultiAssetInput (or ExistingAssetInput if a bare string slips
+                # through).
+                context_asset = self.datapoint_uploader._upload_and_map_asset(
                     media_context
                 )
 

--- a/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
+++ b/src/rapidata/rapidata_client/dataset/_rapidata_dataset.py
@@ -419,7 +419,7 @@ class RapidataDataset:
         )
 
         # Collect unique groups (first occurrence per group wins for context)
-        groups: dict[str, tuple[str | None, str | None]] = {}
+        groups: dict[str, tuple[str | None, str | list[str] | None]] = {}
         for dp in datapoints:
             if dp.group is not None and dp.group not in groups:
                 groups[dp.group] = (dp.context, dp.media_context)
@@ -433,8 +433,18 @@ class RapidataDataset:
         for group_id, (context, media_context) in groups.items():
             context_asset = None
             if media_context is not None:
-                uploaded_name = asset_uploader.upload_asset(media_context)
-                context_asset = asset_mapper.create_existing_asset_input(uploaded_name)
+                if isinstance(media_context, list):
+                    uploaded_names = [
+                        asset_uploader.upload_asset(mc) for mc in media_context
+                    ]
+                    context_asset = asset_mapper.create_existing_asset_input(
+                        uploaded_names
+                    )
+                else:
+                    uploaded_name = asset_uploader.upload_asset(media_context)
+                    context_asset = asset_mapper.create_existing_asset_input(
+                        uploaded_name
+                    )
 
             self.openapi_service.dataset.dataset_group_api.dataset_dataset_id_group_post(
                 dataset_id=self.id,

--- a/src/rapidata/rapidata_client/job/rapidata_job_definition.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_definition.py
@@ -64,7 +64,7 @@ class RapidataJobDefinition:
             datapoints (list[str] | list[list[str]]): paths to the datapoints or strings for text datapoints.
             data_type (Literal["text", "media"]): The type of the datapoints.
             contexts (list[str], optional): One text context per datapoint. Defaults to None.
-            media_contexts (list[list[str]], optional): Media contexts shown alongside each datapoint, one inner list per datapoint. Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically. Defaults to None.
+            media_contexts (list[list[str]], optional): Image URLs / paths shown alongside each datapoint, one inner list per datapoint. Use a single-element inner list for one image per datapoint, or multiple entries to display several images. Defaults to None.
             sentences (list[str], optional): The sentences associated with each datapoint (used by select-words workflows). Defaults to None.
             private_metadata (list[dict[str, str]], optional): Key-value pairs attached to each datapoint that will not be shown to labelers. Defaults to None.
         """

--- a/src/rapidata/rapidata_client/job/rapidata_job_definition.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_definition.py
@@ -54,7 +54,7 @@ class RapidataJobDefinition:
         datapoints: list[str] | list[list[str]],
         data_type: Literal["text", "media"] = "media",
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         sentences: list[str] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -63,6 +63,10 @@ class RapidataJobDefinition:
         Args:
             datapoints (list[str] | list[list[str]]): paths to the datapoints or strings for text datapoints.
             data_type (Literal["text", "media"]): The type of the datapoints.
+            contexts (list[str], optional): One text context per datapoint. Defaults to None.
+            media_contexts (list[str] | list[list[str]], optional): One media context per datapoint. Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint. Defaults to None.
+            sentences (list[str], optional): The sentences associated with each datapoint (used by select-words workflows). Defaults to None.
+            private_metadata (list[dict[str, str]], optional): Key-value pairs attached to each datapoint that will not be shown to labelers. Defaults to None.
         """
         with tracer.start_as_current_span("JobDefinition.update_dataset"):
             from rapidata.rapidata_client.datapoints._datapoints_validator import (

--- a/src/rapidata/rapidata_client/job/rapidata_job_definition.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_definition.py
@@ -54,7 +54,7 @@ class RapidataJobDefinition:
         datapoints: list[str] | list[list[str]],
         data_type: Literal["text", "media"] = "media",
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         sentences: list[str] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -64,7 +64,7 @@ class RapidataJobDefinition:
             datapoints (list[str] | list[list[str]]): paths to the datapoints or strings for text datapoints.
             data_type (Literal["text", "media"]): The type of the datapoints.
             contexts (list[str], optional): One text context per datapoint. Defaults to None.
-            media_contexts (list[str] | list[list[str]], optional): One media context per datapoint. Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint. Defaults to None.
+            media_contexts (list[list[str]], optional): Media contexts shown alongside each datapoint, one inner list per datapoint. Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically. Defaults to None.
             sentences (list[str], optional): The sentences associated with each datapoint (used by select-words workflows). Defaults to None.
             private_metadata (list[dict[str, str]], optional): Key-value pairs attached to each datapoint that will not be shown to labelers. Defaults to None.
         """

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -155,7 +155,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         confidence_threshold: float | None = None,
         quorum_threshold: int | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -177,8 +177,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the classification. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the classification i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the classification i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             confidence_threshold (float, optional): The probability threshold for the classification. Defaults to None.\n
                 If provided, the classification datapoint will stop after the threshold is reached or at the number of responses, whatever happens first.
             quorum_threshold (int, optional): The number of matching responses required to reach quorum. Defaults to None.\n
@@ -224,7 +225,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         a_b_names: list[str] | None = None,
         confidence_threshold: float | None = None,
         quorum_threshold: int | None = None,
@@ -245,9 +246,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             a_b_names (list[str], optional): Custom naming for the two opposing models defined by the index in the datapoints list. Defaults to None.\n
                 If provided has to be a list of exactly two strings.
                 example:
@@ -311,7 +313,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         random_comparisons_ratio: float = 0.5,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> RapidataJobDefinition:
         """
@@ -332,9 +334,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the ranking i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the ranking i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per ranking, or a list of lists of strings to display multiple images / videos as media context per ranking.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             settings (Sequence[RapidataSetting], optional): The list of settings for the ranking. Defaults to []. Decides how the tasks should be shown.
@@ -398,7 +401,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -417,9 +420,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the free text. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the free text i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the free text i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             settings (Sequence[RapidataSetting], optional): The list of settings for the free text. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -496,7 +500,7 @@ class RapidataJobManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -513,8 +517,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the locate. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the locate i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the locate i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             settings (Sequence[RapidataSetting], optional): The list of settings for the locate. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -544,7 +549,7 @@ class RapidataJobManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -561,8 +566,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the draw lines i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the draw lines i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             settings (Sequence[RapidataSetting], optional): The list of settings for the draw lines. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -592,7 +598,7 @@ class RapidataJobManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -612,8 +618,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the timestamp i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the timestamp i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             settings (Sequence[RapidataSetting], optional): The list of settings for the timestamp. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -177,9 +177,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the classification. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the classification (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the classification (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             confidence_threshold (float, optional): The probability threshold for the classification. Defaults to None.\n
                 If provided, the classification datapoint will stop after the threshold is reached or at the number of responses, whatever happens first.
             quorum_threshold (int, optional): The number of matching responses required to reach quorum. Defaults to None.\n
@@ -246,10 +246,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the comparison (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             a_b_names (list[str], optional): Custom naming for the two opposing models defined by the index in the datapoints list. Defaults to None.\n
                 If provided has to be a list of exactly two strings.
                 example:
@@ -334,10 +334,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the ranking (each inner list is the media URLs / paths shown for that ranking). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the ranking (each inner list is the images shown for that ranking). Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per ranking, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per ranking, or multiple entries to display several images.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             settings (Sequence[RapidataSetting], optional): The list of settings for the ranking. Defaults to []. Decides how the tasks should be shown.
@@ -347,11 +347,6 @@ class RapidataJobManager:
                 raise ValueError(
                     "Number of contexts must match the number of sets that will be ranked"
                 )
-            from rapidata.rapidata_client.datapoints._datapoints_validator import (
-                _normalize_media_contexts,
-            )
-
-            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "Number of media contexts must match the number of sets that will be ranked"
@@ -425,10 +420,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the free text. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the free text (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the free text (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             settings (Sequence[RapidataSetting], optional): The list of settings for the free text. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -522,9 +517,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the locate. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the locate (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the locate (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             settings (Sequence[RapidataSetting], optional): The list of settings for the locate. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -571,9 +566,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the draw lines (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the draw lines (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             settings (Sequence[RapidataSetting], optional): The list of settings for the draw lines. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -623,9 +618,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the timestamp (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the timestamp (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             settings (Sequence[RapidataSetting], optional): The list of settings for the timestamp. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -155,7 +155,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         confidence_threshold: float | None = None,
         quorum_threshold: int | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -177,9 +177,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the classification. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the classification i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the classification (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             confidence_threshold (float, optional): The probability threshold for the classification. Defaults to None.\n
                 If provided, the classification datapoint will stop after the threshold is reached or at the number of responses, whatever happens first.
             quorum_threshold (int, optional): The number of matching responses required to reach quorum. Defaults to None.\n
@@ -225,7 +225,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         a_b_names: list[str] | None = None,
         confidence_threshold: float | None = None,
         quorum_threshold: int | None = None,
@@ -246,10 +246,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             a_b_names (list[str], optional): Custom naming for the two opposing models defined by the index in the datapoints list. Defaults to None.\n
                 If provided has to be a list of exactly two strings.
                 example:
@@ -313,7 +313,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         random_comparisons_ratio: float = 0.5,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
     ) -> RapidataJobDefinition:
         """
@@ -334,10 +334,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the ranking i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the ranking (each inner list is the media URLs / paths shown for that ranking). Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per ranking, or a list of lists of strings to display multiple images / videos as media context per ranking.
+                Use a single-element inner list for one media asset per ranking, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             settings (Sequence[RapidataSetting], optional): The list of settings for the ranking. Defaults to []. Decides how the tasks should be shown.
@@ -347,6 +347,11 @@ class RapidataJobManager:
                 raise ValueError(
                     "Number of contexts must match the number of sets that will be ranked"
                 )
+            from rapidata.rapidata_client.datapoints._datapoints_validator import (
+                _normalize_media_contexts,
+            )
+
+            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "Number of media contexts must match the number of sets that will be ranked"
@@ -401,7 +406,7 @@ class RapidataJobManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -420,10 +425,10 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the free text. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the free text i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the free text (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             settings (Sequence[RapidataSetting], optional): The list of settings for the free text. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -500,7 +505,7 @@ class RapidataJobManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -517,9 +522,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the locate. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the locate i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the locate (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             settings (Sequence[RapidataSetting], optional): The list of settings for the locate. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -549,7 +554,7 @@ class RapidataJobManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -566,9 +571,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the draw lines i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the draw lines (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             settings (Sequence[RapidataSetting], optional): The list of settings for the draw lines. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n
@@ -598,7 +603,7 @@ class RapidataJobManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         private_metadata: list[dict[str, str]] | None = None,
     ) -> RapidataJobDefinition:
@@ -618,9 +623,9 @@ class RapidataJobManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the timestamp i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the timestamp (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             settings (Sequence[RapidataSetting], optional): The list of settings for the timestamp. Defaults to []. Decides how the tasks should be shown.
             private_metadata (list[dict[str, str]], optional): Key-value string pairs for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints.\n

--- a/src/rapidata/rapidata_client/order/rapidata_order_manager.py
+++ b/src/rapidata/rapidata_client/order/rapidata_order_manager.py
@@ -183,7 +183,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         validation_set_id: str | None = None,
         confidence_threshold: float | None = None,
         quorum_threshold: int | None = None,
@@ -208,9 +208,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the classification. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the classification i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the classification (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             confidence_threshold (float, optional): The probability threshold for the classification. Defaults to None.\n
@@ -282,7 +282,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         a_b_names: list[str] | None = None,
         validation_set_id: str | None = None,
         confidence_threshold: float | None = None,
@@ -306,10 +306,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             a_b_names (list[str], optional): Custom naming for the two opposing models defined by the index in the datapoints list. Defaults to None.\n
                 If provided has to be a list of exactly two strings.
                 example:
@@ -406,7 +406,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         random_comparisons_ratio: float = 0.5,
         contexts: Optional[list[str]] = None,
-        media_contexts: Optional[list[str] | list[list[str]]] = None,
+        media_contexts: Optional[list[list[str]]] = None,
         validation_set_id: Optional[str] = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -430,10 +430,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the ranking i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the ranking (each inner list is the media URLs / paths shown for that ranking). Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per ranking, or a list of lists of strings to display multiple images / videos as media context per ranking.
+                Use a single-element inner list for one media asset per ranking, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the ranking. Defaults to []. Decides who the tasks should be shown to.
@@ -464,6 +464,11 @@ class RapidataOrderManager:
                 raise ValueError(
                     "Number of contexts must match the number of sets that will be ranked"
                 )
+            from rapidata.rapidata_client.datapoints._datapoints_validator import (
+                _normalize_media_contexts,
+            )
+
+            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "Number of media contexts must match the number of sets that will be ranked"
@@ -521,7 +526,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
@@ -542,10 +547,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the free text. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the free text i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the free text (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             filters (Sequence[RapidataFilter], optional): The list of filters for the free text. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the free text. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the free text. Defaults to []. Decides in what order the tasks should be shown.
@@ -598,7 +603,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         sentences: list[str],
         responses_per_datapoint: int = 10,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -618,9 +623,9 @@ class RapidataOrderManager:
             sentences (list[str]): The list of sentences for the select words - Will be split up by spaces and shown along side each datapoint.\n
                 Must be the same length as datapoints.
             responses_per_datapoint (int, optional): The number of responses that will be collected per datapoint. Defaults to 10.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the select words i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the select words (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the select words. Defaults to []. Decides who the tasks should be shown to.
@@ -677,7 +682,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -697,9 +702,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the locate. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the locate i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the locate (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the locate. Defaults to []. Decides who the tasks should be shown to.
@@ -751,7 +756,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -771,9 +776,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the draw lines i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the draw lines (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the draw lines. Defaults to []. Decides who the tasks should be shown to.
@@ -825,7 +830,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -848,9 +853,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the timestamp i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the timestamp (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the timestamp. Defaults to []. Decides who the tasks should be shown to.

--- a/src/rapidata/rapidata_client/order/rapidata_order_manager.py
+++ b/src/rapidata/rapidata_client/order/rapidata_order_manager.py
@@ -208,9 +208,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the classification. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the classification (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the classification (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             confidence_threshold (float, optional): The probability threshold for the classification. Defaults to None.\n
@@ -306,10 +306,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the comparison (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             a_b_names (list[str], optional): Custom naming for the two opposing models defined by the index in the datapoints list. Defaults to None.\n
                 If provided has to be a list of exactly two strings.
                 example:
@@ -430,10 +430,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the ranking (each inner list is the media URLs / paths shown for that ranking). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the ranking (each inner list is the images shown for that ranking). Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per ranking, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per ranking, or multiple entries to display several images.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the ranking. Defaults to []. Decides who the tasks should be shown to.
@@ -464,11 +464,6 @@ class RapidataOrderManager:
                 raise ValueError(
                     "Number of contexts must match the number of sets that will be ranked"
                 )
-            from rapidata.rapidata_client.datapoints._datapoints_validator import (
-                _normalize_media_contexts,
-            )
-
-            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "Number of media contexts must match the number of sets that will be ranked"
@@ -547,10 +542,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the free text. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the free text (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the free text (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             filters (Sequence[RapidataFilter], optional): The list of filters for the free text. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the free text. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the free text. Defaults to []. Decides in what order the tasks should be shown.
@@ -623,9 +618,9 @@ class RapidataOrderManager:
             sentences (list[str]): The list of sentences for the select words - Will be split up by spaces and shown along side each datapoint.\n
                 Must be the same length as datapoints.
             responses_per_datapoint (int, optional): The number of responses that will be collected per datapoint. Defaults to 10.
-            media_contexts (list[list[str]], optional): The list of media contexts for the select words (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the select words (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the select words. Defaults to []. Decides who the tasks should be shown to.
@@ -702,9 +697,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the locate. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the locate (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the locate (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the locate. Defaults to []. Decides who the tasks should be shown to.
@@ -776,9 +771,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the draw lines (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the draw lines (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the draw lines. Defaults to []. Decides who the tasks should be shown to.
@@ -853,9 +848,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the timestamp (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the timestamp (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the timestamp. Defaults to []. Decides who the tasks should be shown to.

--- a/src/rapidata/rapidata_client/order/rapidata_order_manager.py
+++ b/src/rapidata/rapidata_client/order/rapidata_order_manager.py
@@ -183,7 +183,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         validation_set_id: str | None = None,
         confidence_threshold: float | None = None,
         quorum_threshold: int | None = None,
@@ -208,8 +208,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the classification. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the classification i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the classification i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and options. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             confidence_threshold (float, optional): The probability threshold for the classification. Defaults to None.\n
@@ -281,7 +282,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         a_b_names: list[str] | None = None,
         validation_set_id: str | None = None,
         confidence_threshold: float | None = None,
@@ -305,9 +306,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             a_b_names (list[str], optional): Custom naming for the two opposing models defined by the index in the datapoints list. Defaults to None.\n
                 If provided has to be a list of exactly two strings.
                 example:
@@ -404,7 +406,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         random_comparisons_ratio: float = 0.5,
         contexts: Optional[list[str]] = None,
-        media_contexts: Optional[list[str]] = None,
+        media_contexts: Optional[list[str] | list[list[str]]] = None,
         validation_set_id: Optional[str] = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -428,9 +430,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the ranking i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the ranking i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per ranking, or a list of lists of strings to display multiple images / videos as media context per ranking.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the ranking. Defaults to []. Decides who the tasks should be shown to.
@@ -518,7 +521,7 @@ class RapidataOrderManager:
         data_type: Literal["media", "text"] = "media",
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
         selections: Sequence[RapidataSelection] | None = None,
@@ -539,9 +542,10 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the free text. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the free text i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the free text i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             filters (Sequence[RapidataFilter], optional): The list of filters for the free text. Defaults to []. Decides who the tasks should be shown to.
             settings (Sequence[RapidataSetting], optional): The list of settings for the free text. Defaults to []. Decides how the tasks should be shown.
             selections (Sequence[RapidataSelection], optional): The list of selections for the free text. Defaults to []. Decides in what order the tasks should be shown.
@@ -594,7 +598,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         sentences: list[str],
         responses_per_datapoint: int = 10,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -614,8 +618,9 @@ class RapidataOrderManager:
             sentences (list[str]): The list of sentences for the select words - Will be split up by spaces and shown along side each datapoint.\n
                 Must be the same length as datapoints.
             responses_per_datapoint (int, optional): The number of responses that will be collected per datapoint. Defaults to 10.
-            media_contexts (list[str], optional): The list of media contexts for the select words i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the select words i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the select words. Defaults to []. Decides who the tasks should be shown to.
@@ -672,7 +677,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -692,8 +697,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the locate. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the locate i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the locate i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the locate. Defaults to []. Decides who the tasks should be shown to.
@@ -745,7 +751,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -765,8 +771,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the draw lines i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the draw lines i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the draw lines. Defaults to []. Decides who the tasks should be shown to.
@@ -818,7 +825,7 @@ class RapidataOrderManager:
         datapoints: list[str],
         responses_per_datapoint: int = 10,
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         validation_set_id: str | None = None,
         filters: Sequence[RapidataFilter] | None = None,
         settings: Sequence[RapidataSetting] | None = None,
@@ -841,8 +848,9 @@ class RapidataOrderManager:
             contexts (list[str], optional): The list of contexts for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts for the timestamp i.e links to the images / videos. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts for the timestamp i.e links to the images / videos. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             validation_set_id (str, optional): The ID of the validation set. Defaults to None.\n
                 If provided, one validation task will be shown infront of the datapoints that will be labeled.
             filters (Sequence[RapidataFilter], optional): The list of filters for the timestamp. Defaults to []. Decides who the tasks should be shown to.

--- a/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
+++ b/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
@@ -33,17 +33,22 @@ class ValidationRapidUploader:
         # Translate truth for compare rapids with media assets
         truth = self._translate_compare_truth(rapid, asset_to_uploaded)
 
+        # media_context is always a list[str]; reuse the same upload+map helper
+        # used for the main asset (we don't need the asset->uploaded mapping
+        # part here, so just take the IAssetInput).
+        context_asset = (
+            self._upload_and_map_asset(rapid.media_context)[0]
+            if rapid.media_context
+            else None
+        )
+
         self.openapi_service.validation.validation_api.validation_set_validation_set_id_rapid_post(
             validation_set_id=validation_set_id,
             add_validation_rapid_endpoint_input=AddValidationRapidEndpointInput(
                 asset=uploaded_asset,
                 payload=self._get_payload(rapid),
                 context=rapid.context,
-                contextAsset=(
-                    self._upload_and_map_media_context(rapid.media_context)
-                    if rapid.media_context
-                    else None
-                ),
+                contextAsset=context_asset,
                 truth=truth,
                 randomCorrectProbability=rapid.random_correct_probability,
                 explanation=rapid.explanation,
@@ -54,22 +59,6 @@ class ValidationRapidUploader:
                 ),
             ),
         )
-
-    def _upload_and_map_media_context(
-        self, media_context: list[str]
-    ) -> IAssetInput:
-        """Upload media context asset(s) and map to IAssetInput.
-
-        ``media_context`` is always a list. A single-element list is sent as a
-        plain ``ExistingAssetInput``; two or more entries are bundled into a
-        ``MultiAssetInput``.
-        """
-        uploaded_names = [
-            self.asset_uploader.upload_asset(mc) for mc in media_context
-        ]
-        if len(uploaded_names) == 1:
-            return self.asset_mapper.create_existing_asset_input(uploaded_names[0])
-        return self.asset_mapper.create_existing_asset_input(uploaded_names)
 
     def _upload_and_map_asset(
         self, asset: str | list[str]

--- a/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
+++ b/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
@@ -56,21 +56,20 @@ class ValidationRapidUploader:
         )
 
     def _upload_and_map_media_context(
-        self, media_context: str | list[str]
+        self, media_context: list[str]
     ) -> IAssetInput:
         """Upload media context asset(s) and map to IAssetInput.
 
-        Accepts either a single string (one image) or a list of strings
-        (multiple images shown as media context).
+        ``media_context`` is always a list. A single-element list is sent as a
+        plain ``ExistingAssetInput``; two or more entries are bundled into a
+        ``MultiAssetInput``.
         """
-        if isinstance(media_context, list):
-            uploaded_names = [
-                self.asset_uploader.upload_asset(mc) for mc in media_context
-            ]
-            return self.asset_mapper.create_existing_asset_input(uploaded_names)
-        else:
-            uploaded_name = self.asset_uploader.upload_asset(media_context)
-            return self.asset_mapper.create_existing_asset_input(uploaded_name)
+        uploaded_names = [
+            self.asset_uploader.upload_asset(mc) for mc in media_context
+        ]
+        if len(uploaded_names) == 1:
+            return self.asset_mapper.create_existing_asset_input(uploaded_names[0])
+        return self.asset_mapper.create_existing_asset_input(uploaded_names)
 
     def _upload_and_map_asset(
         self, asset: str | list[str]

--- a/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
+++ b/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
@@ -22,19 +22,13 @@ class ValidationRapidUploader:
         self.asset_mapper = AssetMapper()
 
     def upload_rapid(self, rapid: Rapid, validation_set_id: str) -> None:
-        asset_to_uploaded: dict[str, str] = {}
-
         if rapid.data_type == "media":
-            # Compare rapids translate truth IDs through this mapping; other
-            # rapid types ignore it.
-            uploaded_asset, asset_to_uploaded = (
-                self.asset_uploader.upload_and_map_asset_with_mapping(rapid.asset)
-            )
+            uploaded_asset = self.asset_uploader.upload_and_map_asset(rapid.asset)
         else:
             uploaded_asset = self.asset_mapper.create_text_input(rapid.asset)
 
         # Translate truth for compare rapids with media assets
-        truth = self._translate_compare_truth(rapid, asset_to_uploaded)
+        truth = self._translate_compare_truth(rapid)
 
         context_asset = (
             self.asset_uploader.upload_and_map_asset(rapid.media_context)
@@ -60,19 +54,24 @@ class ValidationRapidUploader:
             ),
         )
 
-    def _translate_compare_truth(
-        self, rapid: Rapid, asset_to_uploaded: dict[str, str]
-    ) -> IValidationTruthModel | None:
+    def _translate_compare_truth(self, rapid: Rapid) -> IValidationTruthModel | None:
         """Translate compare rapid truth from original asset paths to uploaded names.
 
-        For compare rapids with media assets, the truth's winnerId or correctCombinations
-        need to be translated from original asset paths to uploaded asset names.
+        For compare rapids with media assets, ``winnerId`` /
+        ``correctCombinations`` reference assets by their original path,
+        but the API expects uploaded names. Re-calling ``upload_asset`` is
+        a cache hit (asset uploads are always cached) so this is just a
+        lookup, not a re-upload.
         """
         if not rapid.truth or rapid.data_type != "media":
             return rapid.truth
 
         if not rapid.truth.actual_instance:
             return rapid.truth
+
+        asset_paths = (
+            set(rapid.asset) if isinstance(rapid.asset, list) else {rapid.asset}
+        )
 
         # Handle CompareTruth
         if isinstance(
@@ -81,9 +80,8 @@ class ValidationRapidUploader:
             compare_truth = rapid.truth.actual_instance
             original_winner_id = compare_truth.winner_id
 
-            # If the winner_id is in our mapping, translate it
-            if original_winner_id in asset_to_uploaded:
-                uploaded_winner_id = asset_to_uploaded[original_winner_id]
+            if original_winner_id in asset_paths:
+                uploaded_winner_id = self.asset_uploader.upload_asset(original_winner_id)
                 return IValidationTruthModel(
                     actual_instance=IValidationTruthModelCompareTruthModel(
                         _t="CompareTruth", winnerId=uploaded_winner_id
@@ -95,13 +93,15 @@ class ValidationRapidUploader:
             rapid.truth.actual_instance, IValidationTruthModelMultiCompareTruthModel
         ):
             multi_compare_truth = rapid.truth.actual_instance
-            translated_combinations = []
-
-            for combination in multi_compare_truth.correct_combinations:
-                translated_combo = [
-                    asset_to_uploaded.get(asset_id, asset_id) for asset_id in combination
+            translated_combinations = [
+                [
+                    self.asset_uploader.upload_asset(asset_id)
+                    if asset_id in asset_paths
+                    else asset_id
+                    for asset_id in combination
                 ]
-                translated_combinations.append(translated_combo)
+                for combination in multi_compare_truth.correct_combinations
+            ]
 
             return IValidationTruthModel(
                 actual_instance=IValidationTruthModelMultiCompareTruthModel(

--- a/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
+++ b/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
@@ -3,6 +3,7 @@ from rapidata.service.openapi_service import OpenAPIService
 from rapidata.api_client.models.add_validation_rapid_endpoint_input import (
     AddValidationRapidEndpointInput,
 )
+from rapidata.api_client.models.i_asset_input import IAssetInput
 from rapidata.api_client.models.i_rapid_payload_model import IRapidPayloadModel
 from rapidata.api_client.models.i_validation_truth_model import IValidationTruthModel
 from rapidata.api_client.models.i_validation_truth_model_compare_truth_model import (
@@ -22,13 +23,12 @@ class ValidationRapidUploader:
         self.asset_mapper = AssetMapper()
 
     def upload_rapid(self, rapid: Rapid, validation_set_id: str) -> None:
+        asset_to_uploaded: dict[str, str] = {}
+
         if rapid.data_type == "media":
-            uploaded_asset = self.asset_uploader.upload_and_map_asset(rapid.asset)
+            uploaded_asset, asset_to_uploaded = self._upload_rapid_asset(rapid.asset)
         else:
             uploaded_asset = self.asset_mapper.create_text_input(rapid.asset)
-
-        # Translate truth for compare rapids with media assets
-        truth = self._translate_compare_truth(rapid)
 
         context_asset = (
             self.asset_uploader.upload_and_map_asset(rapid.media_context)
@@ -43,7 +43,7 @@ class ValidationRapidUploader:
                 payload=self._get_payload(rapid),
                 context=rapid.context,
                 contextAsset=context_asset,
-                truth=truth,
+                truth=self._translate_compare_truth(rapid, asset_to_uploaded),
                 randomCorrectProbability=rapid.random_correct_probability,
                 explanation=rapid.explanation,
                 featureFlags=(
@@ -54,14 +54,39 @@ class ValidationRapidUploader:
             ),
         )
 
-    def _translate_compare_truth(self, rapid: Rapid) -> IValidationTruthModel | None:
+    def _upload_rapid_asset(
+        self, asset: str | list[str]
+    ) -> tuple[IAssetInput, dict[str, str]]:
+        """Upload the rapid asset(s) and return the wrapped input plus a path→name map.
+
+        The map lets ``_translate_compare_truth`` rewrite truth references
+        (winner ids, correct combinations) from caller-supplied paths to the
+        uploaded names the API expects. Truth only ever points at the rapid's
+        own assets, so this mapping isn't needed for ``media_context``.
+        """
+        if isinstance(asset, list):
+            asset_to_uploaded = {a: self.asset_uploader.upload_asset(a) for a in asset}
+            return (
+                self.asset_mapper.create_existing_asset_input(
+                    list(asset_to_uploaded.values())
+                ),
+                asset_to_uploaded,
+            )
+
+        uploaded_name = self.asset_uploader.upload_asset(asset)
+        return (
+            self.asset_mapper.create_existing_asset_input(uploaded_name),
+            {asset: uploaded_name},
+        )
+
+    def _translate_compare_truth(
+        self, rapid: Rapid, asset_to_uploaded: dict[str, str]
+    ) -> IValidationTruthModel | None:
         """Translate compare rapid truth from original asset paths to uploaded names.
 
         For compare rapids with media assets, ``winnerId`` /
-        ``correctCombinations`` reference assets by their original path,
-        but the API expects uploaded names. Re-calling ``upload_asset`` is
-        a cache hit (asset uploads are always cached) so this is just a
-        lookup, not a re-upload.
+        ``correctCombinations`` reference assets by their original path, but
+        the API expects uploaded names.
         """
         if not rapid.truth or rapid.data_type != "media":
             return rapid.truth
@@ -69,35 +94,27 @@ class ValidationRapidUploader:
         if not rapid.truth.actual_instance:
             return rapid.truth
 
-        asset_paths = (
-            set(rapid.asset) if isinstance(rapid.asset, list) else {rapid.asset}
-        )
-
-        # Handle CompareTruth
         if isinstance(
             rapid.truth.actual_instance, IValidationTruthModelCompareTruthModel
         ):
             compare_truth = rapid.truth.actual_instance
             original_winner_id = compare_truth.winner_id
 
-            if original_winner_id in asset_paths:
-                uploaded_winner_id = self.asset_uploader.upload_asset(original_winner_id)
+            if original_winner_id in asset_to_uploaded:
                 return IValidationTruthModel(
                     actual_instance=IValidationTruthModelCompareTruthModel(
-                        _t="CompareTruth", winnerId=uploaded_winner_id
+                        _t="CompareTruth",
+                        winnerId=asset_to_uploaded[original_winner_id],
                     )
                 )
 
-        # Handle MultiCompareTruth
         elif isinstance(
             rapid.truth.actual_instance, IValidationTruthModelMultiCompareTruthModel
         ):
             multi_compare_truth = rapid.truth.actual_instance
             translated_combinations = [
                 [
-                    self.asset_uploader.upload_asset(asset_id)
-                    if asset_id in asset_paths
-                    else asset_id
+                    asset_to_uploaded.get(asset_id, asset_id)
                     for asset_id in combination
                 ]
                 for combination in multi_compare_truth.correct_combinations

--- a/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
+++ b/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
@@ -40,9 +40,7 @@ class ValidationRapidUploader:
                 payload=self._get_payload(rapid),
                 context=rapid.context,
                 contextAsset=(
-                    self.asset_mapper.create_existing_asset_input(
-                        self.asset_uploader.upload_asset(rapid.media_context)
-                    )
+                    self._upload_and_map_media_context(rapid.media_context)
                     if rapid.media_context
                     else None
                 ),
@@ -56,6 +54,23 @@ class ValidationRapidUploader:
                 ),
             ),
         )
+
+    def _upload_and_map_media_context(
+        self, media_context: str | list[str]
+    ) -> IAssetInput:
+        """Upload media context asset(s) and map to IAssetInput.
+
+        Accepts either a single string (one image) or a list of strings
+        (multiple images shown as media context).
+        """
+        if isinstance(media_context, list):
+            uploaded_names = [
+                self.asset_uploader.upload_asset(mc) for mc in media_context
+            ]
+            return self.asset_mapper.create_existing_asset_input(uploaded_names)
+        else:
+            uploaded_name = self.asset_uploader.upload_asset(media_context)
+            return self.asset_mapper.create_existing_asset_input(uploaded_name)
 
     def _upload_and_map_asset(
         self, asset: str | list[str]

--- a/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
+++ b/src/rapidata/rapidata_client/validation/rapids/_validation_rapid_uploader.py
@@ -3,7 +3,6 @@ from rapidata.service.openapi_service import OpenAPIService
 from rapidata.api_client.models.add_validation_rapid_endpoint_input import (
     AddValidationRapidEndpointInput,
 )
-from rapidata.api_client.models.i_asset_input import IAssetInput
 from rapidata.api_client.models.i_rapid_payload_model import IRapidPayloadModel
 from rapidata.api_client.models.i_validation_truth_model import IValidationTruthModel
 from rapidata.api_client.models.i_validation_truth_model_compare_truth_model import (
@@ -26,18 +25,19 @@ class ValidationRapidUploader:
         asset_to_uploaded: dict[str, str] = {}
 
         if rapid.data_type == "media":
-            uploaded_asset, asset_to_uploaded = self._upload_and_map_asset(rapid.asset)
+            # Compare rapids translate truth IDs through this mapping; other
+            # rapid types ignore it.
+            uploaded_asset, asset_to_uploaded = (
+                self.asset_uploader.upload_and_map_asset_with_mapping(rapid.asset)
+            )
         else:
             uploaded_asset = self.asset_mapper.create_text_input(rapid.asset)
 
         # Translate truth for compare rapids with media assets
         truth = self._translate_compare_truth(rapid, asset_to_uploaded)
 
-        # media_context is always a list[str]; reuse the same upload+map helper
-        # used for the main asset (we don't need the asset->uploaded mapping
-        # part here, so just take the IAssetInput).
         context_asset = (
-            self._upload_and_map_asset(rapid.media_context)[0]
+            self.asset_uploader.upload_and_map_asset(rapid.media_context)
             if rapid.media_context
             else None
         )
@@ -59,28 +59,6 @@ class ValidationRapidUploader:
                 ),
             ),
         )
-
-    def _upload_and_map_asset(
-        self, asset: str | list[str]
-    ) -> tuple[IAssetInput, dict[str, str]]:
-        """Upload asset(s) and map to IAssetInput.
-
-        Returns:
-            Tuple of (IAssetInput, mapping from original asset paths to uploaded names)
-        """
-        if isinstance(asset, list):
-            asset_to_uploaded = {a: self.asset_uploader.upload_asset(a) for a in asset}
-            uploaded_names = list(asset_to_uploaded.values())
-            return (
-                self.asset_mapper.create_existing_asset_input(uploaded_names),
-                asset_to_uploaded,
-            )
-        else:
-            uploaded_name = self.asset_uploader.upload_asset(asset)
-            return (
-                self.asset_mapper.create_existing_asset_input(uploaded_name),
-                {asset: uploaded_name},
-            )
 
     def _translate_compare_truth(
         self, rapid: Rapid, asset_to_uploaded: dict[str, str]

--- a/src/rapidata/rapidata_client/validation/rapids/rapids.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
-from rapidata.rapidata_client.config import logger
+from rapidata.rapidata_client.datapoints._datapoint import coerce_media_context
 from typing import Literal, Sequence
 from pydantic import BaseModel, model_validator, field_validator, ConfigDict
 from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -27,37 +27,7 @@ class Rapid(BaseModel):
     @field_validator("media_context", mode="before")
     @classmethod
     def media_context_normalize(cls, v: object) -> list[str] | None:
-        """Always store media_context as a list of strings.
-
-        Accepts ``str`` for backward compatibility — emits a deprecation
-        warning and wraps it in a single-element list so the rest of the
-        SDK only ever has to deal with ``list[str]``.
-        """
-        if v is None:
-            return None
-        if isinstance(v, str):
-            if v == "":
-                raise ValueError(
-                    "media_context cannot be an empty string. If not needed, set to None."
-                )
-            logger.warning(
-                "Passing a string for media_context is deprecated; pass a list of strings instead. "
-                "Wrapping the value in a single-element list."
-            )
-            return [v]
-        if isinstance(v, list):
-            if len(v) == 0:
-                raise ValueError(
-                    "media_context cannot be an empty list. If not needed, set to None."
-                )
-            if any(not isinstance(item, str) or item == "" for item in v):
-                raise ValueError(
-                    "Every entry in a media_context list must be a non-empty string."
-                )
-            return v
-        raise ValueError(
-            f"media_context must be a list of strings or None, got {type(v).__name__}."
-        )
+        return coerce_media_context(v)
 
     @model_validator(mode="after")
     def check_sentence_and_context(self) -> Rapid:

--- a/src/rapidata/rapidata_client/validation/rapids/rapids.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids.py
@@ -13,7 +13,7 @@ class Rapid(BaseModel):
     data_type: Literal["media", "text"] = "media"
     truth: IValidationTruthModel | None = None
     context: str | None = None
-    media_context: str | None = None
+    media_context: str | list[str] | None = None
     sentence: str | None = None
     random_correct_probability: float | None = None
     explanation: str | None = None

--- a/src/rapidata/rapidata_client/validation/rapids/rapids.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from rapidata.rapidata_client.config import logger
 from typing import Literal, Sequence
-from pydantic import BaseModel, model_validator, ConfigDict
+from pydantic import BaseModel, model_validator, field_validator, ConfigDict
 from rapidata.api_client.models.i_rapid_payload import IRapidPayload
 from rapidata.api_client.models.i_validation_truth_model import IValidationTruthModel
 
@@ -13,7 +14,7 @@ class Rapid(BaseModel):
     data_type: Literal["media", "text"] = "media"
     truth: IValidationTruthModel | None = None
     context: str | None = None
-    media_context: str | list[str] | None = None
+    media_context: list[str] | None = None
     sentence: str | None = None
     random_correct_probability: float | None = None
     explanation: str | None = None
@@ -22,6 +23,41 @@ class Rapid(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True, populate_by_name=True, extra="allow"
     )
+
+    @field_validator("media_context", mode="before")
+    @classmethod
+    def media_context_normalize(cls, v: object) -> list[str] | None:
+        """Always store media_context as a list of strings.
+
+        Accepts ``str`` for backward compatibility — emits a deprecation
+        warning and wraps it in a single-element list so the rest of the
+        SDK only ever has to deal with ``list[str]``.
+        """
+        if v is None:
+            return None
+        if isinstance(v, str):
+            if v == "":
+                raise ValueError(
+                    "media_context cannot be an empty string. If not needed, set to None."
+                )
+            logger.warning(
+                "Passing a string for media_context is deprecated; pass a list of strings instead. "
+                "Wrapping the value in a single-element list."
+            )
+            return [v]
+        if isinstance(v, list):
+            if len(v) == 0:
+                raise ValueError(
+                    "media_context cannot be an empty list. If not needed, set to None."
+                )
+            if any(not isinstance(item, str) or item == "" for item in v):
+                raise ValueError(
+                    "Every entry in a media_context list must be a non-empty string."
+                )
+            return v
+        raise ValueError(
+            f"media_context must be a list of strings or None, got {type(v).__name__}."
+        )
 
     @model_validator(mode="after")
     def check_sentence_and_context(self) -> Rapid:

--- a/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
@@ -37,7 +37,7 @@ class RapidsManager:
             truths (list[str]): The correct answers to the question.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -106,7 +106,7 @@ class RapidsManager:
             datapoint (list[str]): The two assets that the labeler will be comparing.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -245,7 +245,7 @@ class RapidsManager:
             truths (list[Box]): The bounding boxes of the object that the labeler ought to be locating.
             datapoint (str): The asset that the labeler will be locating the object in.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -305,7 +305,7 @@ class RapidsManager:
                 their drawn lines fall within any of these boxes.
             datapoint (str): The asset that the labeler will be drawing the object in.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -367,7 +367,7 @@ class RapidsManager:
                 The first element of the tuple is the start of the interval and the second element is the end of the interval.
             datapoint (str): The asset that the labeler will be timestamping.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload

--- a/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
@@ -25,7 +25,7 @@ class RapidsManager:
         truths: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a classification rapid
@@ -37,7 +37,7 @@ class RapidsManager:
             truths (list[str]): The correct answers to the question.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -95,7 +95,7 @@ class RapidsManager:
         datapoint: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a compare rapid
@@ -106,7 +106,7 @@ class RapidsManager:
             datapoint (list[str]): The two assets that the labeler will be comparing.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -235,7 +235,7 @@ class RapidsManager:
         truths: list[Box],
         datapoint: str,
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a locate rapid
@@ -245,7 +245,7 @@ class RapidsManager:
             truths (list[Box]): The bounding boxes of the object that the labeler ought to be locating.
             datapoint (str): The asset that the labeler will be locating the object in.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -293,7 +293,7 @@ class RapidsManager:
         truths: list[Box],
         datapoint: str,
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a draw rapid
@@ -305,7 +305,7 @@ class RapidsManager:
                 their drawn lines fall within any of these boxes.
             datapoint (str): The asset that the labeler will be drawing the object in.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -356,7 +356,7 @@ class RapidsManager:
         truths: list[tuple[int, int]],
         datapoint: str,
         context: str | None = None,
-        media_context: str | list[str] | None = None,
+        media_context: list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a timestamp rapid
@@ -367,7 +367,7 @@ class RapidsManager:
                 The first element of the tuple is the start of the interval and the second element is the end of the interval.
             datapoint (str): The asset that the labeler will be timestamping.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
+            media_context (list[str], optional): A list of links to images / videos that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one media asset, or multiple to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload

--- a/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
@@ -25,7 +25,7 @@ class RapidsManager:
         truths: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a classification rapid
@@ -37,7 +37,7 @@ class RapidsManager:
             truths (list[str]): The correct answers to the question.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
+            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -95,7 +95,7 @@ class RapidsManager:
         datapoint: list[str],
         data_type: Literal["media", "text"] = "media",
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a compare rapid
@@ -106,7 +106,7 @@ class RapidsManager:
             datapoint (list[str]): The two assets that the labeler will be comparing.
             data_type (str, optional): The type of the datapoint. Defaults to "media" (any form of image, video or audio).
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
+            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -235,7 +235,7 @@ class RapidsManager:
         truths: list[Box],
         datapoint: str,
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a locate rapid
@@ -245,7 +245,7 @@ class RapidsManager:
             truths (list[Box]): The bounding boxes of the object that the labeler ought to be locating.
             datapoint (str): The asset that the labeler will be locating the object in.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
+            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -293,7 +293,7 @@ class RapidsManager:
         truths: list[Box],
         datapoint: str,
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a draw rapid
@@ -305,7 +305,7 @@ class RapidsManager:
                 their drawn lines fall within any of these boxes.
             datapoint (str): The asset that the labeler will be drawing the object in.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
+            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload
@@ -356,7 +356,7 @@ class RapidsManager:
         truths: list[tuple[int, int]],
         datapoint: str,
         context: str | None = None,
-        media_context: str | None = None,
+        media_context: str | list[str] | None = None,
         explanation: str | None = None,
     ) -> Rapid:
         """Build a timestamp rapid
@@ -367,7 +367,7 @@ class RapidsManager:
                 The first element of the tuple is the start of the interval and the second element is the end of the interval.
             datapoint (str): The asset that the labeler will be timestamping.
             context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
-            media_context (str, optional): The media context is a link to an image / video that will be shown in addition to the instruction (can be combined with context). Defaults to None.
+            media_context (str | list[str], optional): The media context is a link to an image / video (or a list of links) that will be shown in addition to the instruction (can be combined with context). Pass a list to display multiple images / videos. Defaults to None.
             explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
         """
         from rapidata.api_client.models.i_rapid_payload import IRapidPayload

--- a/src/rapidata/rapidata_client/validation/validation_set_manager.py
+++ b/src/rapidata/rapidata_client/validation/validation_set_manager.py
@@ -71,7 +71,7 @@ class ValidationSetManager:
         truths: list[list[str]],
         data_type: Literal["media", "text"] = "media",
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         explanations: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -91,9 +91,10 @@ class ValidationSetManager:
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and answer options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             explanations (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -159,7 +160,7 @@ class ValidationSetManager:
         truths: list[str],
         data_type: Literal["media", "text"] = "media",
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -179,9 +180,10 @@ class ValidationSetManager:
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and truth. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -318,7 +320,7 @@ class ValidationSetManager:
         truths: list[list[Box]],
         datapoints: list[str],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -333,9 +335,10 @@ class ValidationSetManager:
                     truths: [[Box(0, 0, 100, 100)], [Box(50, 50, 150, 150)]] -> first datapoint the object is in the top left corner, second datapoint the object is in the center
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[str], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -395,7 +398,7 @@ class ValidationSetManager:
         truths: list[list[Box]],
         datapoints: list[str],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -410,9 +413,10 @@ class ValidationSetManager:
                     truths: [[Box(0, 0, 100, 100)], [Box(50, 50, 150, 150)]] -> first datapoint the object is in the top left corner, second datapoint the object is in the center
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[str], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -472,7 +476,7 @@ class ValidationSetManager:
         truths: list[list[tuple[int, int]]],
         datapoints: list[str],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | None = None,
+        media_contexts: list[str] | list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -488,9 +492,10 @@ class ValidationSetManager:
                     truths: [[(0, 10)], [(20, 30)]] -> first datapoint the correct interval is from 0 to 10, second datapoint the correct interval is from 20 to 30
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[str], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
+                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 

--- a/src/rapidata/rapidata_client/validation/validation_set_manager.py
+++ b/src/rapidata/rapidata_client/validation/validation_set_manager.py
@@ -31,9 +31,6 @@ from rapidata.rapidata_client.config import (
     rapidata_config,
     tracer,
 )
-from rapidata.rapidata_client.datapoints._datapoints_validator import (
-    _normalize_media_contexts,
-)
 from tqdm.auto import tqdm
 from rapidata.rapidata_client.validation.rapids.rapids import Rapid
 
@@ -94,10 +91,10 @@ class ValidationSetManager:
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and answer options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the comparison (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             explanations (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -124,7 +121,6 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
-            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -184,10 +180,10 @@ class ValidationSetManager:
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and truth. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the comparison (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -212,7 +208,6 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
-            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -340,10 +335,10 @@ class ValidationSetManager:
                     truths: [[Box(0, 0, 100, 100)], [Box(50, 50, 150, 150)]] -> first datapoint the object is in the top left corner, second datapoint the object is in the center
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the comparison (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -367,7 +362,6 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
-            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -419,10 +413,10 @@ class ValidationSetManager:
                     truths: [[Box(0, 0, 100, 100)], [Box(50, 50, 150, 150)]] -> first datapoint the object is in the top left corner, second datapoint the object is in the center
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the comparison (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -446,7 +440,6 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
-            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -499,10 +492,10 @@ class ValidationSetManager:
                     truths: [[(0, 10)], [(20, 30)]] -> first datapoint the correct interval is from 0 to 10, second datapoint the correct interval is from 20 to 30
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of image URLs / paths shown for the comparison (each inner list is the images shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
+                Use a single-element inner list for one image per datapoint, or multiple entries to display several images.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -526,7 +519,6 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
-            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"

--- a/src/rapidata/rapidata_client/validation/validation_set_manager.py
+++ b/src/rapidata/rapidata_client/validation/validation_set_manager.py
@@ -31,6 +31,9 @@ from rapidata.rapidata_client.config import (
     rapidata_config,
     tracer,
 )
+from rapidata.rapidata_client.datapoints._datapoints_validator import (
+    _normalize_media_contexts,
+)
 from tqdm.auto import tqdm
 from rapidata.rapidata_client.validation.rapids.rapids import Rapid
 
@@ -71,7 +74,7 @@ class ValidationSetManager:
         truths: list[list[str]],
         data_type: Literal["media", "text"] = "media",
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         explanations: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -91,10 +94,10 @@ class ValidationSetManager:
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and answer options. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             explanations (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -121,6 +124,7 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
+            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -160,7 +164,7 @@ class ValidationSetManager:
         truths: list[str],
         data_type: Literal["media", "text"] = "media",
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -180,10 +184,10 @@ class ValidationSetManager:
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction and truth. (Therefore will be different for each datapoint)
                 Will be match up with the datapoints using the list index.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -208,6 +212,7 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
+            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -320,7 +325,7 @@ class ValidationSetManager:
         truths: list[list[Box]],
         datapoints: list[str],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -335,10 +340,10 @@ class ValidationSetManager:
                     truths: [[Box(0, 0, 100, 100)], [Box(50, 50, 150, 150)]] -> first datapoint the object is in the top left corner, second datapoint the object is in the center
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -362,6 +367,7 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
+            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -398,7 +404,7 @@ class ValidationSetManager:
         truths: list[list[Box]],
         datapoints: list[str],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -413,10 +419,10 @@ class ValidationSetManager:
                     truths: [[Box(0, 0, 100, 100)], [Box(50, 50, 150, 150)]] -> first datapoint the object is in the top left corner, second datapoint the object is in the center
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -440,6 +446,7 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
+            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"
@@ -476,7 +483,7 @@ class ValidationSetManager:
         truths: list[list[tuple[int, int]]],
         datapoints: list[str],
         contexts: list[str] | None = None,
-        media_contexts: list[str] | list[list[str]] | None = None,
+        media_contexts: list[list[str]] | None = None,
         explanation: list[str | None] | None = None,
         dimensions: list[str] = [],
     ) -> RapidataValidationSet:
@@ -492,10 +499,10 @@ class ValidationSetManager:
                     truths: [[(0, 10)], [(20, 30)]] -> first datapoint the correct interval is from 0 to 10, second datapoint the correct interval is from 20 to 30
             datapoints (list[str]): The datapoints that will be used for validation.
             contexts (list[str], optional): The contexts for each datapoint. Defaults to None.
-            media_contexts (list[str] | list[list[str]], optional): The list of media contexts i.e. links to the images / videos for the comparison. Defaults to None.\n
+            media_contexts (list[list[str]], optional): The list of media contexts for the comparison (each inner list is the media URLs / paths shown for that datapoint). Defaults to None.\n
                 If provided has to be the same length as datapoints and will be shown in addition to the instruction. (Therefore will be different for each datapoint)
                 Will be matched up with the datapoints using the list index.
-                Pass a list of strings for one media context per datapoint, or a list of lists of strings to display multiple images / videos as media context per datapoint.
+                Use a single-element inner list for one media asset per datapoint, or multiple entries to display several images / videos. Passing a flat ``list[str]`` is still accepted but emits a deprecation warning and is wrapped automatically.
             explanation (list[str | None], optional): The explanations for each datapoint. Will be given to the annotators in case the answer is wrong. Defaults to None.
             dimensions (list[str], optional): The dimensions to add to the validation set accross which users will be tracked. Defaults to [] which is the default dimension.
 
@@ -519,6 +526,7 @@ class ValidationSetManager:
             if contexts and len(contexts) != len(datapoints):
                 raise ValueError("The number of contexts and datapoints must be equal")
 
+            media_contexts = _normalize_media_contexts(media_contexts)
             if media_contexts and len(media_contexts) != len(datapoints):
                 raise ValueError(
                     "The number of media contexts and datapoints must be equal"

--- a/uv.lock
+++ b/uv.lock
@@ -2570,7 +2570,7 @@ wheels = [
 
 [[package]]
 name = "rapidata"
-version = "3.9.8"
+version = "3.9.12"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

- Widened `media_contexts` from `list[str]` to `list[str] | list[list[str]]` across all order/job/validation/audience APIs
- When a caller passes a list of lists, each inner list is uploaded and wrapped in a `MultiAssetInput`, so annotators see multiple reference images for that datapoint
- Fully backward-compatible: all existing `list[str]` callers continue to work without changes

## What changed

| File | Change |
|---|---|
| `_datapoint.py` | `media_context: str \| list[str] \| None` |
| `_datapoints_validator.py` | validates both shapes; rejects mixed lists |
| `_datapoint_uploader.py` | `_upload_and_map_media_context()` handles str or list |
| `_asset_upload_orchestrator.py` | extracts all URLs from list media_context |
| `_rapidata_dataset.py` | `_create_dataset_groups` handles list media_context |
| `rapids.py` | `Rapid.media_context: str \| list[str] \| None` |
| `_validation_rapid_uploader.py` | new `_upload_and_map_media_context()` |
| `rapids_manager.py` | all rapid builder `media_context` params updated |
| `validation_set_manager.py` | all `create_*_set` signatures updated |
| `rapidata_order_manager.py` | all `create_*_order` signatures updated |
| `rapidata_job_manager.py` | all `create_*_job_definition` signatures updated |
| `rapidata_job_definition.py` | `update_dataset` signature updated |
| `audience_example_handler.py` | new `_upload_and_map_media_context()`; both example methods updated |
| `rapidata_audience.py` | `add_classification_example` / `add_compare_example` signatures updated |
| `docs/job_definition_parameters.md` | updated `media_contexts` reference with multi-image example |

## Test plan

- [ ] pyright passes: `0 errors, 0 warnings, 0 informations` ✅ (verified in this session)
- [ ] Pass `media_contexts=[["img1.jpg", "img2.jpg"], ["img3.jpg"]]` to a classification order and confirm both images appear as context in the rapid
- [ ] Pass existing `media_contexts=["img1.jpg", "img2.jpg"]` and confirm no regression

🔗 Session: [https://session-c1c6a759.poseidon.rapidata.internal/](https://session-c1c6a759.poseidon.rapidata.internal/)