### PR TITLE
fix(results): correct column generation in compare/ranking to_pandas

### DIFF
--- a/src/rapidata/rapidata_client/results/rapidata_results.py
+++ b/src/rapidata/rapidata_client/results/rapidata_results.py
@@ -254,26 +254,29 @@ class RapidataResults(dict):
                 for i, asset in enumerate(assets):
                     base_row[f"asset_{i + 1}"] = asset
 
-            # Per-metric asset columns. Only dicts that are actually keyed by
-            # asset names count as comparative metrics — this skips fields
-            # like ``privateMetadata``/``summary`` that happen to be dicts but
-            # don't have per-asset values.
+            # Per-metric asset columns. Dicts keyed by asset names are
+            # treated as comparative metrics and split into A_/B_ (compare) or
+            # per-asset (ranking) columns. Other dicts (e.g. ``privateMetadata``
+            # whose keys are arbitrary user data, not asset identifiers) are
+            # flattened with their field name as the prefix so their values
+            # still make it into the dataframe.
             asset_set = set(assets)
             for key, values in result.items():
                 if not isinstance(values, dict) or not values:
                     continue
-                if not asset_set.intersection(values.keys()):
-                    continue
-                if is_compare:
-                    base_row[f"A_{key}"] = values.get(assets[0])
-                    base_row[f"B_{key}"] = values.get(assets[1])
-                    if "Both" in values:
-                        base_row[f"Both_{key}"] = values["Both"]
-                    if "Neither" in values:
-                        base_row[f"Neither_{key}"] = values["Neither"]
+                if asset_set.intersection(values.keys()):
+                    if is_compare:
+                        base_row[f"A_{key}"] = values.get(assets[0])
+                        base_row[f"B_{key}"] = values.get(assets[1])
+                        if "Both" in values:
+                            base_row[f"Both_{key}"] = values["Both"]
+                        if "Neither" in values:
+                            base_row[f"Neither_{key}"] = values["Neither"]
+                    else:
+                        for asset in assets:
+                            base_row[f"{asset}_{key}"] = values.get(asset)
                 else:
-                    for asset in assets:
-                        base_row[f"{asset}_{key}"] = values.get(asset)
+                    base_row.update(self._flatten_dict(values, parent_key=key))
 
             detailed = result.get("detailedResults")
             if split_details and isinstance(detailed, list) and detailed:

--- a/src/rapidata/rapidata_client/results/rapidata_results.py
+++ b/src/rapidata/rapidata_client/results/rapidata_results.py
@@ -20,8 +20,11 @@ class RapidataResults(dict):
 
         Converts the results to a pandas DataFrame.
 
-        For Compare results, creates standardized A/B columns for metrics.
-        For regular results, flattens nested dictionaries into columns with underscore-separated names.
+        For Compare results (exactly 2 assets), creates standardized ``A_``/``B_``
+        columns for each metric (plus ``Both_``/``Neither_`` when those options
+        are present). For Ranking results with N assets, creates one
+        ``<asset>_<metric>`` column per asset. For non-compare results, flattens
+        nested dictionaries into columns with underscore-separated names.
 
         Args:
             split_details: If True, splits each datapoint by its detailed results,
@@ -44,17 +47,17 @@ class RapidataResults(dict):
                 "Warning: Results are old and Order type is not specified. Dataframe might be wrong."
             )
 
-        # Check for detailed results if split_details is True
-        if split_details:
-            if not self._has_detailed_results():
-                raise ValueError("No detailed results found in the data")
-            return self._to_pandas_with_detailed_results()
+        if split_details and not self._has_detailed_results():
+            raise ValueError("No detailed results found in the data")
 
-        if (
-            self["info"].get("orderType") == "Compare"
-            or self["info"].get("orderType") == "Ranking"
-        ):
-            return self._compare_to_pandas()
+        # Compare/Ranking have an asset-aware shape; route them to the
+        # compare-specific path even when split_details=True so we keep the
+        # A_/B_ (or per-asset) column splitting.
+        if self["info"].get("orderType") in ("Compare", "Ranking"):
+            return self._compare_to_pandas(split_details=split_details)
+
+        if split_details:
+            return self._to_pandas_with_detailed_results()
 
         # Get the structure from first item
         first_item = self["results"][0]
@@ -189,9 +192,38 @@ class RapidataResults(dict):
             d = d.get(key, {})
         return d.get(path[-1])
 
-    def _compare_to_pandas(self) -> "pd.DataFrame":
+    @staticmethod
+    def _extract_compare_assets(result: dict[str, Any]) -> list[str]:
+        """Return the ordered list of asset identifiers for a compare/ranking row.
+
+        Prefers ``assetUrls`` when present (the canonical asset list emitted by
+        the backend, never contaminated with ``Both``/``Neither``). Falls back
+        to ``aggregatedResults`` (filtering ``Both``/``Neither``) for older
+        payloads or text-asset compares that don't include ``assetUrls``.
         """
-        Converts Compare results to a pandas DataFrame dynamically.
+        excluded = {"Both", "Neither"}
+
+        asset_urls = result.get("assetUrls")
+        if isinstance(asset_urls, dict) and asset_urls:
+            return [k for k in asset_urls.keys() if k not in excluded]
+
+        aggregated = result.get("aggregatedResults")
+        if isinstance(aggregated, dict) and aggregated:
+            return [k for k in aggregated.keys() if k not in excluded]
+
+        return []
+
+    def _compare_to_pandas(self, split_details: bool = False) -> "pd.DataFrame":
+        """Convert Compare/Ranking results to a pandas DataFrame.
+
+        For Compare (exactly 2 assets), produces ``A_<metric>`` / ``B_<metric>``
+        columns (plus ``Both_<metric>`` / ``Neither_<metric>`` when those
+        options are present). For Ranking with N assets, produces one
+        ``<asset>_<metric>`` column per asset.
+
+        When ``split_details=True``, each datapoint is expanded to one row per
+        ``detailedResults`` entry, with the asset/metric columns copied across
+        and the per-response fields flattened in.
         """
         import pandas as pd
 
@@ -200,43 +232,58 @@ class RapidataResults(dict):
 
         rows = []
         for result in self["results"]:
-            # Get all asset names from the first metric we find
-            assets = []
-            for key in result:
-                if isinstance(result[key], dict) and len(result[key]) >= 2:
-                    assets = list(result[key].keys())
-                    break
-            else:
+            assets = self._extract_compare_assets(result)
+            if len(assets) < 2:
                 continue
 
-            assets = [asset for asset in assets if asset not in ["Both", "Neither"]]
+            is_compare = len(assets) == 2
 
-            # Initialize row with non-comparative fields
-            row = {
+            # Non-comparative fields. Skip dicts (asset metrics, handled below)
+            # and lists (e.g. detailedResults — handled separately when
+            # split_details=True, otherwise omitted from the tabular export).
+            base_row: dict[str, Any] = {
                 key: value
                 for key, value in result.items()
-                if not isinstance(value, dict)
+                if not isinstance(value, (dict, list))
             }
-            row["assetA"] = assets[0]
-            row["assetB"] = assets[1]
 
-            # Handle comparative metrics
+            if is_compare:
+                base_row["assetA"] = assets[0]
+                base_row["assetB"] = assets[1]
+            else:
+                for i, asset in enumerate(assets):
+                    base_row[f"asset_{i + 1}"] = asset
+
+            # Per-metric asset columns. Only dicts that are actually keyed by
+            # asset names count as comparative metrics — this skips fields
+            # like ``privateMetadata``/``summary`` that happen to be dicts but
+            # don't have per-asset values.
+            asset_set = set(assets)
             for key, values in result.items():
-                if isinstance(values, dict) and len(values) >= 2:
-                    # Add main asset columns
-                    for i, asset in enumerate(
-                        assets[:2]
-                    ):  # Limit to first 2 main assets
-                        column_prefix = "A_" if i == 0 else "B_"
-                        row[f"{column_prefix}{key}"] = values.get(asset, 0)
-
-                    # Add special option columns if they exist
+                if not isinstance(values, dict) or not values:
+                    continue
+                if not asset_set.intersection(values.keys()):
+                    continue
+                if is_compare:
+                    base_row[f"A_{key}"] = values.get(assets[0])
+                    base_row[f"B_{key}"] = values.get(assets[1])
                     if "Both" in values:
-                        row[f"Both_{key}"] = values.get("Both", 0)
+                        base_row[f"Both_{key}"] = values["Both"]
                     if "Neither" in values:
-                        row[f"Neither_{key}"] = values.get("Neither", 0)
+                        base_row[f"Neither_{key}"] = values["Neither"]
+                else:
+                    for asset in assets:
+                        base_row[f"{asset}_{key}"] = values.get(asset)
 
-            rows.append(row)
+            detailed = result.get("detailedResults")
+            if split_details and isinstance(detailed, list) and detailed:
+                for detailed_result in detailed:
+                    row = base_row.copy()
+                    if isinstance(detailed_result, dict):
+                        row.update(self._flatten_dict(detailed_result))
+                    rows.append(row)
+            else:
+                rows.append(base_row)
 
         return pd.DataFrame(rows)
 


### PR DESCRIPTION
## Summary

`RapidataResults.to_pandas()` had four column-generation bugs in the compare/ranking branch. All four are fixed in this PR; positional A/B asset assignment is left as-is per backend ordering guarantees.

| # | Bug | Before | After |
|---|---|---|---|
| 2 | `split_details=True` bypassed the compare path. Asset metrics stayed as raw dict values in single columns. | `aggregatedResults: {a:0, b:3}` (one column) | `A_aggregatedResults=0, B_aggregatedResults=3` (split + per-vote rows) |
| 3 | Asset detection picked "the first dict with ≥2 entries", so `privateMetadata` with 2+ keys hijacked detection and zeroed every metric column. | `assetA='campaign_id', A_aggregatedResults=0` | `assetA='aurora.png', A_aggregatedResults=3` |
| 4 | Ranking with ≥3 assets silently dropped everything past index 1. | only `A_*`/`B_*` columns | per-asset `<asset>_<metric>` columns |
| 5 | `detailedResults` leaked into the dataframe as a list-valued column. | `detailedResults` column with nested dicts | omitted from row body; consumed only by `split_details=True` |

### Implementation notes

- New `_extract_compare_assets` helper resolves the asset list deterministically: prefer `assetUrls` (the canonical list emitted by the backend), fall back to `aggregatedResults` (with `Both`/`Neither` filtered).
- `to_pandas` now routes Compare/Ranking through the compare-aware path even when `split_details=True`, so A/B (or per-asset) splitting is preserved alongside per-vote row expansion.
- A metric dict is only treated as comparative if it shares at least one key with the asset list — this keeps unrelated dicts (`privateMetadata`, `summary`, …) out of the metric columns instead of producing `A_<key>=None` noise.
- Lists in result rows are skipped when building the base row; `detailedResults` is consumed exclusively by the `split_details=True` branch.

## Test plan

Reproduced each bug against the current `main` and confirmed the fix on the new branch with the following inputs (run as a standalone script importing `rapidata_results.py` directly):

- [x] Standard compare with assetUrls + aggregatedResults + detailedResults → `detailedResults` no longer in columns; `A_/B_` columns generated as expected
- [x] Compare with `privateMetadata={...}` (≥2 keys) preceding `assetUrls` → `assetA`/`assetB` correctly resolved; metric columns no longer all 0
- [x] Compare with `split_details=True` → `A_/B_` columns retained, one row per detailed vote, `votedFor`/`userDetails_*` flattened in
- [x] Compare with Both/Neither voting enabled → `Both_<metric>`/`Neither_<metric>` columns still emitted (regression)
- [x] Ranking with 3 assets → per-asset `<asset>_<metric>` columns; no data dropped
- [x] `split_details=True` with no `detailedResults` field still raises `ValueError` (regression)
- [x] `pyright src/rapidata/rapidata_client/results/rapidata_results.py` → 0 errors, 0 warnings

🔗 Session: https://session-aaa156f7.poseidon.rapidata.internal/