### PR TITLE
feat(audience): filter into filtered audience

### DIFF
--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -202,6 +202,37 @@ audience = client.audience.get_audience_by_id("audience_id")
 job = audience.assign_job(new_job_definition)
 ```
 
+## Filtered Audiences
+
+A filtered audience is a lightweight subset of an existing audience's
+qualified labelers — derived by applying filters on top of the base
+audience. No new qualification or recruiting takes place; the filtered
+audience reuses the same pool. Use it when you want to target a specific
+slice (e.g. by country, language, or demographic) of an audience that you
+have already trained.
+
+```py
+from rapidata import CountryFilter, DemographicFilter
+
+base = client.audience.get_audience_by_id("audience_id")
+
+us_under_30 = base.filter([
+    CountryFilter(["US"]),
+    DemographicFilter("age", ["18-29"]),
+])
+
+job = us_under_30.assign_job(new_job_definition)
+```
+
+The returned object is a regular `RapidataAudience` — its `id` can be
+passed anywhere an audience id is accepted, including `assign_job` and
+[leaderboard creation](mri.md).
+
+Supported filters: `CountryFilter`, `LanguageFilter`, `DemographicFilter`,
+combined with `AndFilter` / `OrFilter` / `NotFilter` (or the `&` / `|` /
+`~` operators). Multiple filters passed in the list are combined with
+logical AND.
+
 ## Next Steps
 
 - Learn about [Classification Jobs](examples/classify_job.md) for categorizing data

--- a/src/rapidata/__init__.py
+++ b/src/rapidata/__init__.py
@@ -43,6 +43,7 @@ from .rapidata_client import (
     CompareEquirectangularSetting,
 # --- GENERATED SETTINGS IMPORTS END ---
     CountryFilter,
+    DemographicFilter,
     LanguageFilter,
     NotFilter,
     OrFilter,

--- a/src/rapidata/rapidata_client/__init__.py
+++ b/src/rapidata/rapidata_client/__init__.py
@@ -48,6 +48,7 @@ from .settings import (
 # --- GENERATED SETTINGS IMPORTS END ---
 from .filter import (
     CountryFilter,
+    DemographicFilter,
     LanguageFilter,
     NotFilter,
     OrFilter,

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -64,6 +64,72 @@ class RapidataAudience:
             logger.debug("Audience '%s' has been deleted.", self)
             managed_print(f"Audience '{self}' has been deleted.")
 
+    def filter(self, filters: list[RapidataFilter]) -> RapidataAudience:
+        """Derive a filtered audience from this audience.
+
+        Applies the given filters on top of this audience's graduated annotators and returns
+        a lightweight, filtered audience. The filtered audience reuses this audience's pool of
+        qualified annotators — no new recruiting or onboarding takes place. The returned id can
+        be passed to job and leaderboard creation in place of a regular audience id.
+
+        Supported filter types: ``CountryFilter``, ``LanguageFilter``, ``DemographicFilter``,
+        and the combinators ``AndFilter`` / ``OrFilter`` / ``NotFilter`` (also via the
+        ``&`` / ``|`` / ``~`` operators).
+
+        Args:
+            filters (list[RapidataFilter]): One or more filters to apply. Multiple filters are
+                combined with a logical AND. Pass a single ``AndFilter`` / ``OrFilter`` /
+                ``NotFilter`` if you need a different combinator at the top level.
+
+        Returns:
+            RapidataAudience: A new audience instance representing the filtered view. Its
+            ``filters`` property reflects the applied filter tree.
+
+        Example:
+            ```python
+            from rapidata import CountryFilter, DemographicFilter
+
+            base = client.audience.get_audience_by_id("aud_...")
+            us_under_30 = base.filter(
+                [CountryFilter(["US"]), DemographicFilter("age", ["18-29"])]
+            )
+            benchmark.create_leaderboard(
+                name="my-leaderboard",
+                instruction="Pick the better image",
+                audience_id=us_under_30.id,
+            )
+            ```
+        """
+        with tracer.start_as_current_span("RapidataAudience.filter"):
+            from rapidata.api_client.models.create_filtered_audience_endpoint_input import (
+                CreateFilteredAudienceEndpointInput,
+            )
+            from rapidata.rapidata_client.filter.and_filter import AndFilter
+
+            if not filters:
+                raise ValueError("At least one filter must be provided.")
+
+            top_level = filters[0] if len(filters) == 1 else AndFilter(filters)
+
+            logger.debug(
+                f"Creating filtered audience from {self.id} with filters: {filters}"
+            )
+            response = self._openapi_service.audience.audience_api.audience_base_audience_id_filter_post(
+                base_audience_id=self.id,
+                create_filtered_audience_endpoint_input=CreateFilteredAudienceEndpointInput(
+                    filter=top_level._to_audience_model(),
+                ),
+            )
+            logger.info(
+                f"Created filtered audience {response.audience_id} from base {self.id}"
+            )
+            return RapidataAudience(
+                id=response.audience_id,
+                name=self._name,
+                filters=list(filters),
+                openapi_service=self._openapi_service,
+            )
+
     def update_filters(self, filters: list[RapidataFilter]) -> RapidataAudience:
         """Update the filters for this audience.
 

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -8,6 +8,7 @@ from rapidata.rapidata_client.benchmark._detail_mapper import LevelOfDetail
 
 if TYPE_CHECKING:
     import pandas as pd
+    from rapidata.rapidata_client.audience.rapidata_audience import RapidataAudience
     from rapidata.rapidata_client.benchmark.leaderboard.rapidata_leaderboard import (
         RapidataLeaderboard,
     )
@@ -320,7 +321,7 @@ class RapidataBenchmark:
         inverse_ranking: bool = False,
         level_of_detail: LevelOfDetail | None = None,
         min_responses_per_matchup: int | None = None,
-        audience_id: str | None = None,
+        audience_id: str | RapidataAudience | None = None,
         settings: Sequence["RapidataSetting"] | None = None,
     ) -> RapidataLeaderboard:
         """
@@ -334,12 +335,13 @@ class RapidataBenchmark:
             inverse_ranking: Whether to inverse the ranking of the leaderboard. (if the question is inversed, e.g. "Which video is worse?")
             level_of_detail: The level of detail of the leaderboard. This will effect how many comparisons are done per model evaluation. (default: "low")
             min_responses_per_matchup: The minimum number of responses required to be considered for the leaderboard. (default: 3)
-            audience_id: The id of the audience that should answer the leaderboard. Defaults to the global audience when not specified.
+            audience_id: The audience that should answer the leaderboard. Pass either the audience id or a :class:`RapidataAudience` instance. Accepts both plain dimension audiences and filtered audiences derived via :py:meth:`RapidataAudience.filter`. Defaults to the global audience when not specified.
             settings: The settings that should be applied to the leaderboard. Will determine the behavior of the tasks on the leaderboard. (default: [])
         """
         from rapidata.api_client.models.create_leaderboard_endpoint_input import (
             CreateLeaderboardEndpointInput,
         )
+        from rapidata.rapidata_client.audience.rapidata_audience import RapidataAudience
         from rapidata.rapidata_client.benchmark._detail_mapper import DetailMapper
         from rapidata.rapidata_client.benchmark.leaderboard.rapidata_leaderboard import (
             RapidataLeaderboard,
@@ -362,6 +364,12 @@ class RapidataBenchmark:
                     "Min responses per matchup must be an integer and at least 3"
                 )
 
+            resolved_audience_id = (
+                audience_id.id
+                if isinstance(audience_id, RapidataAudience)
+                else audience_id
+            )
+
             logger.info(
                 "Creating leaderboard %s with instruction %s, show_prompt %s, show_prompt_asset %s, inverse_ranking %s, level_of_detail %s, min_responses_per_matchup %s, audience_id %s, settings %s",
                 name,
@@ -371,7 +379,7 @@ class RapidataBenchmark:
                 inverse_ranking,
                 level_of_detail,
                 min_responses_per_matchup,
-                audience_id,
+                resolved_audience_id,
                 settings,
             )
 
@@ -390,7 +398,7 @@ class RapidataBenchmark:
                             if level_of_detail is not None
                             else None
                         ),
-                        audienceId=audience_id,
+                        audienceId=resolved_audience_id,
                         featureFlags=(
                             [setting._to_feature_flag() for setting in settings]
                             if settings

--- a/src/rapidata/rapidata_client/filter/__init__.py
+++ b/src/rapidata/rapidata_client/filter/__init__.py
@@ -2,6 +2,7 @@ from ._base_filter import RapidataFilter
 from .age_filter import AgeFilter, AgeGroup
 from .campaign_filter import CampaignFilter
 from .country_filter import CountryFilter
+from .demographic_filter import DemographicFilter
 from .gender_filter import GenderFilter, Gender
 from .language_filter import LanguageFilter
 from .user_score_filter import UserScoreFilter

--- a/src/rapidata/rapidata_client/filter/_backend_filter_mapper.py
+++ b/src/rapidata/rapidata_client/filter/_backend_filter_mapper.py
@@ -34,6 +34,9 @@ class BackendFilterMapper:
         from rapidata.api_client.models.i_audience_filter_country_audience_filter import (
             IAudienceFilterCountryAudienceFilter,
         )
+        from rapidata.api_client.models.i_audience_filter_demographic_audience_filter import (
+            IAudienceFilterDemographicAudienceFilter,
+        )
         from rapidata.api_client.models.i_audience_filter_language_audience_filter import (
             IAudienceFilterLanguageAudienceFilter,
         )
@@ -43,6 +46,7 @@ class BackendFilterMapper:
             "OrAudienceFilter": IAudienceFilterOrAudienceFilter,
             "NotAudienceFilter": IAudienceFilterNotAudienceFilter,
             "CountryAudienceFilter": IAudienceFilterCountryAudienceFilter,
+            "DemographicAudienceFilter": IAudienceFilterDemographicAudienceFilter,
             "LanguageAudienceFilter": IAudienceFilterLanguageAudienceFilter,
         }
 
@@ -54,6 +58,7 @@ class BackendFilterMapper:
 
         from rapidata.rapidata_client.filter.and_filter import AndFilter
         from rapidata.rapidata_client.filter.country_filter import CountryFilter
+        from rapidata.rapidata_client.filter.demographic_filter import DemographicFilter
         from rapidata.rapidata_client.filter.language_filter import LanguageFilter
         from rapidata.rapidata_client.filter.not_filter import NotFilter
         from rapidata.rapidata_client.filter.or_filter import OrFilter
@@ -61,6 +66,7 @@ class BackendFilterMapper:
         cls._imported_client_filters = {
             "AndFilter": AndFilter,
             "CountryFilter": CountryFilter,
+            "DemographicFilter": DemographicFilter,
             "LanguageFilter": LanguageFilter,
             "NotFilter": NotFilter,
             "OrFilter": OrFilter,
@@ -92,6 +98,9 @@ class BackendFilterMapper:
         BackendCountryAudienceFilter = cls._imported_backend_filters[
             "CountryAudienceFilter"
         ]
+        BackendDemographicAudienceFilter = cls._imported_backend_filters[
+            "DemographicAudienceFilter"
+        ]
         BackendLanguageAudienceFilter = cls._imported_backend_filters[
             "LanguageAudienceFilter"
         ]
@@ -101,6 +110,7 @@ class BackendFilterMapper:
         ClientOrFilter = cls._imported_client_filters["OrFilter"]
         ClientNotFilter = cls._imported_client_filters["NotFilter"]
         ClientCountryFilter = cls._imported_client_filters["CountryFilter"]
+        ClientDemographicFilter = cls._imported_client_filters["DemographicFilter"]
         ClientLanguageFilter = cls._imported_client_filters["LanguageFilter"]
 
         # Handle recursive filters (AndFilter, OrFilter, NotFilter)
@@ -126,6 +136,11 @@ class BackendFilterMapper:
         # Handle simple filters with straightforward mappings
         elif isinstance(actual_instance, BackendCountryAudienceFilter):
             return ClientCountryFilter(actual_instance.countries)  # type: ignore[attr-defined]
+        elif isinstance(actual_instance, BackendDemographicAudienceFilter):
+            return ClientDemographicFilter(
+                identifier=actual_instance.identifier,  # type: ignore[attr-defined]
+                values=actual_instance.values,  # type: ignore[attr-defined]
+            )
         elif isinstance(actual_instance, BackendLanguageAudienceFilter):
             return ClientLanguageFilter(actual_instance.languages)  # type: ignore[attr-defined]
 

--- a/src/rapidata/rapidata_client/filter/demographic_filter.py
+++ b/src/rapidata/rapidata_client/filter/demographic_filter.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from rapidata.rapidata_client.filter._base_filter import RapidataFilter
+from pydantic import BaseModel
+
+
+class DemographicFilter(RapidataFilter, BaseModel):
+    """DemographicFilter Class
+
+    Filters the graduates of an audience by a demographic attribute (e.g. age, gender,
+    occupation). Used when deriving a filtered audience from an existing dimension audience
+    via :py:meth:`RapidataAudience.filter`.
+
+    Args:
+        identifier (str): The demographic key to filter on (e.g. ``"age"``, ``"gender"``,
+            ``"occupation"``).
+        values (list[str]): The accepted values for that demographic. A graduate is included
+            if any of their stored demographic values for ``identifier`` matches one of these.
+
+    Example:
+        ```python
+        from rapidata import DemographicFilter
+
+        # Keep graduates who are between 18 and 39 years old.
+        DemographicFilter("age", ["18-29", "30-39"])
+        ```
+    """
+
+    identifier: str
+    values: list[str]
+
+    def __init__(self, identifier: str, values: list[str]):
+        super().__init__(identifier=identifier, values=values)
+
+    def _to_model(self):
+        raise NotImplementedError(
+            "DemographicFilter only applies to filtered audiences; use AgeFilter / GenderFilter for user-level filters."
+        )
+
+    def _to_audience_model(self):
+        from rapidata.api_client.models.i_audience_filter import IAudienceFilter
+        from rapidata.api_client.models.i_audience_filter_demographic_audience_filter import (
+            IAudienceFilterDemographicAudienceFilter,
+        )
+
+        return IAudienceFilter(
+            actual_instance=IAudienceFilterDemographicAudienceFilter(
+                _t="DemographicFilter",
+                identifier=self.identifier,
+                values=self.values,
+            )
+        )

--- a/src/rapidata/rapidata_client/filter/rapidata_filters.py
+++ b/src/rapidata/rapidata_client/filter/rapidata_filters.py
@@ -1,4 +1,5 @@
 from rapidata.rapidata_client.filter.country_filter import CountryFilter
+from rapidata.rapidata_client.filter.demographic_filter import DemographicFilter
 from rapidata.rapidata_client.filter.language_filter import LanguageFilter
 from rapidata.rapidata_client.filter.not_filter import NotFilter
 from rapidata.rapidata_client.filter.or_filter import OrFilter
@@ -18,6 +19,7 @@ class RapidataFilters:
     Attributes:
         Country (CountryFilter): Filters for users with a specific country.
         Language (LanguageFilter): Filters for users with a specific language.
+        Demographic (DemographicFilter): Filters audience graduates by a demographic attribute (e.g. age, gender). Only valid when deriving a filtered audience via :py:meth:`RapidataAudience.filter`.
         Not (NotFilter): Inverts the filter.
         Or (OrFilter): Combines multiple filters with a logical OR operation.
         And (AndFilter): Combines multiple filters with a logical AND operation.
@@ -44,6 +46,7 @@ class RapidataFilters:
 
     Country = CountryFilter
     Language = LanguageFilter
+    Demographic = DemographicFilter
     Not = NotFilter
     Or = OrFilter
     And = AndFilter


### PR DESCRIPTION
## Summary

- Adds **`RapidataAudience.filter(filters)`** which calls the new `POST /audience/{baseAudienceId}/filter` endpoint and returns a filtered `RapidataAudience`. The returned id reuses the base audience's graduated annotators (no new recruiting) and is accepted everywhere a regular audience id is accepted — including `assign_job` and leaderboard creation.
- Adds a new **`DemographicFilter`** filter type (audience-only, for `age` / `gender` / `occupation`). Existing `CountryFilter`, `LanguageFilter`, and the `AndFilter` / `OrFilter` / `NotFilter` combinators (or `&` / `|` / `~` operators) all carry over.
- Widens **`RapidataBenchmark.create_leaderboard`**'s `audience_id` to accept either a `RapidataAudience` instance or a plain id string, so the filtered audience can be wired up directly.

The OpenAPI client regen that exposes the new endpoint is in #581 (now merged), so this PR is **9 files, ~180 lines** of hand-written code.

## Example: filter the global audience to Arabic-speaking labelers

```python
from rapidata import RapidataClient, LanguageFilter

client = RapidataClient()

# "global" is the well-known dimension audience that anyone can label.
global_audience = client.audience.get_audience_by_id("global")

# Filter down to its Arabic-speaking graduates. No new recruiting — the
# filtered audience reuses the same pool, just narrower.
arabic_speakers = global_audience.filter([LanguageFilter(["ar"])])

# Use the filtered audience anywhere an audience id is accepted.
benchmark = client.benchmark.create_new_benchmark(name="My Benchmark", ...)
benchmark.create_leaderboard(
    name="image-quality-ar",
    instruction="أي صورة أفضل؟",
    audience_id=arabic_speakers,  # also accepts arabic_speakers.id
)
```

For more complex slices, combine filters:

```python
from rapidata import CountryFilter, DemographicFilter

# Arabic-speakers in SA, AE or EG, between 18 and 39.
slice = global_audience.filter([
    LanguageFilter(["ar"]),
    CountryFilter(["SA", "AE", "EG"]),
    DemographicFilter("age", ["18-29", "30-39"]),
])
```

Multiple filters in the list are AND-combined. For other combinators use `AndFilter` / `OrFilter` / `NotFilter` or the `&` / `|` / `~` operators.

## Backend dependency

The audience filter endpoint is live and jobs (`audience.assign_job(...)`) already work end-to-end. The leaderboard validator that rejected filtered audience ids has its own backend PR: [RapidataAI/rapidata-backend#4179](https://github.com/RapidataAI/rapidata-backend/pull/4179). Until that merges, `create_leaderboard(audience_id=filtered)` will return a validation error from the backend.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` — 0 errors, 0 warnings
- [x] Local smoke test: round-trips filter payloads through the generated pydantic models and emits the expected JSON discriminator (`{"_t": "AndFilter", "filters": [...]}` etc.)
- [ ] Integration: derive a filtered audience and assign a job to it
- [ ] Integration: create a leaderboard with a filtered audience id (needs backend PR #4179)

🔗 Session: [https://session-0439e1c4.poseidon.rapidata.internal/](https://session-0439e1c4.poseidon.rapidata.internal/)