### PR TITLE
feat(benchmark): filter overall standings by leaderboard_ids

### DIFF
--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -594,9 +594,17 @@ class RapidataBenchmark:
                 + Fore.RESET
             )
 
-    def get_overall_standings(self, tags: Optional[list[str]] = None) -> pd.DataFrame:
+    def get_overall_standings(
+        self,
+        tags: Optional[list[str]] = None,
+        leaderboard_ids: Optional[list[str]] = None,
+    ) -> pd.DataFrame:
         """
         Returns an aggregated elo table of all leaderboards in the benchmark.
+
+        Args:
+            tags: Filter standings by these tags. If None, all tags are considered.
+            leaderboard_ids: Filter to only include matchups from these leaderboards. If None, all leaderboards are considered.
         """
         import pandas as pd
 
@@ -604,6 +612,7 @@ class RapidataBenchmark:
             participants = self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_standings_get(
                 benchmark_id=self.id,
                 tags=tags,
+                leaderboard_ids=leaderboard_ids,
             )
 
             standings = []


### PR DESCRIPTION
## Summary

- Adds an optional `leaderboard_ids` parameter to `RapidataBenchmark.get_overall_standings`, mirroring the filter that already exists on `get_win_loss_matrix`.
- Lets callers scope an aggregated benchmark standings query to a specific subset of leaderboards (e.g. when combined with tag filters), instead of always aggregating across every leaderboard in the benchmark.
- The underlying API endpoint already accepts `leaderboardIds`; this just plumbs it through the SDK wrapper.

## Test plan

- [ ] `uv run pyright src/rapidata/rapidata_client` — passed locally (0 errors, 0 warnings).
- [ ] Smoke-test with a real benchmark: `benchmark.get_overall_standings(tags=[...], leaderboard_ids=[...])` returns a DataFrame whose rows reflect only matchups from the selected leaderboards.

🔗 Session: ${POSEIDON_SESSION_URL:-$HOSTNAME}