### PR TITLE
feat(audience): add filter_global shortcut

### DIFF
--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -233,6 +233,19 @@ combined with `AndFilter` / `OrFilter` / `NotFilter` (or the `&` / `|` /
 `~` operators). Multiple filters passed in the list are combined with
 logical AND.
 
+### Filtering the global audience
+
+The global audience is the most common base — slicing it by language,
+country, or demographic is enough for most jobs. There's a shortcut
+that skips the `get_audience_by_id("global")` step:
+
+```py
+from rapidata import LanguageFilter
+
+arabic_speakers = client.audience.filter_global([LanguageFilter(["ar"])])
+job = arabic_speakers.assign_job(new_job_definition)
+```
+
 ## Next Steps
 
 - Learn about [Classification Jobs](examples/classify_job.md) for categorizing data

--- a/src/rapidata/rapidata_client/audience/rapidata_audience_manager.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience_manager.py
@@ -60,6 +60,35 @@ class RapidataAudienceManager:
             )
             return audience
 
+    def filter_global(self, filters: list[RapidataFilter]) -> RapidataAudience:
+        """Derive a filtered audience from the global audience.
+
+        Shortcut for ``get_audience_by_id("global").filter(filters)``. The global
+        audience is the broadest pool of labelers, and most filtered audiences are
+        slices of it (e.g. by country, language, or demographic).
+
+        Supported filter types: ``CountryFilter``, ``LanguageFilter``,
+        ``DemographicFilter``, combined with ``AndFilter`` / ``OrFilter`` /
+        ``NotFilter``. Multiple filters in the list are AND-combined.
+
+        Args:
+            filters (list[RapidataFilter]): One or more filters to apply.
+
+        Returns:
+            RapidataAudience: The filtered audience instance.
+
+        Example:
+            ```python
+            from rapidata import LanguageFilter
+
+            arabic_speakers = client.audience.filter_global([LanguageFilter(["ar"])])
+            job = arabic_speakers.assign_job(job_definition)
+            ```
+        """
+        with tracer.start_as_current_span("RapidataAudienceManager.filter_global"):
+            logger.debug(f"Filtering global audience with filters: {filters}")
+            return self.get_audience_by_id("global").filter(filters)
+
     def get_audience_by_id(self, audience_id: str) -> RapidataAudience:
         """Get an audience by its ID.
 


### PR DESCRIPTION
## Summary

Adds \`client.audience.filter_global(filters)\` as a shortcut for the common pattern of "filter the global audience by language / country / demographic". Drops a line and removes the magic-string \`get_audience_by_id("global")\` lookup.

Follow-up to #587. **2 files, 42 lines.**

## Before / after

\`\`\`python
# Before
global_audience = client.audience.get_audience_by_id("global")
arabic_speakers = global_audience.filter([LanguageFilter(["ar"])])

# After
arabic_speakers = client.audience.filter_global([LanguageFilter(["ar"])])
\`\`\`

The shortcut just delegates to \`get_audience_by_id("global").filter(filters)\` — same audience, same payload, two API calls. Kept it as a plain delegation rather than a direct endpoint call so the filter behaviour stays in one place (\`RapidataAudience.filter\`).

## Naming

Went with \`filter_global\` rather than a bare \`.filter(...)\` on the manager — \`client.audience.filter(...)\` reads more like "search my existing audiences" than "create a filtered audience from global", and being explicit about the base avoids that ambiguity.

## Test plan

- [x] \`uv run pyright src/rapidata/rapidata_client\` — 0 errors

🔗 Session: [https://session-0439e1c4.poseidon.rapidata.internal/](https://session-0439e1c4.poseidon.rapidata.internal/)