### PR TITLE
feat(job): print dashboard preview link

### DIFF
--- a/src/rapidata/rapidata_client/config/_qr_preview.py
+++ b/src/rapidata/rapidata_client/config/_qr_preview.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 
 
 _PREVIEW_URL_TEMPLATE = "https://rapids.{environment}/preview/campaign?id={campaign_id}"
+_APP_JOB_DEFINITION_URL_TEMPLATE = (
+    "https://app.{environment}/definitions/{job_definition_id}"
+)
 
 
 def build_campaign_preview_url(environment: str, campaign_id: str) -> str:
@@ -28,6 +31,24 @@ def build_campaign_preview_url(environment: str, campaign_id: str) -> str:
     return _PREVIEW_URL_TEMPLATE.format(
         environment=environment, campaign_id=campaign_id
     )
+
+
+def build_job_definition_preview_url(environment: str, job_definition_id: str) -> str:
+    """Return the app URL for previewing the given job definition."""
+    return _APP_JOB_DEFINITION_URL_TEMPLATE.format(
+        environment=environment, job_definition_id=job_definition_id
+    )
+
+
+def print_job_definition_preview_link(
+    environment: str, job_definition_id: str
+) -> None:
+    """Print the app URL for previewing the given job definition."""
+    if rapidata_config.logging.silent_mode:
+        return
+
+    url = build_job_definition_preview_url(environment, job_definition_id)
+    managed_print(f"Preview in dashboard: {url}")
 
 
 def print_campaign_preview_qr(environment: str, campaign_id: str) -> None:

--- a/src/rapidata/rapidata_client/config/_qr_preview.py
+++ b/src/rapidata/rapidata_client/config/_qr_preview.py
@@ -24,6 +24,7 @@ _PREVIEW_URL_TEMPLATE = "https://rapids.{environment}/preview/campaign?id={campa
 _APP_JOB_DEFINITION_URL_TEMPLATE = (
     "https://app.{environment}/definitions/{job_definition_id}"
 )
+_APP_ORDER_URL_TEMPLATE = "https://app.{environment}/order/detail/{order_id}"
 
 
 def build_campaign_preview_url(environment: str, campaign_id: str) -> str:
@@ -40,6 +41,11 @@ def build_job_definition_preview_url(environment: str, job_definition_id: str) -
     )
 
 
+def build_order_preview_url(environment: str, order_id: str) -> str:
+    """Return the app URL for the given order's detail page."""
+    return _APP_ORDER_URL_TEMPLATE.format(environment=environment, order_id=order_id)
+
+
 def print_job_definition_preview_link(
     environment: str, job_definition_id: str
 ) -> None:
@@ -48,6 +54,15 @@ def print_job_definition_preview_link(
         return
 
     url = build_job_definition_preview_url(environment, job_definition_id)
+    managed_print(f"Preview in dashboard: {url}")
+
+
+def print_order_preview_link(environment: str, order_id: str) -> None:
+    """Print the app URL for the given order's detail page."""
+    if rapidata_config.logging.silent_mode:
+        return
+
+    url = build_order_preview_url(environment, order_id)
     managed_print(f"Preview in dashboard: {url}")
 
 

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -4,6 +4,7 @@ from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.config import logger, tracer
 from rapidata.rapidata_client.config._qr_preview import (
     print_campaign_preview_qr_for_pipeline,
+    print_job_definition_preview_link,
 )
 from rapidata.rapidata_client.datapoints._datapoint import Datapoint
 from rapidata.rapidata_client.workflow import Workflow
@@ -142,6 +143,10 @@ class RapidataJobManager:
         print_campaign_preview_qr_for_pipeline(
             openapi_service=self._openapi_service,
             pipeline_id=job_definition_response.pipeline_id,
+        )
+        print_job_definition_preview_link(
+            environment=self._openapi_service.environment,
+            job_definition_id=job_model.id,
         )
 
         return job_model

--- a/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
+++ b/src/rapidata/rapidata_client/order/_rapidata_order_builder.py
@@ -18,6 +18,7 @@ from rapidata.rapidata_client.config import (
 )
 from rapidata.rapidata_client.config._qr_preview import (
     print_campaign_preview_qr_for_pipeline,
+    print_order_preview_link,
 )
 from rapidata.rapidata_client.validation.validation_set_manager import (
     ValidationSetManager,
@@ -190,6 +191,10 @@ class RapidataOrderBuilder:
         print_campaign_preview_qr_for_pipeline(
             openapi_service=self._openapi_service,
             pipeline_id=result.pipeline_id,
+        )
+        print_order_preview_link(
+            environment=self._openapi_service.environment,
+            order_id=order.id,
         )
         return order
 


### PR DESCRIPTION
## Summary
- print a dashboard preview URL after creating a job definition
- keep the existing phone QR code preview unchanged

## Validation
- `git diff --check`
- `PATH="/home/agent/.local/share/mise/installs/node/20.20.2/bin:$PATH" pyright src/rapidata/rapidata_client` *(fails: dependencies are not installed in this container, causing repo-wide missing-import errors for pydantic, pandas, opentelemetry, etc.)*

🔗 Session: [session-56ddff8d](https://session-56ddff8d.poseidon.rapidata.internal/)