### PR TITLE
feat(upload): expose compression config on asset upload

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,6 +49,23 @@ logger.info("This will be shown") # (2)!
 | `cacheShards` | `int` | `128` | Number of cache shards for parallel access (immutable) |
 | `batchSize` | `int` | `1000` | Number of URLs per batch (100–5000) |
 | `batchPollInterval` | `float` | `0.5` | Batch polling interval in seconds |
+| `compression` | `CompressionConfig \| None` | `None` | Per-upload image-compression override. `None` defers to the server-side defaults; otherwise sets `enabled` / `quality` / `max_dimension` / `library` for every upload through this client. |
+
+#### Compression override
+
+```python
+from rapidata import rapidata_config, CompressionConfig
+
+# Force the asset service to compress images at quality 70 with a max dimension of 1024px,
+# regardless of the server-side default (which is currently off in production).
+rapidata_config.upload.compression = CompressionConfig(
+    enabled=True,
+    quality=70,
+    max_dimension=1024,
+)
+```
+
+Any field left as `None` falls back to the server-side default. Currently applies to single-asset uploads (`/asset/file` and `/asset/url`); batched URL uploads will pick the override up in a follow-up after the OpenAPI client regenerates.
 
 ## Environment Variables
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -49,7 +49,7 @@ logger.info("This will be shown") # (2)!
 | `cacheShards` | `int` | `128` | Number of cache shards for parallel access (immutable) |
 | `batchSize` | `int` | `1000` | Number of URLs per batch (100–5000) |
 | `batchPollInterval` | `float` | `0.5` | Batch polling interval in seconds |
-| `compression` | `CompressionConfig \| None` | `None` | Per-upload image-compression override. `None` defers to the server-side defaults; otherwise sets `enabled` / `quality` / `max_dimension` / `library` for every upload through this client. |
+| `compression` | `CompressionConfig \| None` | `None` | Per-upload image-compression settings; see [Compression override](#compression-override) below. |
 
 #### Compression override
 

--- a/src/rapidata/__init__.py
+++ b/src/rapidata/__init__.py
@@ -62,6 +62,7 @@ from .rapidata_client import (
     rapidata_config,
     logger,
     managed_print,
+    CompressionConfig,
 )
 
 from . import types

--- a/src/rapidata/rapidata_client/__init__.py
+++ b/src/rapidata/rapidata_client/__init__.py
@@ -64,3 +64,4 @@ from .filter import (
 )
 from .exceptions import FailedUploadException, FailedUpload
 from .config import rapidata_config, logger, managed_print
+from .config.upload_config import CompressionConfig

--- a/src/rapidata/rapidata_client/config/upload_config.py
+++ b/src/rapidata/rapidata_client/config/upload_config.py
@@ -2,12 +2,74 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from rapidata.rapidata_client.config import logger
 from rapidata.rapidata_client.config._env_utils import apply_env_overrides
+
+
+class CompressionConfig(BaseModel):
+    """
+    Per-upload override for the asset service's image-compression behaviour.
+
+    Any field left as ``None`` falls back to the value the asset service has
+    configured globally. Set ``enabled`` to ``True`` (or ``False``) to force the
+    behaviour for this client regardless of the server default. Quality is
+    expected in the 1..100 range and ``max_dimension`` must be at least 1; both
+    are validated server-side.
+
+    Currently applies to single-asset uploads (file paths and individual URLs
+    via the ``/asset/file`` and ``/asset/url`` endpoints). Batched URL uploads
+    via the orchestrator's ``/asset/batch-upload`` path will gain the same
+    override in a follow-up once the SDK's OpenAPI client is regenerated to
+    include the ``compression`` field on the batch input model.
+
+    Attributes:
+        enabled (bool | None): Force compression on or off. ``None`` to defer to the server default.
+        quality (int | None): WebP quality (1..100) to use when compression runs.
+        max_dimension (int | None): Maximum width or height in pixels when compression runs.
+        library (Literal["ImageSharp", "NetVips"] | None): Image processing library to use.
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    enabled: bool | None = None
+    quality: int | None = None
+    max_dimension: int | None = None
+    library: Literal["ImageSharp", "NetVips"] | None = None
+
+    @field_validator("quality")
+    @classmethod
+    def _validate_quality(cls, v: int | None) -> int | None:
+        if v is not None and not 1 <= v <= 100:
+            raise ValueError("quality must be between 1 and 100")
+        return v
+
+    @field_validator("max_dimension")
+    @classmethod
+    def _validate_max_dimension(cls, v: int | None) -> int | None:
+        if v is not None and v < 1:
+            raise ValueError("max_dimension must be at least 1")
+        return v
+
+    def is_set(self) -> bool:
+        """Whether any field has been overridden from its default of None."""
+        return any(
+            v is not None
+            for v in (self.enabled, self.quality, self.max_dimension, self.library)
+        )
+
+    def cache_suffix(self) -> str:
+        """
+        Stable string used as part of the asset upload cache key so that
+        the same source asset uploaded under different compression settings
+        does not collide on a single cache entry.
+        """
+        if not self.is_set():
+            return ""
+        return f"|c={self.enabled}/{self.quality}/{self.max_dimension}/{self.library}"
 
 
 class UploadConfig(BaseModel):
@@ -29,6 +91,8 @@ class UploadConfig(BaseModel):
         enableBatchUpload (bool): Enable batch URL uploading (two-step process). Defaults to True.
         batchSize (int): Number of URLs per batch (100-5000). Defaults to 1000.
         batchPollInterval (float): Polling interval in seconds. Defaults to 0.5.
+        compression (CompressionConfig | None): Per-upload override for the asset service's
+            image-compression behaviour. Defaults to None (use server-side defaults).
     """
 
     model_config = ConfigDict(validate_assignment=True)
@@ -62,6 +126,10 @@ class UploadConfig(BaseModel):
     batchPollInterval: float = Field(
         default=0.5,
         description="Polling interval in seconds",
+    )
+    compression: CompressionConfig | None = Field(
+        default=None,
+        description="Per-upload override for image compression. None uses server defaults.",
     )
 
     @field_validator("maxWorkers")

--- a/src/rapidata/rapidata_client/config/upload_config.py
+++ b/src/rapidata/rapidata_client/config/upload_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -30,7 +30,6 @@ class CompressionConfig(BaseModel):
         enabled (bool | None): Force compression on or off. ``None`` to defer to the server default.
         quality (int | None): WebP quality (1..100) to use when compression runs.
         max_dimension (int | None): Maximum width or height in pixels when compression runs.
-        library (Literal["ImageSharp", "NetVips"] | None): Image processing library to use.
     """
 
     model_config = ConfigDict(validate_assignment=True)
@@ -38,10 +37,6 @@ class CompressionConfig(BaseModel):
     enabled: bool | None = None
     quality: int | None = None
     max_dimension: int | None = None
-    # Mirrors the libraries the asset service currently advertises. Update when
-    # the backend adds a new option — this is intentionally not ``str`` so an
-    # incompatible value fails fast at construction rather than at the wire.
-    library: Literal["ImageSharp", "NetVips"] | None = None
 
     @field_validator("quality")
     @classmethod
@@ -64,8 +59,7 @@ class CompressionConfig(BaseModel):
         off" request, distinct from "defer to server default".
         """
         return any(
-            v is not None
-            for v in (self.enabled, self.quality, self.max_dimension, self.library)
+            v is not None for v in (self.enabled, self.quality, self.max_dimension)
         )
 
     def cache_suffix(self) -> str:
@@ -75,13 +69,13 @@ class CompressionConfig(BaseModel):
         does not collide on a single cache entry.
 
         The separator characters ``|``, ``/`` and ``=`` are reserved — none of
-        the existing field types (``bool``, ``int``, ``Literal[fixed strings]``)
-        can produce them, so the suffix round-trips unambiguously. Revisit this
-        if a free-form string field is ever added.
+        the existing field types (``bool``, ``int``) can produce them, so the
+        suffix round-trips unambiguously. Revisit this if a free-form string
+        field is ever added.
         """
         if not self.is_set():
             return ""
-        return f"|c={self.enabled}/{self.quality}/{self.max_dimension}/{self.library}"
+        return f"|c={self.enabled}/{self.quality}/{self.max_dimension}"
 
 
 class UploadConfig(BaseModel):

--- a/src/rapidata/rapidata_client/config/upload_config.py
+++ b/src/rapidata/rapidata_client/config/upload_config.py
@@ -38,6 +38,9 @@ class CompressionConfig(BaseModel):
     enabled: bool | None = None
     quality: int | None = None
     max_dimension: int | None = None
+    # Mirrors the libraries the asset service currently advertises. Update when
+    # the backend adds a new option — this is intentionally not ``str`` so an
+    # incompatible value fails fast at construction rather than at the wire.
     library: Literal["ImageSharp", "NetVips"] | None = None
 
     @field_validator("quality")
@@ -55,8 +58,15 @@ class CompressionConfig(BaseModel):
         return v
 
     def is_set(self) -> bool:
-        """Whether any field has been overridden from its default of None."""
-        return bool(self.model_dump(exclude_none=True))
+        """
+        Whether any field has been overridden from its default of ``None``.
+        ``enabled=False`` counts as set — it is the explicit "force compression
+        off" request, distinct from "defer to server default".
+        """
+        return any(
+            v is not None
+            for v in (self.enabled, self.quality, self.max_dimension, self.library)
+        )
 
     def cache_suffix(self) -> str:
         """

--- a/src/rapidata/rapidata_client/config/upload_config.py
+++ b/src/rapidata/rapidata_client/config/upload_config.py
@@ -56,16 +56,18 @@ class CompressionConfig(BaseModel):
 
     def is_set(self) -> bool:
         """Whether any field has been overridden from its default of None."""
-        return any(
-            v is not None
-            for v in (self.enabled, self.quality, self.max_dimension, self.library)
-        )
+        return bool(self.model_dump(exclude_none=True))
 
     def cache_suffix(self) -> str:
         """
         Stable string used as part of the asset upload cache key so that
         the same source asset uploaded under different compression settings
         does not collide on a single cache entry.
+
+        The separator characters ``|``, ``/`` and ``=`` are reserved — none of
+        the existing field types (``bool``, ``int``, ``Literal[fixed strings]``)
+        can produce them, so the suffix round-trips unambiguously. Revisit this
+        if a free-form string field is ever added.
         """
         if not self.is_set():
             return ""

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -115,10 +115,10 @@ class AssetUploader:
         OpenAPI clients that don't yet expose the params.
 
         Keys match the wire-format parameter names exposed by the asset service
-        (``compress``, ``quality``, ``maxdim``, ``library``) — note that the
-        Pythonic ``max_dimension`` field on ``CompressionConfig`` is mapped to
-        the lowercase ``maxdim`` query parameter that the backend exposes,
-        matching the existing ``/asset/compress`` endpoint convention.
+        (``compress``, ``quality``, ``maxdim``) — note that the Pythonic
+        ``max_dimension`` field on ``CompressionConfig`` is mapped to the
+        lowercase ``maxdim`` query parameter, matching the existing
+        ``/asset/compress`` endpoint convention.
         """
         if compression is None or not compression.is_set():
             return {}
@@ -129,8 +129,6 @@ class AssetUploader:
             kwargs["quality"] = compression.quality
         if compression.max_dimension is not None:
             kwargs["maxdim"] = compression.max_dimension
-        if compression.library is not None:
-            kwargs["library"] = compression.library
         return kwargs
 
     def _upload_url_asset(self, url: str) -> str:

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -66,12 +66,21 @@ class AssetUploader:
     def __init__(self, openapi_service: OpenAPIService) -> None:
         self.openapi_service = openapi_service
 
+    # NOTE: the public ``get_*_cache_key`` helpers read
+    # ``rapidata_config.upload.compression`` at call time rather than taking a
+    # snapshot, so the upload-path call sites (which DO snapshot inside
+    # ``_upload_*_asset``) and external probes can drift if another thread
+    # mutates the config between the two reads. That asymmetry is intentional:
+    # external probes only ever cause cache misses (not stale uploads), and
+    # the upload path is the only one that must keep kwargs and cache key in
+    # lockstep — pass a snapshot to ``_build_*_cache_key`` directly when that
+    # consistency matters.
     def get_file_cache_key(self, asset: str) -> str:
-        """Generate cache key for a file, including environment and active compression settings."""
+        """Generate cache key for a file, including environment and current compression settings."""
         return self._build_file_cache_key(asset, rapidata_config.upload.compression)
 
     def get_url_cache_key(self, url: str) -> str:
-        """Generate cache key for a URL, including environment and active compression settings."""
+        """Generate cache key for a URL, including environment and current compression settings."""
         return self._build_url_cache_key(url, rapidata_config.upload.compression)
 
     def _build_file_cache_key(
@@ -104,6 +113,12 @@ class AssetUploader:
         fields the user explicitly set so the call shape is unchanged when
         compression is disabled — keeping us forward-compatible with older
         OpenAPI clients that don't yet expose the params.
+
+        Keys match the wire-format parameter names exposed by the asset service
+        (``compress``, ``quality``, ``maxdim``, ``library``) — note that the
+        Pythonic ``max_dimension`` field on ``CompressionConfig`` is mapped to
+        the lowercase ``maxdim`` query parameter that the backend exposes,
+        matching the existing ``/asset/compress`` endpoint convention.
         """
         if compression is None or not compression.is_set():
             return {}

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -14,27 +14,6 @@ from rapidata.rapidata_client.datapoints._single_flight_cache import SingleFligh
 from diskcache import FanoutCache
 
 
-def _compression_kwargs(compression: CompressionConfig | None) -> dict[str, Any]:
-    """
-    Build the kwargs dict to pass to the OpenAPI upload methods. Only includes
-    fields the user explicitly set so the call shape is unchanged when
-    compression is disabled — keeping us forward-compatible with older
-    OpenAPI clients that don't yet expose the params.
-    """
-    if compression is None or not compression.is_set():
-        return {}
-    kwargs: dict[str, Any] = {}
-    if compression.enabled is not None:
-        kwargs["compress"] = compression.enabled
-    if compression.quality is not None:
-        kwargs["quality"] = compression.quality
-    if compression.max_dimension is not None:
-        kwargs["maxdim"] = compression.max_dimension
-    if compression.library is not None:
-        kwargs["library"] = compression.library
-    return kwargs
-
-
 class AssetUploader:
     # Class-level caches shared across all instances
     # URL cache: Always in-memory (URLs are lightweight, no benefit to disk caching)
@@ -89,23 +68,55 @@ class AssetUploader:
 
     def get_file_cache_key(self, asset: str) -> str:
         """Generate cache key for a file, including environment and active compression settings."""
+        return self._build_file_cache_key(asset, rapidata_config.upload.compression)
+
+    def get_url_cache_key(self, url: str) -> str:
+        """Generate cache key for a URL, including environment and active compression settings."""
+        return self._build_url_cache_key(url, rapidata_config.upload.compression)
+
+    def _build_file_cache_key(
+        self, asset: str, compression: CompressionConfig | None
+    ) -> str:
         env = self.openapi_service.environment
         try:
             stat = os.stat(asset)
         except FileNotFoundError:
             raise FileNotFoundError(f"File not found: {asset}") from None
-        suffix = self._compression_cache_suffix()
-        return f"{env}@{asset}:{stat.st_size}:{stat.st_mtime_ns}{suffix}"
+        return (
+            f"{env}@{asset}:{stat.st_size}:{stat.st_mtime_ns}"
+            f"{self._compression_cache_suffix(compression)}"
+        )
 
-    def get_url_cache_key(self, url: str) -> str:
-        """Generate cache key for a URL, including environment and active compression settings."""
+    def _build_url_cache_key(
+        self, url: str, compression: CompressionConfig | None
+    ) -> str:
         env = self.openapi_service.environment
-        return f"{env}@{url}{self._compression_cache_suffix()}"
+        return f"{env}@{url}{self._compression_cache_suffix(compression)}"
 
     @staticmethod
-    def _compression_cache_suffix() -> str:
-        compression = rapidata_config.upload.compression
+    def _compression_cache_suffix(compression: CompressionConfig | None) -> str:
         return compression.cache_suffix() if compression is not None else ""
+
+    @staticmethod
+    def _compression_kwargs(compression: CompressionConfig | None) -> dict[str, Any]:
+        """
+        Build the kwargs dict to pass to the OpenAPI upload methods. Only includes
+        fields the user explicitly set so the call shape is unchanged when
+        compression is disabled — keeping us forward-compatible with older
+        OpenAPI clients that don't yet expose the params.
+        """
+        if compression is None or not compression.is_set():
+            return {}
+        kwargs: dict[str, Any] = {}
+        if compression.enabled is not None:
+            kwargs["compress"] = compression.enabled
+        if compression.quality is not None:
+            kwargs["quality"] = compression.quality
+        if compression.max_dimension is not None:
+            kwargs["maxdim"] = compression.max_dimension
+        if compression.library is not None:
+            kwargs["library"] = compression.library
+        return kwargs
 
     def _upload_url_asset(self, url: str) -> str:
         """
@@ -114,8 +125,13 @@ class AssetUploader:
         URLs are always cached in-memory (lightweight, no disk I/O overhead).
         Caching is required for the two-step upload flow and cannot be disabled.
         """
-
-        kwargs = _compression_kwargs(rapidata_config.upload.compression)
+        # Snapshot the compression config once so the kwargs we send and the
+        # cache key we look it up under are guaranteed consistent — without
+        # this, another thread mutating rapidata_config.upload.compression
+        # between the two reads could land mismatched kwargs/cache entries.
+        compression = rapidata_config.upload.compression
+        kwargs = self._compression_kwargs(compression)
+        cache_key = self._build_url_cache_key(url, compression)
 
         def upload_url() -> str:
             response = self.openapi_service.asset.asset_api.asset_url_post(
@@ -126,7 +142,7 @@ class AssetUploader:
             )
             return response.file_name
 
-        return self._url_cache.get_or_fetch(self.get_url_cache_key(url), upload_url)
+        return self._url_cache.get_or_fetch(cache_key, upload_url)
 
     def _upload_file_asset(self, file_path: str) -> str:
         """
@@ -135,8 +151,10 @@ class AssetUploader:
         Caching is always enabled as it's required for the two-step upload flow.
         Use cacheToDisk config to control whether cache is stored to disk or memory.
         """
-
-        kwargs = _compression_kwargs(rapidata_config.upload.compression)
+        # See _upload_url_asset for why this single-snapshot pattern matters.
+        compression = rapidata_config.upload.compression
+        kwargs = self._compression_kwargs(compression)
+        cache_key = self._build_file_cache_key(file_path, compression)
 
         def upload_file() -> str:
             response = self.openapi_service.asset.asset_api.asset_file_post(
@@ -149,9 +167,7 @@ class AssetUploader:
             )
             return response.file_name
 
-        return self._get_file_cache().get_or_fetch(
-            self.get_file_cache_key(file_path), upload_file
-        )
+        return self._get_file_cache().get_or_fetch(cache_key, upload_file)
 
     # Accept http / https / HTTP / HTTPS / mixed case — people type URLs
     # by hand or copy them from docs with varying capitalisation.

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -3,13 +3,36 @@ from __future__ import annotations
 import re
 import os
 import threading
+from typing import Any
 
 from rapidata.api_client.models.i_asset_input import IAssetInput
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.config import logger, rapidata_config, tracer
+from rapidata.rapidata_client.config.upload_config import CompressionConfig
 from rapidata.rapidata_client.datapoints._asset_mapper import AssetMapper
 from rapidata.rapidata_client.datapoints._single_flight_cache import SingleFlightCache
 from diskcache import FanoutCache
+
+
+def _compression_kwargs(compression: CompressionConfig | None) -> dict[str, Any]:
+    """
+    Build the kwargs dict to pass to the OpenAPI upload methods. Only includes
+    fields the user explicitly set so the call shape is unchanged when
+    compression is disabled — keeping us forward-compatible with older
+    OpenAPI clients that don't yet expose the params.
+    """
+    if compression is None or not compression.is_set():
+        return {}
+    kwargs: dict[str, Any] = {}
+    if compression.enabled is not None:
+        kwargs["compress"] = compression.enabled
+    if compression.quality is not None:
+        kwargs["quality"] = compression.quality
+    if compression.max_dimension is not None:
+        kwargs["maxdim"] = compression.max_dimension
+    if compression.library is not None:
+        kwargs["library"] = compression.library
+    return kwargs
 
 
 class AssetUploader:
@@ -65,18 +88,24 @@ class AssetUploader:
         self.openapi_service = openapi_service
 
     def get_file_cache_key(self, asset: str) -> str:
-        """Generate cache key for a file, including environment."""
+        """Generate cache key for a file, including environment and active compression settings."""
         env = self.openapi_service.environment
         try:
             stat = os.stat(asset)
         except FileNotFoundError:
             raise FileNotFoundError(f"File not found: {asset}") from None
-        return f"{env}@{asset}:{stat.st_size}:{stat.st_mtime_ns}"
+        suffix = self._compression_cache_suffix()
+        return f"{env}@{asset}:{stat.st_size}:{stat.st_mtime_ns}{suffix}"
 
     def get_url_cache_key(self, url: str) -> str:
-        """Generate cache key for a URL, including environment."""
+        """Generate cache key for a URL, including environment and active compression settings."""
         env = self.openapi_service.environment
-        return f"{env}@{url}"
+        return f"{env}@{url}{self._compression_cache_suffix()}"
+
+    @staticmethod
+    def _compression_cache_suffix() -> str:
+        compression = rapidata_config.upload.compression
+        return compression.cache_suffix() if compression is not None else ""
 
     def _upload_url_asset(self, url: str) -> str:
         """
@@ -86,8 +115,12 @@ class AssetUploader:
         Caching is required for the two-step upload flow and cannot be disabled.
         """
 
+        kwargs = _compression_kwargs(rapidata_config.upload.compression)
+
         def upload_url() -> str:
-            response = self.openapi_service.asset.asset_api.asset_url_post(url=url)
+            response = self.openapi_service.asset.asset_api.asset_url_post(
+                url=url, **kwargs
+            )
             logger.info(
                 "Asset uploaded from URL: %s, file name: %s", url, response.file_name
             )
@@ -103,8 +136,12 @@ class AssetUploader:
         Use cacheToDisk config to control whether cache is stored to disk or memory.
         """
 
+        kwargs = _compression_kwargs(rapidata_config.upload.compression)
+
         def upload_file() -> str:
-            response = self.openapi_service.asset.asset_api.asset_file_post(file=file_path)
+            response = self.openapi_service.asset.asset_api.asset_file_post(
+                file=file_path, **kwargs
+            )
             logger.info(
                 "Asset uploaded from file: %s, file name: %s",
                 file_path,


### PR DESCRIPTION
## Summary

Surface the asset service's image-compression knobs through the SDK config. Callers can now opt their client into compression and tune `quality` / `max_dimension` / `library` per process by setting:

```python
from rapidata import rapidata_config, CompressionConfig

rapidata_config.upload.compression = CompressionConfig(enabled=True, quality=70, max_dimension=1024)
```

Any field left as `None` keeps the server-side default, so existing callers see no behaviour change.

## Implementation

- New `CompressionConfig` pydantic model in `config/upload_config.py` with quality/max-dim validators and a `cache_suffix()` helper for cache-key fingerprinting.
- New `compression: CompressionConfig | None` field on `UploadConfig`.
- Public re-export from `rapidata` and `rapidata.rapidata_client` so users can `from rapidata import CompressionConfig`.
- `AssetUploader._upload_file_asset` and `_upload_url_asset` now read `rapidata_config.upload.compression` and pass `compress` / `quality` / `maxdim` / `library` kwargs to `asset_file_post` / `asset_url_post` only when set — call shape is unchanged when compression is not configured (forward-compatible with the current generated client).
- The file and URL cache keys include the compression fingerprint so the same asset uploaded under different settings does not collide on a single cache entry.

## Dependencies

This PR is a wrapper-layer addition; the actual server-side knob is added by [`RapidataAI/rapidata-backend#4164`](https://github.com/RapidataAI/rapidata-backend/pull/4164). The OpenAPI client (`src/rapidata/api_client/`) needs to be regenerated against the deployed asset service for the compression kwargs to actually reach the wire — the existing `update-openapi-client` workflow handles that.

Order of operations:

1. Merge & deploy the backend PR.
2. Run the `update-openapi-client` workflow (or wait for the automated dispatch) to regenerate `asset_api.py` with the new params.
3. Merge this PR.

Until step 2 lands, setting `rapidata_config.upload.compression` produces the configured override on the SDK side but the kwargs are dropped at the OpenAPI client boundary; the request will still succeed and use the server-side defaults.

## Out of scope

- Batched URL uploads via `/asset/batch-upload` — `BatchAssetUploader` does not yet pass `compression` because the input model needs OpenAPI regen first. Follow-up PR after step 2 above. `CompressionConfig`'s docstring calls this out.
- Frontend / dashboard UI for the new knobs.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` — 0 errors, 0 warnings.
- [x] Smoke imports + validators verified locally:
  - default `_compression_kwargs(None)` returns `{}`
  - partial config emits only set fields
  - `quality=0` and `max_dimension=0` raise `ValidationError`
  - assignment to `rapidata_config.upload.compression` round-trips
- [ ] Manual smoke (post-OpenAPI-regen): upload a known-large image with `enabled=True, quality=50` and confirm the returned filename ends in `.webp`.

🔗 Session: https://session-2c7d2568.poseidon.rapidata.internal/