### PR TITLE
feat(benchmark): concurrent prompt upload with progress bar

### DIFF
--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -75,12 +75,12 @@ standings = leaderboard.get_standings(tags=["landscape", "outdoor"])
 If you have already created a benchmark and want to add new prompts and assets after the fact. Note however that these will only take effect for new models.
 
 ```python
-# Adding individual prompts with assets
-benchmark.add_prompt(
-    identifier="new_style",
-    prompt="Generate artwork in this new style",
-    prompt_asset="https://assets.rapidata.ai/new_style_ref.jpg",
-    tags=["abstract", "modern"]
+# Adding prompts with assets (one or many, matched up by index)
+benchmark.add_prompts(
+    identifiers=["new_style"],
+    prompts=["Generate artwork in this new style"],
+    prompt_assets=["https://assets.rapidata.ai/new_style_ref.jpg"],
+    tags=[["abstract", "modern"]]
 )
 ```
 

--- a/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
+++ b/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from opentelemetry import context as otel_context
+from tqdm.auto import tqdm
+
+from rapidata.rapidata_client.config import logger, rapidata_config, tracer
+from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
+
+if TYPE_CHECKING:
+    from rapidata.service.openapi_service import OpenAPIService
+
+
+@dataclass
+class BenchmarkPrompt:
+    """A single prompt to register on a benchmark."""
+
+    identifier: str
+    prompt: str | None = None
+    prompt_asset: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+
+class BenchmarkPromptUploader:
+    """Registers prompts on a benchmark — one at a time or many concurrently.
+
+    Keeps the upload mechanics (asset upload, the prompt POST, concurrency,
+    progress, failure handling) out of the ``RapidataBenchmark`` entity.
+    """
+
+    def __init__(self, benchmark_id: str, openapi_service: OpenAPIService) -> None:
+        self._benchmark_id = benchmark_id
+        self._openapi_service = openapi_service
+        self._asset_uploader = AssetUploader(openapi_service)
+
+    def upload(self, prompt: BenchmarkPrompt) -> None:
+        """Register a single prompt. Performs the network calls only."""
+        from rapidata.api_client.models.create_prompt_for_benchmark_endpoint_input import (
+            CreatePromptForBenchmarkEndpointInput,
+        )
+        from rapidata.api_client.models.i_asset_input_existing_asset_input import (
+            IAssetInputExistingAssetInput,
+        )
+        from rapidata.api_client.models.i_asset_input import IAssetInput
+
+        self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post(
+            benchmark_id=self._benchmark_id,
+            create_prompt_for_benchmark_endpoint_input=CreatePromptForBenchmarkEndpointInput(
+                identifier=prompt.identifier,
+                prompt=prompt.prompt,
+                promptAsset=(
+                    IAssetInput(
+                        actual_instance=IAssetInputExistingAssetInput(
+                            _t="ExistingAssetInput",
+                            name=self._asset_uploader.upload_asset(prompt.prompt_asset),
+                        )
+                    )
+                    if prompt.prompt_asset is not None
+                    else None
+                ),
+                tags=prompt.tags,
+            ),
+        )
+
+    def upload_many(self, prompts: list[BenchmarkPrompt]) -> list[BenchmarkPrompt]:
+        """Register many prompts concurrently.
+
+        Every prompt is attempted even if some fail; failures are logged and the
+        prompts that succeeded are returned in input order. Raises a
+        ``RuntimeError`` only if every prompt failed.
+        """
+        current_context = otel_context.get_current()
+        failures: dict[str, Exception] = {}
+
+        def upload_one(prompt: BenchmarkPrompt) -> None:
+            token = otel_context.attach(current_context)
+            try:
+                self.upload(prompt)
+            except Exception as e:
+                failures[prompt.identifier] = e
+                logger.error(
+                    "Failed to upload prompt %s: %s", prompt.identifier, str(e)
+                )
+            finally:
+                otel_context.detach(token)
+
+        with tracer.start_as_current_span("BenchmarkPromptUploader.upload_many"):
+            with ThreadPoolExecutor(
+                max_workers=rapidata_config.upload.maxWorkers
+            ) as executor:
+                futures = [executor.submit(upload_one, prompt) for prompt in prompts]
+                with tqdm(
+                    total=len(prompts),
+                    desc="Uploading prompts",
+                    disable=rapidata_config.logging.silent_mode,
+                ) as pbar:
+                    for future in as_completed(futures):
+                        future.result()
+                        pbar.update(1)
+
+        if failures:
+            logger.warning(
+                "%d of %d prompts failed to upload and were skipped: %s",
+                len(failures),
+                len(prompts),
+                list(failures.keys()),
+            )
+            if len(failures) == len(prompts):
+                raise RuntimeError(
+                    "Failed to upload any prompts to the benchmark. See logs for details."
+                )
+
+        return [p for p in prompts if p.identifier not in failures]

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 import urllib.parse
 import webbrowser
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from colorama import Fore
+from opentelemetry import context as otel_context
+from tqdm.auto import tqdm
 from typing import Literal, Optional, Sequence, TYPE_CHECKING
 from rapidata.rapidata_client.config import logger, managed_print, tracer
+from rapidata.rapidata_client.config.rapidata_config import rapidata_config
 from rapidata.rapidata_client.benchmark._detail_mapper import LevelOfDetail
 
 if TYPE_CHECKING:
@@ -225,15 +229,6 @@ class RapidataBenchmark:
             prompt_asset: The prompt asset that will be used to evaluate the model. Provided as a link to the asset.
             tags: The tags can be used to filter the leaderboard results. They will NOT be shown to the users.
         """
-        from rapidata.api_client.models.create_prompt_for_benchmark_endpoint_input import (
-            CreatePromptForBenchmarkEndpointInput,
-        )
-        from rapidata.api_client.models.i_asset_input_existing_asset_input import (
-            IAssetInputExistingAssetInput,
-        )
-
-        from rapidata.api_client.models.i_asset_input import IAssetInput
-
         with tracer.start_as_current_span("RapidataBenchmark.add_prompt_to_benchmark"):
             if tags is None:
                 tags = []
@@ -287,30 +282,102 @@ class RapidataBenchmark:
             self.__prompts.append(prompt)
             self.__prompt_assets.append(prompt_asset)
 
-            self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post(
-                benchmark_id=self.id,
-                create_prompt_for_benchmark_endpoint_input=CreatePromptForBenchmarkEndpointInput(
-                    identifier=identifier,
-                    prompt=prompt,
-                    promptAsset=(
-                        IAssetInput(
-                            actual_instance=(
-                                IAssetInputExistingAssetInput(
-                                    _t="ExistingAssetInput",
-                                    name=self._asset_uploader.upload_asset(
-                                        prompt_asset
-                                    ),
-                                )
-                                if prompt_asset is not None
-                                else None
-                            )
+            self._post_prompt(identifier, prompt, prompt_asset, tags)
+
+    def _post_prompt(
+        self,
+        identifier: str,
+        prompt: str | None,
+        prompt_asset: str | None,
+        tags: list[str],
+    ) -> None:
+        """Performs the network calls to register a single prompt.
+
+        Does not validate or mutate the local caches — callers own that. Kept
+        free of shared state so it can be run concurrently (see
+        :py:meth:`_add_prompts`).
+        """
+        from rapidata.api_client.models.create_prompt_for_benchmark_endpoint_input import (
+            CreatePromptForBenchmarkEndpointInput,
+        )
+        from rapidata.api_client.models.i_asset_input_existing_asset_input import (
+            IAssetInputExistingAssetInput,
+        )
+        from rapidata.api_client.models.i_asset_input import IAssetInput
+
+        self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post(
+            benchmark_id=self.id,
+            create_prompt_for_benchmark_endpoint_input=CreatePromptForBenchmarkEndpointInput(
+                identifier=identifier,
+                prompt=prompt,
+                promptAsset=(
+                    IAssetInput(
+                        actual_instance=IAssetInputExistingAssetInput(
+                            _t="ExistingAssetInput",
+                            name=self._asset_uploader.upload_asset(prompt_asset),
                         )
-                        if prompt_asset is not None
-                        else None
-                    ),
-                    tags=tags,
+                    )
+                    if prompt_asset is not None
+                    else None
                 ),
-            )
+                tags=tags,
+            ),
+        )
+
+    def _add_prompts(
+        self,
+        identifiers: Sequence[str],
+        prompts: Sequence[str | None],
+        prompt_assets: Sequence[str | None],
+        tags: Sequence[list[str] | None],
+    ) -> None:
+        """Registers many prompts concurrently.
+
+        Used by benchmark creation, where the inputs have already been validated
+        (matching lengths, unique identifiers) and the benchmark is empty — so the
+        per-prompt validation and cache reads in :py:meth:`add_prompt` are
+        unnecessary and would not be thread-safe. Uploads run on a thread pool;
+        the local caches are populated in input order once all succeed.
+        """
+        normalized_tags = [tag if tag is not None else [] for tag in tags]
+        current_context = otel_context.get_current()
+
+        def post_with_context(
+            identifier: str,
+            prompt: str | None,
+            prompt_asset: str | None,
+            tag: list[str],
+        ) -> None:
+            token = otel_context.attach(current_context)
+            try:
+                self._post_prompt(identifier, prompt, prompt_asset, tag)
+            finally:
+                otel_context.detach(token)
+
+        with tracer.start_as_current_span("RapidataBenchmark._add_prompts"):
+            with ThreadPoolExecutor(
+                max_workers=rapidata_config.upload.maxWorkers
+            ) as executor:
+                futures = [
+                    executor.submit(post_with_context, identifier, prompt, asset, tag)
+                    for identifier, prompt, asset, tag in zip(
+                        identifiers, prompts, prompt_assets, normalized_tags
+                    )
+                ]
+
+                with tqdm(
+                    total=len(identifiers),
+                    desc="Uploading prompts",
+                    disable=rapidata_config.logging.silent_mode,
+                ) as pbar:
+                    for future in as_completed(futures):
+                        future.result()
+                        pbar.update(1)
+
+            self.__identifiers.extend(identifiers)
+            self.__prompts.extend(prompts)
+            self.__prompt_assets.extend(prompt_assets)
+            self.__tags.extend(normalized_tags)
 
     def create_leaderboard(
         self,

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -336,10 +336,15 @@ class RapidataBenchmark:
         Used by benchmark creation, where the inputs have already been validated
         (matching lengths, unique identifiers) and the benchmark is empty — so the
         per-prompt validation and cache reads in :py:meth:`add_prompt` are
-        unnecessary and would not be thread-safe. Uploads run on a thread pool;
-        the local caches are populated in input order once all succeed.
+        unnecessary and would not be thread-safe. Uploads run on a thread pool.
+
+        A failed upload does not abort the rest: every prompt is attempted, the
+        failures are logged, and only the prompts that succeeded are added to the
+        local caches (in input order). If every prompt fails a ``RuntimeError`` is
+        raised, since the benchmark would otherwise be empty.
         """
         normalized_tags = [tag if tag is not None else [] for tag in tags]
+        entries = list(zip(identifiers, prompts, prompt_assets, normalized_tags))
         current_context = otel_context.get_current()
 
         def post_with_context(
@@ -347,12 +352,17 @@ class RapidataBenchmark:
             prompt: str | None,
             prompt_asset: str | None,
             tag: list[str],
-        ) -> None:
+        ) -> tuple[str, Exception | None]:
             token = otel_context.attach(current_context)
             try:
                 self._post_prompt(identifier, prompt, prompt_asset, tag)
+                return identifier, None
+            except Exception as e:
+                return identifier, e
             finally:
                 otel_context.detach(token)
+
+        failed: dict[str, Exception] = {}
 
         with tracer.start_as_current_span("RapidataBenchmark._add_prompts"):
             with ThreadPoolExecutor(
@@ -360,24 +370,42 @@ class RapidataBenchmark:
             ) as executor:
                 futures = [
                     executor.submit(post_with_context, identifier, prompt, asset, tag)
-                    for identifier, prompt, asset, tag in zip(
-                        identifiers, prompts, prompt_assets, normalized_tags
-                    )
+                    for identifier, prompt, asset, tag in entries
                 ]
 
                 with tqdm(
-                    total=len(identifiers),
+                    total=len(entries),
                     desc="Uploading prompts",
                     disable=rapidata_config.logging.silent_mode,
                 ) as pbar:
                     for future in as_completed(futures):
-                        future.result()
+                        identifier, error = future.result()
+                        if error is not None:
+                            failed[identifier] = error
+                            logger.error(
+                                "Failed to upload prompt %s: %s", identifier, str(error)
+                            )
                         pbar.update(1)
 
-            self.__identifiers.extend(identifiers)
-            self.__prompts.extend(prompts)
-            self.__prompt_assets.extend(prompt_assets)
-            self.__tags.extend(normalized_tags)
+            for identifier, prompt, prompt_asset, tag in entries:
+                if identifier in failed:
+                    continue
+                self.__identifiers.append(identifier)
+                self.__prompts.append(prompt)
+                self.__prompt_assets.append(prompt_asset)
+                self.__tags.append(tag)
+
+        if failed:
+            logger.warning(
+                "%d of %d prompts failed to upload and were skipped: %s",
+                len(failed),
+                len(entries),
+                list(failed.keys()),
+            )
+            if len(failed) == len(entries):
+                raise RuntimeError(
+                    "Failed to upload any prompts to the benchmark. See logs for details."
+                )
 
     def create_leaderboard(
         self,

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 import urllib.parse
 import webbrowser
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from colorama import Fore
-from opentelemetry import context as otel_context
-from tqdm.auto import tqdm
 from typing import Literal, Optional, Sequence, TYPE_CHECKING
 from rapidata.rapidata_client.config import logger, managed_print, tracer
-from rapidata.rapidata_client.config.rapidata_config import rapidata_config
 from rapidata.rapidata_client.benchmark._detail_mapper import LevelOfDetail
+from rapidata.rapidata_client.benchmark._prompt_uploader import (
+    BenchmarkPrompt,
+    BenchmarkPromptUploader,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -36,8 +36,6 @@ class RapidataBenchmark:
     """
 
     def __init__(self, name: str, id: str, openapi_service: OpenAPIService):
-        from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
-
         self.name = name
         self.id = id
         self._openapi_service = openapi_service
@@ -50,7 +48,7 @@ class RapidataBenchmark:
         self.__benchmark_page: str = (
             f"https://app.{self._openapi_service.environment}/mri/benchmarks/{self.id}"
         )
-        self._asset_uploader = AssetUploader(openapi_service)
+        self._prompt_uploader = BenchmarkPromptUploader(id, openapi_service)
 
     def __instantiate_prompts(self) -> None:
         from rapidata.rapidata_client.config import tracer
@@ -282,47 +280,9 @@ class RapidataBenchmark:
             self.__prompts.append(prompt)
             self.__prompt_assets.append(prompt_asset)
 
-            self._post_prompt(identifier, prompt, prompt_asset, tags)
-
-    def _post_prompt(
-        self,
-        identifier: str,
-        prompt: str | None,
-        prompt_asset: str | None,
-        tags: list[str],
-    ) -> None:
-        """Performs the network calls to register a single prompt.
-
-        Does not validate or mutate the local caches — callers own that. Kept
-        free of shared state so it can be run concurrently (see
-        :py:meth:`_add_prompts`).
-        """
-        from rapidata.api_client.models.create_prompt_for_benchmark_endpoint_input import (
-            CreatePromptForBenchmarkEndpointInput,
-        )
-        from rapidata.api_client.models.i_asset_input_existing_asset_input import (
-            IAssetInputExistingAssetInput,
-        )
-        from rapidata.api_client.models.i_asset_input import IAssetInput
-
-        self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post(
-            benchmark_id=self.id,
-            create_prompt_for_benchmark_endpoint_input=CreatePromptForBenchmarkEndpointInput(
-                identifier=identifier,
-                prompt=prompt,
-                promptAsset=(
-                    IAssetInput(
-                        actual_instance=IAssetInputExistingAssetInput(
-                            _t="ExistingAssetInput",
-                            name=self._asset_uploader.upload_asset(prompt_asset),
-                        )
-                    )
-                    if prompt_asset is not None
-                    else None
-                ),
-                tags=tags,
-            ),
-        )
+            self._prompt_uploader.upload(
+                BenchmarkPrompt(identifier, prompt, prompt_asset, tags)
+            )
 
     def _add_prompts(
         self,
@@ -331,81 +291,25 @@ class RapidataBenchmark:
         prompt_assets: Sequence[str | None],
         tags: Sequence[list[str] | None],
     ) -> None:
-        """Registers many prompts concurrently.
+        """Registers many prompts concurrently, used by benchmark creation.
 
-        Used by benchmark creation, where the inputs have already been validated
-        (matching lengths, unique identifiers) and the benchmark is empty — so the
-        per-prompt validation and cache reads in :py:meth:`add_prompt` are
-        unnecessary and would not be thread-safe. Uploads run on a thread pool.
-
-        A failed upload does not abort the rest: every prompt is attempted, the
-        failures are logged, and only the prompts that succeeded are added to the
-        local caches (in input order). If every prompt fails a ``RuntimeError`` is
-        raised, since the benchmark would otherwise be empty.
+        The inputs are already validated there (matching lengths, unique
+        identifiers) and the benchmark is empty, so this bypasses the per-prompt
+        validation and cache reads in :py:meth:`add_prompt`. Only the prompts that
+        upload successfully are added to the local caches, in input order.
         """
-        normalized_tags = [tag if tag is not None else [] for tag in tags]
-        entries = list(zip(identifiers, prompts, prompt_assets, normalized_tags))
-        current_context = otel_context.get_current()
-
-        def post_with_context(
-            identifier: str,
-            prompt: str | None,
-            prompt_asset: str | None,
-            tag: list[str],
-        ) -> tuple[str, Exception | None]:
-            token = otel_context.attach(current_context)
-            try:
-                self._post_prompt(identifier, prompt, prompt_asset, tag)
-                return identifier, None
-            except Exception as e:
-                return identifier, e
-            finally:
-                otel_context.detach(token)
-
-        failed: dict[str, Exception] = {}
-
-        with tracer.start_as_current_span("RapidataBenchmark._add_prompts"):
-            with ThreadPoolExecutor(
-                max_workers=rapidata_config.upload.maxWorkers
-            ) as executor:
-                futures = [
-                    executor.submit(post_with_context, identifier, prompt, asset, tag)
-                    for identifier, prompt, asset, tag in entries
-                ]
-
-                with tqdm(
-                    total=len(entries),
-                    desc="Uploading prompts",
-                    disable=rapidata_config.logging.silent_mode,
-                ) as pbar:
-                    for future in as_completed(futures):
-                        identifier, error = future.result()
-                        if error is not None:
-                            failed[identifier] = error
-                            logger.error(
-                                "Failed to upload prompt %s: %s", identifier, str(error)
-                            )
-                        pbar.update(1)
-
-            for identifier, prompt, prompt_asset, tag in entries:
-                if identifier in failed:
-                    continue
-                self.__identifiers.append(identifier)
-                self.__prompts.append(prompt)
-                self.__prompt_assets.append(prompt_asset)
-                self.__tags.append(tag)
-
-        if failed:
-            logger.warning(
-                "%d of %d prompts failed to upload and were skipped: %s",
-                len(failed),
-                len(entries),
-                list(failed.keys()),
+        to_upload = [
+            BenchmarkPrompt(identifier, prompt, asset, tag if tag is not None else [])
+            for identifier, prompt, asset, tag in zip(
+                identifiers, prompts, prompt_assets, tags
             )
-            if len(failed) == len(entries):
-                raise RuntimeError(
-                    "Failed to upload any prompts to the benchmark. See logs for details."
-                )
+        ]
+
+        for uploaded in self._prompt_uploader.upload_many(to_upload):
+            self.__identifiers.append(uploaded.identifier)
+            self.__prompts.append(uploaded.prompt)
+            self.__prompt_assets.append(uploaded.prompt_asset)
+            self.__tags.append(uploaded.tags)
 
     def create_leaderboard(
         self,

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import urllib.parse
 import webbrowser
 from colorama import Fore
-from typing import Literal, Optional, Sequence, TYPE_CHECKING
+from typing import Literal, Optional, Sequence, TYPE_CHECKING, cast
 from rapidata.rapidata_client.config import logger, managed_print, tracer
 from rapidata.rapidata_client.benchmark._detail_mapper import LevelOfDetail
 from rapidata.rapidata_client.benchmark._prompt_uploader import (
@@ -211,105 +211,143 @@ class RapidataBenchmark:
 
             return self.__participants
 
-    def add_prompt(
+    def add_prompts(
         self,
-        identifier: str | None = None,
-        prompt: str | None = None,
-        prompt_asset: str | None = None,
-        tags: Optional[list[str]] = None,
-    ):
+        identifiers: Optional[list[str]] = None,
+        prompts: Optional[list[str | None] | list[str]] = None,
+        prompt_assets: Optional[list[str | None] | list[str]] = None,
+        tags: Optional[list[list[str] | None] | list[list[str]]] = None,
+    ) -> None:
         """
-        Adds a prompt to the benchmark.
+        Adds one or more prompts to the benchmark. Everything is matched up by the
+        indexes of the lists.
+
+        prompts or identifiers must be provided, as well as prompts or prompt_assets.
+
+        The prompts are uploaded concurrently. A failed upload does not abort the
+        rest: every prompt is attempted, failures are logged, and only the prompts
+        that succeeded are registered.
 
         Args:
-            identifier: The identifier of the prompt/asset/tags that will be used to match up the media. If not provided, it will use the prompt, asset or prompt + asset as the identifier.
-            prompt: The prompt that will be used to evaluate the model.
-            prompt_asset: The prompt asset that will be used to evaluate the model. Provided as a link to the asset.
-            tags: The tags can be used to filter the leaderboard results. They will NOT be shown to the users.
+            identifiers: The identifiers of the prompts/assets/tags that will be used to match up the media. If not provided, it will use the prompts as the identifiers.
+            prompts: The prompts that will be registered for the benchmark.
+            prompt_assets: The prompt assets that will be registered for the benchmark.
+            tags: The tags that will be associated with the prompts to use for filtering the leaderboard results. They will NOT be shown to the users.
+
+        Example:
+            ```python
+            benchmark.add_prompts(
+                identifiers=["id1", "id2"],
+                prompts=["prompt 1", "prompt 2"],
+                prompt_assets=["https://assets.rapidata.ai/prompt_1.jpg", "https://assets.rapidata.ai/prompt_2.jpg"],
+                tags=[["tag1", "tag2"], ["tag2"]],
+            )
+            ```
         """
-        with tracer.start_as_current_span("RapidataBenchmark.add_prompt_to_benchmark"):
-            if tags is None:
-                tags = []
+        with tracer.start_as_current_span("RapidataBenchmark.add_prompts"):
+            if prompts and (
+                not isinstance(prompts, list)
+                or not all(
+                    isinstance(prompt, str) or prompt is None for prompt in prompts
+                )
+            ):
+                raise ValueError("Prompts must be a list of strings or None.")
 
-            if prompt is None and prompt_asset is None:
-                raise ValueError("Prompt or prompt asset must be provided.")
+            if prompt_assets and (
+                not isinstance(prompt_assets, list)
+                or not all(
+                    isinstance(asset, str) or asset is None for asset in prompt_assets
+                )
+            ):
+                raise ValueError("Media assets must be a list of strings or None.")
 
-            if identifier is None and prompt is None:
-                raise ValueError("Identifier or prompt must be provided.")
+            if identifiers and (
+                not isinstance(identifiers, list)
+                or not all(isinstance(identifier, str) for identifier in identifiers)
+            ):
+                raise ValueError("Identifiers must be a list of strings.")
 
-            if identifier and not isinstance(identifier, str):
-                raise ValueError("Identifier must be a string.")
+            if identifiers and len(set(identifiers)) != len(identifiers):
+                raise ValueError("Identifiers must be unique.")
 
-            if prompt and not isinstance(prompt, str):
-                raise ValueError("Prompt must be a string.")
+            if tags is not None:
+                if not isinstance(tags, list):
+                    raise ValueError("Tags must be a list of lists of strings or None.")
 
-            if prompt_asset and not isinstance(prompt_asset, str):
+                for tag in tags:
+                    if tag is not None and (
+                        not isinstance(tag, list)
+                        or not all(isinstance(item, str) for item in tag)
+                    ):
+                        raise ValueError(
+                            "Tags must be a list of lists of strings or None."
+                        )
+
+            if not identifiers and not prompts:
                 raise ValueError(
-                    "Asset must be a string. That is the link to the asset."
+                    "At least one of identifiers or prompts must be provided."
                 )
 
-            if identifier is None:
-                assert prompt is not None
-                if prompt in self.prompts:
+            if not prompts and not prompt_assets:
+                raise ValueError(
+                    "At least one of prompts or media assets must be provided."
+                )
+
+            if not identifiers:
+                assert prompts is not None
+                if len(set(prompts)) != len(prompts):
                     raise ValueError(
                         "Prompts must be unique. Otherwise use identifiers."
                     )
-                identifier = prompt
+                if any(prompt is None for prompt in prompts):
+                    raise ValueError(
+                        "Prompts must not be None. Otherwise use identifiers."
+                    )
 
-            if identifier in self.identifiers:
-                raise ValueError("Identifier already exists in the benchmark.")
+                identifiers = cast(list[str], prompts)
 
-            if tags is not None and (
-                not isinstance(tags, list)
-                or not all(isinstance(tag, str) for tag in tags)
-            ):
-                raise ValueError("Tags must be a list of strings.")
+            assert identifiers is not None
 
-            logger.info(
-                "Adding identifier %s with prompt %s, prompt asset %s and tags %s to benchmark %s",
-                identifier,
-                prompt,
-                prompt_asset,
-                tags,
-                self.id,
-            )
+            expected_length = len(identifiers)
 
-            self.__identifiers.append(identifier)
+            if not prompts:
+                prompts = cast(list[str | None], [None] * expected_length)
 
-            self.__tags.append(tags)
-            self.__prompts.append(prompt)
-            self.__prompt_assets.append(prompt_asset)
+            if not prompt_assets:
+                prompt_assets = cast(list[str | None], [None] * expected_length)
 
-            self._prompt_uploader.upload(
-                BenchmarkPrompt(identifier, prompt, prompt_asset, tags)
-            )
+            if not tags:
+                tags = cast(list[list[str] | None], [None] * expected_length)
 
-    def _add_prompts(
-        self,
-        identifiers: Sequence[str],
-        prompts: Sequence[str | None],
-        prompt_assets: Sequence[str | None],
-        tags: Sequence[list[str] | None],
-    ) -> None:
-        """Registers many prompts concurrently, used by benchmark creation.
+            if not (expected_length == len(prompts) == len(prompt_assets) == len(tags)):
+                raise ValueError(
+                    "Identifiers, prompts, media assets, and tags must have the same length or set to None."
+                )
 
-        The inputs are already validated there (matching lengths, unique
-        identifiers) and the benchmark is empty, so this bypasses the per-prompt
-        validation and cache reads in :py:meth:`add_prompt`. Only the prompts that
-        upload successfully are added to the local caches, in input order.
-        """
-        to_upload = [
-            BenchmarkPrompt(identifier, prompt, asset, tag if tag is not None else [])
-            for identifier, prompt, asset, tag in zip(
-                identifiers, prompts, prompt_assets, tags
-            )
-        ]
+            already_registered = [
+                identifier
+                for identifier in identifiers
+                if identifier in self.identifiers
+            ]
+            if already_registered:
+                raise ValueError(
+                    f"Identifiers already exist in the benchmark: {already_registered}"
+                )
 
-        for uploaded in self._prompt_uploader.upload_many(to_upload):
-            self.__identifiers.append(uploaded.identifier)
-            self.__prompts.append(uploaded.prompt)
-            self.__prompt_assets.append(uploaded.prompt_asset)
-            self.__tags.append(uploaded.tags)
+            to_upload = [
+                BenchmarkPrompt(
+                    identifier, prompt, asset, tag if tag is not None else []
+                )
+                for identifier, prompt, asset, tag in zip(
+                    identifiers, prompts, prompt_assets, tags
+                )
+            ]
+
+            for uploaded in self._prompt_uploader.upload_many(to_upload):
+                self.__identifiers.append(uploaded.identifier)
+                self.__prompts.append(uploaded.prompt)
+                self.__prompt_assets.append(uploaded.prompt_asset)
+                self.__tags.append(uploaded.tags)
 
     def create_leaderboard(
         self,

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
@@ -1,4 +1,5 @@
 from typing import Optional, cast
+from tqdm.auto import tqdm
 from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
 from rapidata.api_client.models.create_benchmark_endpoint_input import (
     CreateBenchmarkEndpointInput,
@@ -8,6 +9,7 @@ from rapidata.api_client.models.audience_audience_id_jobs_get_job_id_parameter i
 )
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.config import logger, tracer
+from rapidata.rapidata_client.config.rapidata_config import rapidata_config
 
 
 class RapidataBenchmarkManager:
@@ -161,8 +163,11 @@ class RapidataBenchmarkManager:
                 name, benchmark_result.id, self.__openapi_service
             )
 
-            for identifier, prompt, asset, tag in zip(
-                identifiers, prompts, prompt_assets, tags
+            for identifier, prompt, asset, tag in tqdm(
+                zip(identifiers, prompts, prompt_assets, tags),
+                total=expected_length,
+                desc="Uploading prompts",
+                disable=rapidata_config.logging.silent_mode,
             ):
                 benchmark.add_prompt(identifier, prompt, asset, tag)
 

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
@@ -1,5 +1,4 @@
 from typing import Optional, cast
-from tqdm.auto import tqdm
 from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
 from rapidata.api_client.models.create_benchmark_endpoint_input import (
     CreateBenchmarkEndpointInput,
@@ -9,7 +8,6 @@ from rapidata.api_client.models.audience_audience_id_jobs_get_job_id_parameter i
 )
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.rapidata_client.config import logger, tracer
-from rapidata.rapidata_client.config.rapidata_config import rapidata_config
 
 
 class RapidataBenchmarkManager:
@@ -163,13 +161,7 @@ class RapidataBenchmarkManager:
                 name, benchmark_result.id, self.__openapi_service
             )
 
-            for identifier, prompt, asset, tag in tqdm(
-                zip(identifiers, prompts, prompt_assets, tags),
-                total=expected_length,
-                desc="Uploading prompts",
-                disable=rapidata_config.logging.silent_mode,
-            ):
-                benchmark.add_prompt(identifier, prompt, asset, tag)
+            benchmark._add_prompts(identifiers, prompts, prompt_assets, tags)
 
             return benchmark
 

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import Optional
 from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
 from rapidata.api_client.models.create_benchmark_endpoint_input import (
     CreateBenchmarkEndpointInput,
@@ -60,91 +60,6 @@ class RapidataBenchmarkManager:
             if not isinstance(name, str):
                 raise ValueError("Name must be a string.")
 
-            if prompts and (
-                not isinstance(prompts, list)
-                or not all(
-                    isinstance(prompt, str) or prompt is None for prompt in prompts
-                )
-            ):
-                raise ValueError("Prompts must be a list of strings or None.")
-
-            if prompt_assets and (
-                not isinstance(prompt_assets, list)
-                or not all(
-                    isinstance(asset, str) or asset is None for asset in prompt_assets
-                )
-            ):
-                raise ValueError("Media assets must be a list of strings or None.")
-
-            if identifiers and (
-                not isinstance(identifiers, list)
-                or not all(isinstance(identifier, str) for identifier in identifiers)
-            ):
-                raise ValueError("Identifiers must be a list of strings.")
-
-            if identifiers:
-                if not len(set(identifiers)) == len(identifiers):
-                    raise ValueError("Identifiers must be unique.")
-
-            if tags is not None:
-                if not isinstance(tags, list):
-                    raise ValueError("Tags must be a list of lists of strings or None.")
-
-                for tag in tags:
-                    if tag is not None and (
-                        not isinstance(tag, list)
-                        or not all(isinstance(item, str) for item in tag)
-                    ):
-                        raise ValueError(
-                            "Tags must be a list of lists of strings or None."
-                        )
-
-            if not identifiers and not prompts:
-                raise ValueError(
-                    "At least one of identifiers or prompts must be provided."
-                )
-
-            if not prompts and not prompt_assets:
-                raise ValueError(
-                    "At least one of prompts or media assets must be provided."
-                )
-
-            if not identifiers:
-                assert prompts is not None
-                if not len(set(prompts)) == len(prompts):
-                    raise ValueError(
-                        "Prompts must be unique. Otherwise use identifiers."
-                    )
-                if any(prompt is None for prompt in prompts):
-                    raise ValueError(
-                        "Prompts must not be None. Otherwise use identifiers."
-                    )
-
-                identifiers = cast(list[str], prompts)
-
-            assert identifiers is not None
-
-            expected_length = len(identifiers)
-
-            if not prompts:
-                prompts = cast(list[str | None], [None] * expected_length)
-
-            if not prompt_assets:
-                prompt_assets = cast(list[str | None], [None] * expected_length)
-
-            if not tags:
-                tags = cast(list[list[str] | None], [None] * expected_length)
-
-            # At this point, all variables are guaranteed to be lists, not None
-            assert prompts is not None
-            assert prompt_assets is not None
-            assert tags is not None
-
-            if not (expected_length == len(prompts) == len(prompt_assets) == len(tags)):
-                raise ValueError(
-                    "Identifiers, prompts, media assets, and tags must have the same length or set to None."
-                )
-
             logger.info("Creating new benchmark %s", name)
 
             benchmark_result = (
@@ -161,7 +76,7 @@ class RapidataBenchmarkManager:
                 name, benchmark_result.id, self.__openapi_service
             )
 
-            benchmark._add_prompts(identifiers, prompts, prompt_assets, tags)
+            benchmark.add_prompts(identifiers, prompts, prompt_assets, tags)
 
             return benchmark
 

--- a/uv.lock
+++ b/uv.lock
@@ -2570,7 +2570,7 @@ wheels = [
 
 [[package]]
 name = "rapidata"
-version = "3.9.12"
+version = "3.11.9"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## What

When creating a benchmark, the prompts/identifiers are now:
1. **shown with a progress bar** (`tqdm`) while uploading, and
2. **uploaded concurrently** instead of one-by-one.

## Why

`create_new_benchmark` registered prompts in a sequential loop, each `add_prompt` doing a blocking asset-upload + prompt POST. Creation time grew linearly with the number of prompts and gave no feedback while it ran.

## How

- Extracted the network call in `add_prompt` into a side-effect-free `_post_prompt` helper.
- Added a thread-safe `_add_prompts` bulk path that uploads on a `ThreadPoolExecutor`, reusing the existing `rapidata_config.upload.maxWorkers` setting and the OTel-context + `tqdm` pattern already used by participant media upload. Local caches are populated in input order once uploads complete.
- `create_new_benchmark` already validates matching lengths + unique identifiers and the benchmark is empty at creation, so `add_prompt`'s per-call validation/cache-reads (not thread-safe) are intentionally bypassed in the bulk path.

`tqdm` and the thread-pool config are already project dependencies — no new deps. `add_prompt` is unchanged for single-prompt callers.

## Testing

- `pyright` clean on both changed files (matches the `type-check` CI job).
- SDK imports cleanly; new `_post_prompt` / `_add_prompts` methods present.

🔗 Session: https://session-4ec3ad69.poseidon.rapidata.internal/