### PR TITLE
feat(datapoints): retry datapoint creation up to maxRetries

### DIFF
--- a/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_datapoint_uploader.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
+from rapidata.rapidata_client.api.rapidata_api_client import (
+    suppress_rapidata_error_logging,
+)
+from rapidata.rapidata_client.config import logger, rapidata_config
 from rapidata.rapidata_client.datapoints._datapoint import Datapoint
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.datapoints._asset_mapper import AssetMapper
 
 if TYPE_CHECKING:
+    from rapidata.api_client.models.create_datapoint_endpoint_input import (
+        CreateDatapointEndpointInput,
+    )
     from rapidata.api_client.models.create_datapoint_endpoint_output import (
         CreateDatapointEndpointOutput,
     )
@@ -40,15 +48,48 @@ class DatapointUploader:
             else self.asset_uploader.upload_and_map_asset(datapoint.media_context)
         )
 
-        return self.openapi_service.dataset.datapoints_api.dataset_dataset_id_datapoint_post(
-            dataset_id=dataset_id,
-            create_datapoint_endpoint_input=CreateDatapointEndpointInput(
-                asset=uploaded_asset,
-                context=context,
-                contextAsset=context_asset,
-                transcription=datapoint.sentence,
-                sortIndex=index,
-                group=datapoint.group,
-                privateMetadata=datapoint.private_metadata,
-            ),
+        payload = CreateDatapointEndpointInput(
+            asset=uploaded_asset,
+            context=context,
+            contextAsset=context_asset,
+            transcription=datapoint.sentence,
+            sortIndex=index,
+            group=datapoint.group,
+            privateMetadata=datapoint.private_metadata,
         )
+
+        return self._create_datapoint_with_retries(dataset_id, index, payload)
+
+    def _create_datapoint_with_retries(
+        self,
+        dataset_id: str,
+        index: int,
+        payload: CreateDatapointEndpointInput,
+    ) -> CreateDatapointEndpointOutput:
+        max_retries = rapidata_config.upload.maxRetries
+        last_exception: Exception | None = None
+
+        for attempt in range(max_retries):
+            try:
+                with suppress_rapidata_error_logging():
+                    return self.openapi_service.dataset.datapoints_api.dataset_dataset_id_datapoint_post(
+                        dataset_id=dataset_id,
+                        create_datapoint_endpoint_input=payload,
+                    )
+            except Exception as e:
+                last_exception = e
+                if attempt < max_retries - 1:
+                    # Exponential backoff: 1s, 2s, 4s
+                    retry_delay = 2**attempt
+                    logger.debug(
+                        "Datapoint creation failed (attempt %s/%s) for index %s: %s. Retrying in %ss...",
+                        attempt + 1,
+                        max_retries,
+                        index,
+                        e,
+                        retry_delay,
+                    )
+                    time.sleep(retry_delay)
+
+        assert last_exception is not None
+        raise last_exception


### PR DESCRIPTION
## Summary

The SDK previously failed a datapoint upload immediately on the first error from the create-datapoint POST. This wraps the call in a retry loop so transient failures (network blips, brief 5xx) no longer drop the datapoint.

- Up to `rapidata_config.upload.maxRetries` attempts (default 3, already exposed via env/config).
- Exponential backoff between attempts: 1s, 2s, 4s.
- Intermediate failures logged at DEBUG via `suppress_rapidata_error_logging` to avoid spamming users on retried errors; the final exception still propagates so the existing orchestrator-level failure tracking in `_rapidata_dataset.py` keeps working.
- Pattern mirrors the existing sample-upload retry in `benchmark/participant/participant.py`.

Asset upload is left outside the retry loop — assets are uploaded ahead of time by the orchestrator and cached, so only the datapoint creation API call itself is the new retry surface.

## Notes

- I could not run `pyright src/rapidata/rapidata_client` from the Poseidon container (Python tooling not present); please run it locally before merging as required by the repo's CLAUDE.md.

## Test plan

- [ ] Local: kick off an order with a small dataset and confirm successful path is unchanged.
- [ ] Simulate a transient failure (e.g. point at a flaky endpoint or briefly stop the dataset service) and confirm the SDK retries and eventually succeeds within 3 attempts.
- [ ] Force a persistent failure and confirm the datapoint ends up in the failed-uploads list with the original exception.
- [ ] `pyright src/rapidata/rapidata_client` clean.

🔗 Session: https://session-e125c012.poseidon.rapidata.internal/