### PR TITLE
feat(flow): add ranking context assets

### DIFF
--- a/openapi/schemas/flow.openapi.json
+++ b/openapi/schemas/flow.openapi.json
@@ -1274,6 +1274,14 @@
             "description": "Optional context to provide additional ranking guidance.",
             "nullable": true
           },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetInput"
+              }
+            ],
+            "description": "Optional asset context to provide additional ranking guidance."
+          },
           "timeToLiveInSeconds": {
             "type": "integer",
             "description": "Optional time-to-live in seconds before the flow item expires.",
@@ -1420,6 +1428,14 @@
             "type": "string",
             "description": "Optional context associated with this flow item.",
             "nullable": true
+          },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetModel"
+              }
+            ],
+            "description": "Optional asset context associated with this flow item."
           },
           "failureMessage": {
             "type": "string",
@@ -1659,6 +1675,127 @@
           "averageResponseCount": {
             "type": "number",
             "format": "double"
+          }
+        }
+      },
+      "IAssetInput": {
+        "required": [
+          "_t"
+        ],
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IAssetInputExistingAssetInput"
+          },
+          {
+            "$ref": "#/components/schemas/IAssetInputMultiAssetInput"
+          },
+          {
+            "$ref": "#/components/schemas/IAssetInputTextAssetInput"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "_t",
+          "mapping": {
+            "ExistingAssetInput": "#/components/schemas/IAssetInputExistingAssetInput",
+            "MultiAssetInput": "#/components/schemas/IAssetInputMultiAssetInput",
+            "TextAssetInput": "#/components/schemas/IAssetInputTextAssetInput"
+          }
+        }
+      },
+      "IAssetInputExistingAssetInput": {
+        "required": [
+          "name",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "ExistingAssetInput"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "metadata": {
+            "oneOf": [
+              {
+                "nullable": true
+              },
+              {
+                "$ref": "#/components/schemas/MetadataInputCollection"
+              }
+            ]
+          },
+          "identifier": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "IAssetInputMultiAssetInput": {
+        "required": [
+          "assets",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "MultiAssetInput"
+            ],
+            "type": "string"
+          },
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IAssetInput"
+            }
+          },
+          "metadata": {
+            "oneOf": [
+              {
+                "nullable": true
+              },
+              {
+                "$ref": "#/components/schemas/MetadataInputCollection"
+              }
+            ]
+          },
+          "identifier": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "IAssetInputTextAssetInput": {
+        "required": [
+          "text",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "TextAssetInput"
+            ],
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "metadata": {
+            "oneOf": [
+              {
+                "nullable": true
+              },
+              {
+                "$ref": "#/components/schemas/MetadataInputCollection"
+              }
+            ]
+          },
+          "identifier": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -2021,6 +2158,45 @@
           }
         }
       },
+      "IMetadataInput": {
+        "required": [
+          "_t"
+        ],
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IMetadataInputTextMetadataInput"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "_t",
+          "mapping": {
+            "TextMetadataInput": "#/components/schemas/IMetadataInputTextMetadataInput"
+          }
+        }
+      },
+      "IMetadataInputTextMetadataInput": {
+        "required": [
+          "text",
+          "visibilities",
+          "_t"
+        ],
+        "properties": {
+          "_t": {
+            "enum": [
+              "TextMetadataInput"
+            ],
+            "type": "string"
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          },
+          "visibilities": {
+            "$ref": "#/components/schemas/MetadataVisibilities"
+          }
+        }
+      },
       "IMetadataModel": {
         "required": [
           "_t"
@@ -2265,10 +2441,30 @@
           }
         }
       },
+      "MetadataInputCollection": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/IMetadataInput"
+        }
+      },
       "MetadataModelCollection": {
         "type": "object",
         "additionalProperties": {
           "$ref": "#/components/schemas/IMetadataModel"
+        }
+      },
+      "MetadataVisibilities": {
+        "type": "array",
+        "items": {
+          "enum": [
+            "None",
+            "Users",
+            "Customers",
+            "Admins",
+            "Dashboard",
+            "All"
+          ],
+          "type": "string"
         }
       },
       "PidBatchMode": {
@@ -2338,6 +2534,14 @@
             "type": "string",
             "description": "Optional context associated with this flow item.",
             "nullable": true
+          },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetModel"
+              }
+            ],
+            "description": "Optional asset context associated with this flow item."
           },
           "failureMessage": {
             "type": "string",

--- a/openapi/schemas/rapidata.filtered.openapi.json
+++ b/openapi/schemas/rapidata.filtered.openapi.json
@@ -26092,6 +26092,14 @@
             "description": "Optional context to provide additional ranking guidance.",
             "nullable": true
           },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetInput"
+              }
+            ],
+            "description": "Optional asset context to provide additional ranking guidance."
+          },
           "timeToLiveInSeconds": {
             "type": "integer",
             "description": "Optional time-to-live in seconds before the flow item expires.",
@@ -26215,6 +26223,14 @@
             "type": "string",
             "description": "Optional context associated with this flow item.",
             "nullable": true
+          },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetModel"
+              }
+            ],
+            "description": "Optional asset context associated with this flow item."
           },
           "failureMessage": {
             "type": "string",
@@ -26755,6 +26771,14 @@
             "type": "string",
             "description": "Optional context associated with this flow item.",
             "nullable": true
+          },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetModel"
+              }
+            ],
+            "description": "Optional asset context associated with this flow item."
           },
           "failureMessage": {
             "type": "string",

--- a/openapi/schemas/rapidata.openapi.json
+++ b/openapi/schemas/rapidata.openapi.json
@@ -26142,6 +26142,14 @@
             "description": "Optional context to provide additional ranking guidance.",
             "nullable": true
           },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetInput"
+              }
+            ],
+            "description": "Optional asset context to provide additional ranking guidance."
+          },
           "timeToLiveInSeconds": {
             "type": "integer",
             "description": "Optional time-to-live in seconds before the flow item expires.",
@@ -26265,6 +26273,14 @@
             "type": "string",
             "description": "Optional context associated with this flow item.",
             "nullable": true
+          },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetModel"
+              }
+            ],
+            "description": "Optional asset context associated with this flow item."
           },
           "failureMessage": {
             "type": "string",
@@ -26805,6 +26821,14 @@
             "type": "string",
             "description": "Optional context associated with this flow item.",
             "nullable": true
+          },
+          "contextAsset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IAssetModel"
+              }
+            ],
+            "description": "Optional asset context associated with this flow item."
           },
           "failureMessage": {
             "type": "string",

--- a/src/rapidata/api_client/models/create_flow_item_endpoint_input.py
+++ b/src/rapidata/api_client/models/create_flow_item_endpoint_input.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import ValidationError
 from rapidata.api_client.lazy_model import LazyValidatedModel
+from rapidata.api_client.models.i_asset_input import IAssetInput
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -30,9 +31,10 @@ class CreateFlowItemEndpointInput(LazyValidatedModel):
     """ # noqa: E501
     dataset_id: StrictStr = Field(description="The ID of the dataset to use for this flow item.", alias="datasetId")
     context: Optional[StrictStr] = Field(default=None, description="Optional context to provide additional ranking guidance.")
+    context_asset: Optional[IAssetInput] = Field(default=None, description="Optional asset context to provide additional ranking guidance.", alias="contextAsset")
     time_to_live_in_seconds: Optional[StrictInt] = Field(default=None, description="Optional time-to-live in seconds before the flow item expires.", alias="timeToLiveInSeconds")
     drain_duration_in_seconds: Optional[StrictInt] = Field(default=None, description="Optional drain duration in seconds. When set, rapids are paused this many seconds before TTL expiry to allow in-flight responses to complete.", alias="drainDurationInSeconds")
-    __properties: ClassVar[List[str]] = ["datasetId", "context", "timeToLiveInSeconds", "drainDurationInSeconds"]
+    __properties: ClassVar[List[str]] = ["datasetId", "context", "contextAsset", "timeToLiveInSeconds", "drainDurationInSeconds"]
 
     # model_config is inherited from LazyValidatedModel
 
@@ -74,6 +76,15 @@ class CreateFlowItemEndpointInput(LazyValidatedModel):
         if self.context is None and "context" in self.model_fields_set:
             _dict['context'] = None
 
+        # override the default output from pydantic by calling `to_dict()` of context_asset
+        if self.context_asset:
+            _dict['contextAsset'] = self.context_asset.to_dict()
+
+        # set to None if context_asset (nullable) is None
+        # and model_fields_set contains the field
+        if self.context_asset is None and "context_asset" in self.model_fields_set:
+            _dict['contextAsset'] = None
+
         # set to None if time_to_live_in_seconds (nullable) is None
         # and model_fields_set contains the field
         if self.time_to_live_in_seconds is None and "time_to_live_in_seconds" in self.model_fields_set:
@@ -98,6 +109,7 @@ class CreateFlowItemEndpointInput(LazyValidatedModel):
         _data = {
             "datasetId": obj.get("datasetId"),
             "context": obj.get("context"),
+            "contextAsset": IAssetInput.from_dict(obj["contextAsset"]) if obj.get("contextAsset") is not None else None,
             "timeToLiveInSeconds": obj.get("timeToLiveInSeconds"),
             "drainDurationInSeconds": obj.get("drainDurationInSeconds")
         }
@@ -106,5 +118,4 @@ class CreateFlowItemEndpointInput(LazyValidatedModel):
         except ValidationError as _val_error:
             _obj = cls._lazy_construct(_data, _val_error)
         return _obj
-
 

--- a/src/rapidata/api_client/models/create_flow_item_endpoint_input.py
+++ b/src/rapidata/api_client/models/create_flow_item_endpoint_input.py
@@ -19,9 +19,9 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
+from rapidata.api_client.models.i_asset_input import IAssetInput
 from pydantic import ValidationError
 from rapidata.api_client.lazy_model import LazyValidatedModel
-from rapidata.api_client.models.i_asset_input import IAssetInput
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -71,19 +71,13 @@ class CreateFlowItemEndpointInput(LazyValidatedModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of context_asset
+        if self.context_asset:
+            _dict['contextAsset'] = self.context_asset.to_dict()
         # set to None if context (nullable) is None
         # and model_fields_set contains the field
         if self.context is None and "context" in self.model_fields_set:
             _dict['context'] = None
-
-        # override the default output from pydantic by calling `to_dict()` of context_asset
-        if self.context_asset:
-            _dict['contextAsset'] = self.context_asset.to_dict()
-
-        # set to None if context_asset (nullable) is None
-        # and model_fields_set contains the field
-        if self.context_asset is None and "context_asset" in self.model_fields_set:
-            _dict['contextAsset'] = None
 
         # set to None if time_to_live_in_seconds (nullable) is None
         # and model_fields_set contains the field
@@ -118,4 +112,5 @@ class CreateFlowItemEndpointInput(LazyValidatedModel):
         except ValidationError as _val_error:
             _obj = cls._lazy_construct(_data, _val_error)
         return _obj
+
 

--- a/src/rapidata/api_client/models/get_flow_item_by_id_endpoint_output.py
+++ b/src/rapidata/api_client/models/get_flow_item_by_id_endpoint_output.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from rapidata.api_client.models.flow_item_state import FlowItemState
+from rapidata.api_client.models.i_asset_model import IAssetModel
 from pydantic import ValidationError
 from rapidata.api_client.lazy_model import LazyValidatedModel
 from typing import Optional, Set
@@ -36,13 +37,14 @@ class GetFlowItemByIdEndpointOutput(LazyValidatedModel):
     workflow_id: Optional[StrictStr] = Field(default=None, description="The ID of the workflow created for this flow item.", alias="workflowId")
     state: FlowItemState = Field(description="The current state of the flow item.")
     context: Optional[StrictStr] = Field(default=None, description="Optional context associated with this flow item.")
+    context_asset: Optional[IAssetModel] = Field(default=None, description="Optional asset context associated with this flow item.", alias="contextAsset")
     failure_message: Optional[StrictStr] = Field(default=None, description="The failure message if the flow item failed.", alias="failureMessage")
     expires_at: Optional[datetime] = Field(default=None, description="The expiration timestamp of the flow item.", alias="expiresAt")
     created_at: datetime = Field(description="The timestamp when the flow item was created.", alias="createdAt")
     started_at: Optional[datetime] = Field(default=None, description="The timestamp when the flow item started processing.", alias="startedAt")
     completed_at: Optional[datetime] = Field(default=None, description="The timestamp when the flow item completed.", alias="completedAt")
     failed_at: Optional[datetime] = Field(default=None, description="The timestamp when the flow item failed.", alias="failedAt")
-    __properties: ClassVar[List[str]] = ["id", "flowId", "datasetId", "workflowId", "state", "context", "failureMessage", "expiresAt", "createdAt", "startedAt", "completedAt", "failedAt"]
+    __properties: ClassVar[List[str]] = ["id", "flowId", "datasetId", "workflowId", "state", "context", "contextAsset", "failureMessage", "expiresAt", "createdAt", "startedAt", "completedAt", "failedAt"]
 
     # model_config is inherited from LazyValidatedModel
 
@@ -79,6 +81,9 @@ class GetFlowItemByIdEndpointOutput(LazyValidatedModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of context_asset
+        if self.context_asset:
+            _dict['contextAsset'] = self.context_asset.to_dict()
         # set to None if workflow_id (nullable) is None
         # and model_fields_set contains the field
         if self.workflow_id is None and "workflow_id" in self.model_fields_set:
@@ -132,6 +137,7 @@ class GetFlowItemByIdEndpointOutput(LazyValidatedModel):
             "workflowId": obj.get("workflowId"),
             "state": obj.get("state"),
             "context": obj.get("context"),
+            "contextAsset": IAssetModel.from_dict(obj["contextAsset"]) if obj.get("contextAsset") is not None else None,
             "failureMessage": obj.get("failureMessage"),
             "expiresAt": obj.get("expiresAt"),
             "createdAt": obj.get("createdAt"),

--- a/src/rapidata/api_client/models/query_flow_items_endpoint_output.py
+++ b/src/rapidata/api_client/models/query_flow_items_endpoint_output.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from rapidata.api_client.models.flow_item_state import FlowItemState
+from rapidata.api_client.models.i_asset_model import IAssetModel
 from pydantic import ValidationError
 from rapidata.api_client.lazy_model import LazyValidatedModel
 from typing import Optional, Set
@@ -35,12 +36,13 @@ class QueryFlowItemsEndpointOutput(LazyValidatedModel):
     workflow_id: Optional[StrictStr] = Field(default=None, description="The ID of the workflow created for this flow item.", alias="workflowId")
     state: FlowItemState = Field(description="The current state of the flow item.")
     context: Optional[StrictStr] = Field(default=None, description="Optional context associated with this flow item.")
+    context_asset: Optional[IAssetModel] = Field(default=None, description="Optional asset context associated with this flow item.", alias="contextAsset")
     failure_message: Optional[StrictStr] = Field(default=None, description="The failure message if the flow item failed.", alias="failureMessage")
     created_at: datetime = Field(description="The timestamp when the flow item was created.", alias="createdAt")
     started_at: Optional[datetime] = Field(default=None, description="The timestamp when the flow item started processing.", alias="startedAt")
     completed_at: Optional[datetime] = Field(default=None, description="The timestamp when the flow item completed.", alias="completedAt")
     failed_at: Optional[datetime] = Field(default=None, description="The timestamp when the flow item failed.", alias="failedAt")
-    __properties: ClassVar[List[str]] = ["id", "datasetId", "workflowId", "state", "context", "failureMessage", "createdAt", "startedAt", "completedAt", "failedAt"]
+    __properties: ClassVar[List[str]] = ["id", "datasetId", "workflowId", "state", "context", "contextAsset", "failureMessage", "createdAt", "startedAt", "completedAt", "failedAt"]
 
     # model_config is inherited from LazyValidatedModel
 
@@ -77,6 +79,9 @@ class QueryFlowItemsEndpointOutput(LazyValidatedModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of context_asset
+        if self.context_asset:
+            _dict['contextAsset'] = self.context_asset.to_dict()
         # set to None if workflow_id (nullable) is None
         # and model_fields_set contains the field
         if self.workflow_id is None and "workflow_id" in self.model_fields_set:
@@ -124,6 +129,7 @@ class QueryFlowItemsEndpointOutput(LazyValidatedModel):
             "workflowId": obj.get("workflowId"),
             "state": obj.get("state"),
             "context": obj.get("context"),
+            "contextAsset": IAssetModel.from_dict(obj["contextAsset"]) if obj.get("contextAsset") is not None else None,
             "failureMessage": obj.get("failureMessage"),
             "createdAt": obj.get("createdAt"),
             "startedAt": obj.get("startedAt"),

--- a/src/rapidata/rapidata_client/flow/rapidata_flow.py
+++ b/src/rapidata/rapidata_client/flow/rapidata_flow.py
@@ -7,6 +7,7 @@ from rapidata.rapidata_client.dataset._rapidata_dataset import RapidataDataset
 from rapidata.rapidata_client.datapoints._datapoints_validator import (
     DatapointsValidator,
 )
+from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.exceptions.failed_upload_exception import (
     FailedUploadException,
 )
@@ -27,6 +28,7 @@ class RapidataFlow:
         self,
         datapoints: list[str],
         context: str | None = None,
+        context_assets: list[str] | None = None,
         data_type: Literal["media", "text"] = "media",
         private_metadata: list[dict[str, str]] | None = None,
         accept_failed_uploads: bool = False,
@@ -37,6 +39,7 @@ class RapidataFlow:
         Args:
             datapoints: The list of datapoints (paths or URLs) to upload.
             context: The context shown alongside the instruction.
+            context_assets: Optional image, video, or audio paths/URLs shown alongside the instruction.
             data_type: The data type of the datapoints. Defaults to "media".
             private_metadata: Optional key-value metadata per datapoint.
             accept_failed_uploads: If True, continues even if some uploads fail.
@@ -58,6 +61,8 @@ class RapidataFlow:
 
             if time_to_live is not None and time_to_live < 60:
                 raise ValueError("Time to live must be at least 60 seconds.")
+            if context_assets is not None and not 1 <= len(context_assets) <= 10:
+                raise ValueError("Context assets must contain between 1 and 10 assets.")
 
             logger.debug("Creating flow item for flow '%s'", self.name)
 
@@ -87,11 +92,18 @@ class RapidataFlow:
                         "Failed to upload %d datapoints", len(failed_uploads)
                     )
 
+            context_asset_input = (
+                AssetUploader(self._openapi_service).upload_and_map_asset(context_assets)
+                if context_assets
+                else None
+            )
+
             response = self._openapi_service.flow.ranking_flow_item_api.flow_ranking_flow_id_item_post(
                 flow_id=self.id,
                 create_flow_item_endpoint_input=CreateFlowItemEndpointInput(
                     datasetId=rapidata_dataset.id,
                     context=context,
+                    contextAsset=context_asset_input,
                     timeToLiveInSeconds=time_to_live,
                 ),
             )


### PR DESCRIPTION
## Summary
- add optional context_assets to create_new_flow_batch
- upload context asset files via the existing AssetUploader path and send contextAsset on flow item creation
- update generated create-flow-item input model for the optional contextAsset field

## Validation
- Not run: python/uv are unavailable in this container
- Not run: pyright requires node, and node is unavailable in this container

🔗 Session: https://session-f0bf5a67.poseidon.rapidata.internal/
