### PR TITLE
refactor(audience): split filtered audience into its own type

### DIFF
--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -224,9 +224,14 @@ us_under_30 = base.filter([
 job = us_under_30.assign_job(new_job_definition)
 ```
 
-The returned object is a regular `RapidataAudience` — its `id` can be
-passed anywhere an audience id is accepted, including `assign_job` and
-[leaderboard creation](mri.md).
+The returned object is a `RapidataFilteredAudience` — a slim variant that
+exposes only the operations that make sense for a filtered view
+(`assign_job`, `find_jobs`, `delete`, and use as `audience_id` on
+[leaderboard creation](mri.md)). It deliberately does **not** offer
+`add_classification_example`, `update_filters`, or further nested
+`.filter(...)` calls: those would either mutate the base audience's
+qualification pool (which the filtered view shares) or chain filters in
+a way that's better expressed as a single combined filter on the base.
 
 Supported filters: `CountryFilter`, `LanguageFilter`, `DemographicFilter`,
 combined with `AndFilter` / `OrFilter` / `NotFilter` (or the `&` / `|` /

--- a/src/rapidata/__init__.py
+++ b/src/rapidata/__init__.py
@@ -3,7 +3,9 @@ __version__ = "3.11.1"
 from .rapidata_client import (
     RapidataClient,
     RapidataAudience,
+    RapidataAudienceBase,
     RapidataAudienceManager,
+    RapidataFilteredAudience,
     RapidataOrderManager,
     RapidataOrder,
     RapidataJob,

--- a/src/rapidata/rapidata_client/__init__.py
+++ b/src/rapidata/rapidata_client/__init__.py
@@ -1,7 +1,9 @@
 from .rapidata_client import RapidataClient
 from .audience import (
     RapidataAudience,
+    RapidataAudienceBase,
     RapidataAudienceManager,
+    RapidataFilteredAudience,
 )
 from .order import RapidataOrderManager, RapidataOrder
 from .job import RapidataJob, RapidataJobDefinition, RapidataJobManager

--- a/src/rapidata/rapidata_client/audience/__init__.py
+++ b/src/rapidata/rapidata_client/audience/__init__.py
@@ -1,2 +1,4 @@
+from ._audience_base import RapidataAudienceBase
 from .rapidata_audience import RapidataAudience
 from .rapidata_audience_manager import RapidataAudienceManager
+from .rapidata_filtered_audience import RapidataFilteredAudience

--- a/src/rapidata/rapidata_client/audience/_audience_base.py
+++ b/src/rapidata/rapidata_client/audience/_audience_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from rapidata.rapidata_client.config import logger, tracer, managed_print
+from rapidata.rapidata_client.config import logger, tracer
 
 if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
@@ -50,16 +50,6 @@ class RapidataAudienceBase:
     def filters(self) -> list[RapidataFilter]:
         """The filters applied to the audience."""
         return self._filters
-
-    def delete(self) -> None:
-        """Deletes the audience."""
-        with tracer.start_as_current_span(f"{type(self).__name__}.delete"):
-            logger.info("Deleting audience '%s'", self)
-            self._openapi_service.audience.audience_api.audience_audience_id_delete(
-                self.id
-            )
-            logger.debug("Audience '%s' has been deleted.", self)
-            managed_print(f"Audience '{self}' has been deleted.")
 
     def assign_job(self, job_definition: RapidataJobDefinition) -> RapidataJob:
         """Assign a job to this audience.

--- a/src/rapidata/rapidata_client/audience/_audience_base.py
+++ b/src/rapidata/rapidata_client/audience/_audience_base.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from rapidata.rapidata_client.config import logger, tracer, managed_print
+
+if TYPE_CHECKING:
+    from rapidata.service.openapi_service import OpenAPIService
+    from rapidata.rapidata_client.filter import RapidataFilter
+    from rapidata.rapidata_client.job.rapidata_job_definition import (
+        RapidataJobDefinition,
+    )
+    from rapidata.rapidata_client.job.rapidata_job import RapidataJob
+
+
+class RapidataAudienceBase:
+    """Shared surface for any kind of Rapidata audience.
+
+    Both :class:`RapidataAudience` (dimension audience — has its own pool of qualified
+    annotators) and :class:`RapidataFilteredAudience` (a filtered view on top of a
+    dimension audience) inherit from this. Code that only needs to read the id, run a
+    job, or list jobs should accept ``RapidataAudienceBase``; code that needs to add
+    qualification examples or change recruiting must take ``RapidataAudience``.
+
+    Attributes:
+        id (str): The unique identifier of the audience.
+        name (str): The name of the audience.
+        filters (list[RapidataFilter]): The filters applied to the audience. For a
+            dimension audience these are the recruitment filters; for a filtered
+            audience they are the slice on top of the base audience.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        filters: list[RapidataFilter],
+        openapi_service: OpenAPIService,
+    ):
+        self.id = id
+        self._name = name
+        self._filters = filters
+        self._openapi_service = openapi_service
+
+    @property
+    def name(self) -> str:
+        """The name of the audience."""
+        return self._name
+
+    @property
+    def filters(self) -> list[RapidataFilter]:
+        """The filters applied to the audience."""
+        return self._filters
+
+    def delete(self) -> None:
+        """Deletes the audience."""
+        with tracer.start_as_current_span(f"{type(self).__name__}.delete"):
+            logger.info("Deleting audience '%s'", self)
+            self._openapi_service.audience.audience_api.audience_audience_id_delete(
+                self.id
+            )
+            logger.debug("Audience '%s' has been deleted.", self)
+            managed_print(f"Audience '{self}' has been deleted.")
+
+    def assign_job(self, job_definition: RapidataJobDefinition) -> RapidataJob:
+        """Assign a job to this audience.
+
+        Creates a new job instance from the job definition and assigns it to this audience.
+        The job will be executed by the annotators in this audience.
+
+        Args:
+            job_definition (JobDefinition): The job definition to create and assign to the audience.
+
+        Returns:
+            RapidataJob: The created job instance.
+        """
+        with tracer.start_as_current_span(f"{type(self).__name__}.assign_job"):
+            from rapidata.api_client.models.create_job_endpoint_input import (
+                CreateJobEndpointInput,
+            )
+            from rapidata.rapidata_client.job.rapidata_job import RapidataJob
+            from datetime import datetime
+
+            logger.debug(f"Assigning job to audience: {self.id}")
+            response = self._openapi_service.order.job_api.job_post(
+                create_job_endpoint_input=CreateJobEndpointInput(
+                    audienceId=self.id,
+                    jobDefinitionId=job_definition.id,
+                ),
+            )
+            job = RapidataJob(
+                job_id=response.job_id,
+                name=job_definition.name,
+                audience_id=self.id,
+                created_at=datetime.now(),
+                definition_id=job_definition.id,
+                openapi_service=self._openapi_service,
+            )
+            logger.info(f"Assigned job to audience: {self.id}")
+            return job
+
+    def find_jobs(
+        self, name: str = "", amount: int = 10, page: int = 1
+    ) -> list[RapidataJob]:
+        """Find jobs assigned to this audience.
+
+        Args:
+            name (str, optional): Filter jobs by name (matching jobs will contain this string). Defaults to "" for any job.
+            amount (int, optional): The maximum number of jobs to return. Defaults to 10.
+            page (int, optional): The page of jobs to return. Defaults to 1.
+
+        Returns:
+            list[RapidataJob]: A list of RapidataJob instances assigned to this audience.
+        """
+        with tracer.start_as_current_span(f"{type(self).__name__}.find_jobs"):
+            from rapidata.rapidata_client.job.rapidata_job import RapidataJob
+            from rapidata.api_client.models.audience_audience_id_jobs_get_job_id_parameter import (
+                AudienceAudienceIdJobsGetJobIdParameter,
+            )
+
+            response = self._openapi_service.order.job_api.jobs_get(
+                page=page,
+                page_size=amount,
+                name=AudienceAudienceIdJobsGetJobIdParameter(contains=name),
+                audience_id=AudienceAudienceIdJobsGetJobIdParameter(eq=self.id),
+                sort=["-created_at"],
+            )
+            return [
+                RapidataJob(
+                    job_id=job.job_id,
+                    name=job.name,
+                    audience_id=job.audience_id,
+                    created_at=job.created_at,
+                    definition_id=job.definition_id,
+                    openapi_service=self._openapi_service,
+                    pipeline_id=job.pipeline_id,
+                )
+                for job in response.items
+            ]
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}(id={self.id}, name={self._name}, filters={self._filters})"
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Sequence
-from rapidata.rapidata_client.config import logger, tracer, managed_print
+from rapidata.rapidata_client.config import logger, tracer
+from rapidata.rapidata_client.audience._audience_base import RapidataAudienceBase
 from rapidata.rapidata_client.audience.audience_example_handler import (
     AudienceExampleHandler,
 )
@@ -9,25 +10,22 @@ from rapidata.rapidata_client.datapoints._datapoint import coerce_media_context
 
 if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
-    from rapidata.rapidata_client.filter import RapidataFilter
-    from rapidata.rapidata_client.job.rapidata_job_definition import (
-        RapidataJobDefinition,
+    from rapidata.rapidata_client.audience.rapidata_filtered_audience import (
+        RapidataFilteredAudience,
     )
-    from rapidata.rapidata_client.job.rapidata_job import RapidataJob
+    from rapidata.rapidata_client.filter import RapidataFilter
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
     from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
     import pandas as pd
 
 
-class RapidataAudience:
-    """Represents a Rapidata audience.
+class RapidataAudience(RapidataAudienceBase):
+    """A Rapidata dimension audience.
 
-    An audience is a group of annotators that can be recruited based on example tasks and assigned jobs.
-
-    Attributes:
-        id (str): The unique identifier of the audience.
-        name (str): The name of the audience.
-        filters (list[RapidataFilter]): The list of filters applied to the audience.
+    A dimension audience is a group of annotators recruited via qualification examples
+    and (optionally) recruitment filters. Use :py:meth:`filter` to derive a
+    :class:`RapidataFilteredAudience` — a lightweight slice that reuses the same pool
+    without new recruiting.
     """
 
     def __init__(
@@ -37,34 +35,11 @@ class RapidataAudience:
         filters: list[RapidataFilter],
         openapi_service: OpenAPIService,
     ):
-        self.id = id
-        self._name = name
-        self._filters = filters
-        self._openapi_service = openapi_service
+        super().__init__(id=id, name=name, filters=filters, openapi_service=openapi_service)
         self._example_handler = AudienceExampleHandler(openapi_service, id)
         self._recruiting_started = False
 
-    @property
-    def name(self) -> str:
-        """The name of the audience."""
-        return self._name
-
-    @property
-    def filters(self) -> list[RapidataFilter]:
-        """The list of filters applied to the audience."""
-        return self._filters
-
-    def delete(self) -> None:
-        """Deletes the audience."""
-        with tracer.start_as_current_span("RapidataAudience.delete"):
-            logger.info("Deleting audience '%s'", self)
-            self._openapi_service.audience.audience_api.audience_audience_id_delete(
-                self.id
-            )
-            logger.debug("Audience '%s' has been deleted.", self)
-            managed_print(f"Audience '{self}' has been deleted.")
-
-    def filter(self, filters: list[RapidataFilter]) -> RapidataAudience:
+    def filter(self, filters: list[RapidataFilter]) -> RapidataFilteredAudience:
         """Derive a filtered audience from this audience.
 
         Applies the given filters on top of this audience's graduated annotators and returns
@@ -82,8 +57,11 @@ class RapidataAudience:
                 ``NotFilter`` if you need a different combinator at the top level.
 
         Returns:
-            RapidataAudience: A new audience instance representing the filtered view. Its
-            ``filters`` property reflects the applied filter tree.
+            RapidataFilteredAudience: A slim audience handle representing the filtered view.
+            Only exposes operations that make sense for a filtered audience
+            (``assign_job``, ``find_jobs``, ``delete``); methods like
+            ``add_classification_example`` are intentionally absent because the filtered
+            audience reuses the base's qualified pool.
 
         Example:
             ```python
@@ -104,6 +82,9 @@ class RapidataAudience:
             from rapidata.api_client.models.create_filtered_audience_endpoint_input import (
                 CreateFilteredAudienceEndpointInput,
             )
+            from rapidata.rapidata_client.audience.rapidata_filtered_audience import (
+                RapidataFilteredAudience,
+            )
             from rapidata.rapidata_client.filter.and_filter import AndFilter
 
             if not filters:
@@ -123,7 +104,7 @@ class RapidataAudience:
             logger.info(
                 f"Created filtered audience {response.audience_id} from base {self.id}"
             )
-            return RapidataAudience(
+            return RapidataFilteredAudience(
                 id=response.audience_id,
                 name=self._name,
                 filters=list(filters),
@@ -175,43 +156,6 @@ class RapidataAudience:
             )
             self._name = name
             return self
-
-    def assign_job(self, job_definition: RapidataJobDefinition) -> RapidataJob:
-        """Assign a job to this audience.
-
-        Creates a new job instance from the job definition and assigns it to this audience.
-        The job will be executed by the annotators in this audience.
-
-        Args:
-            job_definition (JobDefinition): The job definition to create and assign to the audience.
-
-        Returns:
-            RapidataJob: The created job instance.
-        """
-        with tracer.start_as_current_span("RapidataAudience.assign_job"):
-            from rapidata.api_client.models.create_job_endpoint_input import (
-                CreateJobEndpointInput,
-            )
-            from rapidata.rapidata_client.job.rapidata_job import RapidataJob
-            from datetime import datetime
-
-            logger.debug(f"Assigning job to audience: {self.id}")
-            response = self._openapi_service.order.job_api.job_post(
-                create_job_endpoint_input=CreateJobEndpointInput(
-                    audienceId=self.id,
-                    jobDefinitionId=job_definition.id,
-                ),
-            )
-            job = RapidataJob(
-                job_id=response.job_id,
-                name=job_definition.name,
-                audience_id=self.id,
-                created_at=datetime.now(),
-                definition_id=job_definition.id,
-                openapi_service=self._openapi_service,
-            )
-            logger.info(f"Assigned job to audience: {self.id}")
-            return job
 
     def add_classification_example(
         self,
@@ -312,45 +256,6 @@ class RapidataAudience:
             self._try_start_recruiting()
             return self
 
-    def find_jobs(
-        self, name: str = "", amount: int = 10, page: int = 1
-    ) -> list[RapidataJob]:
-        """Find jobs assigned to this audience.
-
-        Args:
-            name (str, optional): Filter jobs by name (matching jobs will contain this string). Defaults to "" for any job.
-            amount (int, optional): The maximum number of jobs to return. Defaults to 10.
-            page (int, optional): The page of jobs to return. Defaults to 1.
-
-        Returns:
-            list[RapidataJob]: A list of RapidataJob instances assigned to this audience.
-        """
-        with tracer.start_as_current_span("RapidataAudience.find_jobs"):
-            from rapidata.rapidata_client.job.rapidata_job import RapidataJob
-            from rapidata.api_client.models.audience_audience_id_jobs_get_job_id_parameter import (
-                AudienceAudienceIdJobsGetJobIdParameter,
-            )
-
-            response = self._openapi_service.order.job_api.jobs_get(
-                page=page,
-                page_size=amount,
-                name=AudienceAudienceIdJobsGetJobIdParameter(contains=name),
-                audience_id=AudienceAudienceIdJobsGetJobIdParameter(eq=self.id),
-                sort=["-created_at"],
-            )
-            return [
-                RapidataJob(
-                    job_id=job.job_id,
-                    name=job.name,
-                    audience_id=job.audience_id,
-                    created_at=job.created_at,
-                    definition_id=job.definition_id,
-                    openapi_service=self._openapi_service,
-                    pipeline_id=job.pipeline_id,
-                )
-                for job in response.items
-            ]
-
     def get_examples(
         self,
         amount: int = 10,
@@ -428,9 +333,3 @@ class RapidataAudience:
                     logger.debug(
                         f"Error starting recruiting for audience: {self.id} - {e}"
                     )
-
-    def __str__(self) -> str:
-        return f"RapidataAudience(id={self.id}, name={self._name}, filters={self._filters})"
-
-    def __repr__(self) -> str:
-        return self.__str__()

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Sequence
-from rapidata.rapidata_client.config import logger, tracer
+from rapidata.rapidata_client.config import logger, managed_print, tracer
 from rapidata.rapidata_client.audience._audience_base import RapidataAudienceBase
 from rapidata.rapidata_client.audience.audience_example_handler import (
     AudienceExampleHandler,
@@ -38,6 +38,16 @@ class RapidataAudience(RapidataAudienceBase):
         super().__init__(id=id, name=name, filters=filters, openapi_service=openapi_service)
         self._example_handler = AudienceExampleHandler(openapi_service, id)
         self._recruiting_started = False
+
+    def delete(self) -> None:
+        """Deletes the audience."""
+        with tracer.start_as_current_span("RapidataAudience.delete"):
+            logger.info("Deleting audience '%s'", self)
+            self._openapi_service.audience.audience_api.audience_audience_id_delete(
+                self.id
+            )
+            logger.debug("Audience '%s' has been deleted.", self)
+            managed_print(f"Audience '{self}' has been deleted.")
 
     def filter(self, filters: list[RapidataFilter]) -> RapidataFilteredAudience:
         """Derive a filtered audience from this audience.

--- a/src/rapidata/rapidata_client/audience/rapidata_filtered_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_filtered_audience.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from rapidata.rapidata_client.audience._audience_base import RapidataAudienceBase
+
+
+class RapidataFilteredAudience(RapidataAudienceBase):
+    """A filtered view on top of a :class:`RapidataAudience`.
+
+    Created via :py:meth:`RapidataAudience.filter`. The filtered audience reuses the
+    base audience's pool of qualified annotators — no new qualification or recruiting
+    takes place — and so the surface here is intentionally narrow: you can run jobs
+    on it, list its jobs, delete it, and pass its id to leaderboard / benchmark
+    creation. Operations that mutate the qualification pool
+    (``add_classification_example`` / ``add_compare_example`` / ``update_filters``)
+    live only on :class:`RapidataAudience` and would not be meaningful here.
+
+    Attributes:
+        id (str): The unique identifier of the filtered audience. Prefixed ``fau_``.
+        name (str): The name of the underlying dimension audience.
+        filters (list[RapidataFilter]): The filter tree that defines this slice.
+    """

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -8,7 +8,7 @@ from rapidata.rapidata_client.benchmark._detail_mapper import LevelOfDetail
 
 if TYPE_CHECKING:
     import pandas as pd
-    from rapidata.rapidata_client.audience.rapidata_audience import RapidataAudience
+    from rapidata.rapidata_client.audience._audience_base import RapidataAudienceBase
     from rapidata.rapidata_client.benchmark.leaderboard.rapidata_leaderboard import (
         RapidataLeaderboard,
     )
@@ -321,7 +321,7 @@ class RapidataBenchmark:
         inverse_ranking: bool = False,
         level_of_detail: LevelOfDetail | None = None,
         min_responses_per_matchup: int | None = None,
-        audience_id: str | RapidataAudience | None = None,
+        audience_id: str | RapidataAudienceBase | None = None,
         settings: Sequence["RapidataSetting"] | None = None,
     ) -> RapidataLeaderboard:
         """
@@ -335,13 +335,13 @@ class RapidataBenchmark:
             inverse_ranking: Whether to inverse the ranking of the leaderboard. (if the question is inversed, e.g. "Which video is worse?")
             level_of_detail: The level of detail of the leaderboard. This will effect how many comparisons are done per model evaluation. (default: "low")
             min_responses_per_matchup: The minimum number of responses required to be considered for the leaderboard. (default: 3)
-            audience_id: The audience that should answer the leaderboard. Pass either the audience id or a :class:`RapidataAudience` instance. Accepts both plain dimension audiences and filtered audiences derived via :py:meth:`RapidataAudience.filter`. Defaults to the global audience when not specified.
+            audience_id: The audience that should answer the leaderboard. Pass either the audience id, a :class:`RapidataAudience` (dimension audience), or a :class:`RapidataFilteredAudience` (derived via :py:meth:`RapidataAudience.filter`). Defaults to the global audience when not specified.
             settings: The settings that should be applied to the leaderboard. Will determine the behavior of the tasks on the leaderboard. (default: [])
         """
         from rapidata.api_client.models.create_leaderboard_endpoint_input import (
             CreateLeaderboardEndpointInput,
         )
-        from rapidata.rapidata_client.audience.rapidata_audience import RapidataAudience
+        from rapidata.rapidata_client.audience._audience_base import RapidataAudienceBase
         from rapidata.rapidata_client.benchmark._detail_mapper import DetailMapper
         from rapidata.rapidata_client.benchmark.leaderboard.rapidata_leaderboard import (
             RapidataLeaderboard,
@@ -366,7 +366,7 @@ class RapidataBenchmark:
 
             resolved_audience_id = (
                 audience_id.id
-                if isinstance(audience_id, RapidataAudience)
+                if isinstance(audience_id, RapidataAudienceBase)
                 else audience_id
             )
 


### PR DESCRIPTION
## Summary

Scopes down what a filtered audience can do, so misuse fails at type-check time instead of at runtime.

- New **`RapidataAudienceBase`** holding the operations valid on any audience: `id`, `name`, `filters`, `assign_job`, `find_jobs`, `delete`.
- **`RapidataAudience`** becomes the dimension-audience subclass. Keeps everything that mutates the qualification pool: `add_classification_example`, `add_compare_example`, `update_filters`, `update_name`, `get_examples`, and the `.filter(...)` method.
- New slim **`RapidataFilteredAudience`** subclass returned by `RapidataAudience.filter(...)`. No extra methods on top of the base — filtered audiences share the base's qualified pool, so adding examples or updating recruitment filters on the slice would be meaningless or actively confusing.
- `RapidataBenchmark.create_leaderboard` widens `audience_id` to `str | RapidataAudienceBase | None` so both audience types pass through.

No behaviour change for existing dimension-audience callers — public methods on `RapidataAudience` keep the same names and signatures.

## Why

Today everything `.filter(...)` returns is a `RapidataAudience`, so this compiles and silently does the wrong thing:

```python
filtered = base.filter([LanguageFilter(["ar"])])
filtered.add_classification_example(...)   # mutates the BASE audience's qualification pool
filtered.filter([CountryFilter(["DE"])])   # nested filtering on a filtered view
filtered.update_filters([...])             # tries to change recruiting filters of a view that doesn't recruit
```

After this PR each of those is a pyright error. Verified locally:

```
$ uv run pyright misuse.py
error: Cannot access attribute "add_classification_example" for class "RapidataFilteredAudience"
error: Cannot access attribute "filter" for class "RapidataFilteredAudience"
```

## Public surface

| Method                       | RapidataAudience | RapidataFilteredAudience |
|------------------------------|:---:|:---:|
| `id`, `name`, `filters`      | ✅ | ✅ |
| `assign_job`                 | ✅ | ✅ |
| `find_jobs`                  | ✅ | ✅ |
| `delete`                     | ✅ | ✅ |
| `filter`                     | ✅ | — |
| `update_filters`             | ✅ | — |
| `update_name`                | ✅ | — |
| `add_classification_example` | ✅ | — |
| `add_compare_example`        | ✅ | — |
| `get_examples`               | ✅ | — |

Both pass `isinstance(x, RapidataAudienceBase)`. Code that previously did `isinstance(x, RapidataAudience)` to mean "dimension audience" continues to work — that's the new intent of the check.

## Not in scope

- `RapidataAudienceManager.get_audience_by_id` still hits `GET /audience/{id}` and returns `RapidataAudience` regardless of id prefix. Resolving an `fau_…` id would need either a backend endpoint change or a `GetAudienceInformation`-style branch on the SDK side — leaving as a separate change.

## Test plan

- [x] `uv run pyright src/rapidata/rapidata_client` — 0 errors, 0 warnings
- [x] Pyright catches `add_classification_example` / `.filter` on a `RapidataFilteredAudience` (verified locally — see above)
- [x] `RapidataFilteredAudience.__mro__` includes `RapidataAudienceBase`
- [x] `RapidataFilteredAudience` public methods = `{name, filters, assign_job, find_jobs, delete}`

🔗 Session: [https://session-0439e1c4.poseidon.rapidata.internal/](https://session-0439e1c4.poseidon.rapidata.internal/)