### PR TITLE
feat(signals): add SignalsManager and RapidataSignal for recurring scheduled jobs

### DIFF
--- a/openapi/generate-schema.sh
+++ b/openapi/generate-schema.sh
@@ -63,6 +63,7 @@ workflow
 leaderboard
 flow
 translation
+signals
 "
 
 download() {

--- a/src/rapidata/__init__.py
+++ b/src/rapidata/__init__.py
@@ -2,6 +2,8 @@ __version__ = "3.11.5"
 
 from .rapidata_client import (
     RapidataClient,
+    SignalsManager,
+    RapidataSignal,
     RapidataAudience,
     RapidataAudienceBase,
     RapidataAudienceManager,

--- a/src/rapidata/rapidata_client/__init__.py
+++ b/src/rapidata/rapidata_client/__init__.py
@@ -1,4 +1,5 @@
 from .rapidata_client import RapidataClient
+from .signals import SignalsManager, RapidataSignal
 from .audience import (
     RapidataAudience,
     RapidataAudienceBase,

--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -31,6 +31,7 @@ from rapidata.rapidata_client.config import (
 from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.job.rapidata_job_manager import RapidataJobManager
 from rapidata.rapidata_client.flow.rapidata_flow_manager import RapidataFlowManager
+from rapidata.rapidata_client.signals.signals_manager import SignalsManager
 from rapidata.rapidata_client.api.rapidata_api_client import (
     optional_api_call,
     mark_sdk_outdated,
@@ -88,6 +89,7 @@ class RapidataClient:
             audience (RapidataAudienceManager): The RapidataAudienceManager instance.
             job (JobManager): The JobManager instance.
             mri (RapidataBenchmarkManager): The RapidataBenchmarkManager instance.
+            signals (SignalsManager): The SignalsManager instance.
         """
         tracer.set_session_id(
             uuid.UUID(int=random.Random().getrandbits(128), version=4).hex
@@ -149,6 +151,9 @@ class RapidataClient:
             self._demographic = DemographicManager(
                 openapi_service=self._openapi_service
             )
+
+            logger.debug("Initializing SignalsManager")
+            self.signals = SignalsManager(openapi_service=self._openapi_service)
 
         self._check_beta_features()  # can't be in the trace for some reason
 

--- a/src/rapidata/rapidata_client/signals/__init__.py
+++ b/src/rapidata/rapidata_client/signals/__init__.py
@@ -1,0 +1,4 @@
+from .signals_manager import SignalsManager
+from .rapidata_signal import RapidataSignal
+
+__all__ = ["SignalsManager", "RapidataSignal"]

--- a/src/rapidata/rapidata_client/signals/rapidata_signal.py
+++ b/src/rapidata/rapidata_client/signals/rapidata_signal.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rapidata.service.openapi_service import OpenAPIService
+
+
+class RapidataSignal:
+    """Represents a Rapidata signal instance."""
+
+    def __init__(self, data: dict, openapi_service: "OpenAPIService") -> None:
+        self._data = data
+        self.__openapi_service = openapi_service
+
+    def _url(self, path: str = "") -> str:
+        host = self.__openapi_service.api_client.configuration.host
+        return f"{host}/signals/{self.id}{path}"
+
+    @property
+    def id(self) -> str:
+        return self._data["id"]
+
+    @property
+    def name(self) -> str:
+        return self._data["name"]
+
+    @property
+    def job_definition_id(self) -> str:
+        return self._data["jobDefinitionId"]
+
+    @property
+    def pinned_revision_number(self) -> int | None:
+        return self._data.get("pinnedRevisionNumber")
+
+    @property
+    def audience_id(self) -> str:
+        return self._data["audienceId"]
+
+    @property
+    def schedule(self) -> str:
+        return self._data["schedule"]
+
+    @property
+    def next_run_at(self) -> str:
+        return self._data["nextRunAt"]
+
+    @property
+    def is_public(self) -> bool:
+        return self._data["isPublic"]
+
+    @property
+    def active(self) -> bool:
+        return self._data["active"]
+
+    @property
+    def owner_mail(self) -> str:
+        return self._data["ownerMail"]
+
+    @property
+    def created_at(self) -> str:
+        return self._data["createdAt"]
+
+    def trigger_run(self) -> dict:
+        """Manually trigger a run outside the normal schedule.
+
+        Returns:
+            dict with keys: runId, jobId, pipelineId
+        """
+        response = self.__openapi_service.api_client.call_api(
+            "POST",
+            self._url("/runs"),
+            body={},
+        )
+        return json.loads(response.read().decode("utf-8"))
+
+    def get_runs(self) -> list[dict]:
+        """Get all runs for this signal, newest first."""
+        response = self.__openapi_service.api_client.call_api(
+            "GET",
+            self._url("/runs"),
+        )
+        data = json.loads(response.read().decode("utf-8"))
+        return data.get("runs", [])
+
+    def pause(self) -> "RapidataSignal":
+        """Pause this signal (stops scheduled execution)."""
+        self.__openapi_service.api_client.call_api(
+            "POST",
+            self._url("/active"),
+            body={"active": False},
+        )
+        self._data["active"] = False
+        return self
+
+    def resume(self) -> "RapidataSignal":
+        """Resume a paused signal."""
+        self.__openapi_service.api_client.call_api(
+            "POST",
+            self._url("/active"),
+            body={"active": True},
+        )
+        self._data["active"] = True
+        return self
+
+    def delete(self) -> None:
+        """Permanently delete this signal."""
+        self.__openapi_service.api_client.call_api(
+            "DELETE",
+            self._url(),
+        )
+
+    def __repr__(self) -> str:
+        status = "active" if self.active else "paused"
+        return f"RapidataSignal(id={self.id!r}, name={self.name!r}, schedule={self.schedule!r}, status={status!r})"

--- a/src/rapidata/rapidata_client/signals/signals_manager.py
+++ b/src/rapidata/rapidata_client/signals/signals_manager.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+import json
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from rapidata.service.openapi_service import OpenAPIService
+    from rapidata.rapidata_client.signals.rapidata_signal import RapidataSignal
+
+
+class SignalsManager:
+    """Manage recurring scheduled Rapidata signals."""
+
+    def __init__(self, openapi_service: "OpenAPIService") -> None:
+        self.__openapi_service = openapi_service
+
+    def _base_url(self) -> str:
+        return f"{self.__openapi_service.api_client.configuration.host}/signals"
+
+    def _parse(self, response) -> dict:
+        return json.loads(response.read().decode("utf-8"))
+
+    def create(
+        self,
+        name: str,
+        job_definition_id: str,
+        audience_id: str,
+        schedule: Literal["Daily", "Weekly", "Monthly"],
+        is_public: bool = False,
+        pinned_revision_number: int | None = None,
+    ) -> "RapidataSignal":
+        """Create a new signal.
+
+        Args:
+            name: Display name for the signal.
+            job_definition_id: ID of the job definition to run on each cycle.
+            audience_id: ID of the audience (dimensional or filtered) to target.
+            schedule: How often the signal fires — 'Daily', 'Weekly', or 'Monthly'.
+            is_public: Whether the signal and its results are publicly visible.
+            pinned_revision_number: Pin to a specific job definition revision.
+                Omit to always use the latest revision.
+
+        Returns:
+            RapidataSignal: The created signal instance.
+        """
+        from rapidata.rapidata_client.signals.rapidata_signal import RapidataSignal
+
+        payload: dict = {
+            "name": name,
+            "jobDefinitionId": job_definition_id,
+            "audienceId": audience_id,
+            "schedule": schedule,
+            "isPublic": is_public,
+        }
+        if pinned_revision_number is not None:
+            payload["pinnedRevisionNumber"] = pinned_revision_number
+
+        response = self.__openapi_service.api_client.call_api(
+            "POST",
+            self._base_url(),
+            body=payload,
+        )
+        signal_id = self._parse(response)["id"]
+        return self.get(signal_id)
+
+    def get(self, signal_id: str) -> "RapidataSignal":
+        """Retrieve a signal by ID."""
+        from rapidata.rapidata_client.signals.rapidata_signal import RapidataSignal
+
+        response = self.__openapi_service.api_client.call_api(
+            "GET",
+            f"{self._base_url()}/{signal_id}",
+        )
+        data = self._parse(response)
+        return RapidataSignal(data, self.__openapi_service)
+
+    def list(self) -> list["RapidataSignal"]:
+        """List all signals accessible to the current user."""
+        from rapidata.rapidata_client.signals.rapidata_signal import RapidataSignal
+
+        response = self.__openapi_service.api_client.call_api(
+            "GET",
+            self._base_url(),
+        )
+        data = self._parse(response)
+        return [RapidataSignal(item, self.__openapi_service) for item in data.get("items", [])]
+
+    def __repr__(self) -> str:
+        return "SignalsManager"


### PR DESCRIPTION
## Summary

- Adds a hand-crafted `signals` module at `src/rapidata/rapidata_client/signals/` with `SignalsManager` and `RapidataSignal`
- `SignalsManager` (accessible via `client.signals`) exposes `create`, `get`, and `list`; talks to the signal-service REST API (`/signals` + sub-routes) using `RapidataApiClient.call_api` — the same OAuth-authenticated HTTP client used everywhere
- `RapidataSignal` wraps a single signal document and exposes `trigger_run`, `get_runs`, `pause`, `resume`, and `delete`
- Registers `signals` in `openapi/generate-schema.sh` so the merged schema stays in sync when OpenAPI specs are regenerated
- Both classes exported from `rapidata.SignalsManager` / `rapidata.RapidataSignal` at the top level

## Test plan

- [ ] `python3 -c "from rapidata import RapidataClient, SignalsManager, RapidataSignal; print('OK')` passes
- [ ] `client.signals.create(...)` creates a signal and returns a `RapidataSignal` instance
- [ ] `client.signals.list()` returns existing signals
- [ ] `client.signals.get(signal_id)` returns a specific signal
- [ ] `signal.pause()` / `signal.resume()` toggle the `active` flag
- [ ] `signal.trigger_run()` returns `{runId, jobId, pipelineId}`
- [ ] `signal.delete()` removes the signal

🔗 Session: cli-luca-124c8694