### PR TITLE
feat(benchmark): expose original and english prompts

### DIFF
--- a/docs/mri.md
+++ b/docs/mri.md
@@ -92,6 +92,9 @@ Once your benchmark and leaderboard are set up, you can evaluate models by the f
 All prompts must be from the benchmark's registered prompt set (available through the `prompts` attribute of the benchmark)
 
 !!! note
+    `prompts` returns the prompts as you originally provided them. The English translation of each prompt is available through the `english_prompts` attribute, aligned by index. Prompts added in the current session report `None` there until they are re-fetched, since the translation is produced server-side.
+
+!!! note
     You are not limited to one media per prompt; you can supply the same prompt multiple times.
 
 

--- a/docs/mri.md
+++ b/docs/mri.md
@@ -92,7 +92,7 @@ Once your benchmark and leaderboard are set up, you can evaluate models by the f
 All prompts must be from the benchmark's registered prompt set (available through the `prompts` attribute of the benchmark)
 
 !!! note
-    `prompts` returns the prompts as you originally provided them. The English translation of each prompt is available through the `english_prompts` attribute, aligned by index. Prompts added in the current session report `None` there until they are re-fetched, since the translation is produced server-side.
+    `prompts` returns the prompts as you originally provided them. The English translation of each prompt is available through the `english_prompts` attribute, aligned by index.
 
 !!! note
     You are not limited to one media per prompt; you can supply the same prompt multiple times.

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -45,8 +45,6 @@ class RapidataBenchmark:
         self.__leaderboards: list["RapidataLeaderboard"] = []
         self.__identifiers: list[str] = []
         self.__tags: list[list[str]] = []
-        self.__prompts_fetched: bool = False
-        self.__english_prompts_fetched: bool = False
         self.__participants: list[BenchmarkParticipant] = []
         self.__benchmark_page: str = (
             f"https://app.{self._openapi_service.environment}/mri/benchmarks/{self.id}"
@@ -106,12 +104,9 @@ class RapidataBenchmark:
 
                 current_page += 1
 
-            self.__prompts_fetched = True
-            self.__english_prompts_fetched = True
-
     @property
     def identifiers(self) -> list[str]:
-        if not self.__prompts_fetched:
+        if not self.__identifiers:
             self.__instantiate_prompts()
 
         return self.__identifiers
@@ -121,7 +116,7 @@ class RapidataBenchmark:
         """
         Returns the prompts as originally provided, in the order they were registered.
         """
-        if not self.__prompts_fetched:
+        if not self.__prompts:
             self.__instantiate_prompts()
 
         return self.__prompts
@@ -134,7 +129,7 @@ class RapidataBenchmark:
         The translations are produced server-side, so accessing this after
         `add_prompts` triggers a one-off re-fetch of the prompt set.
         """
-        if not self.__english_prompts_fetched:
+        if not self.__english_prompts:
             self.__instantiate_prompts()
 
         return self.__english_prompts
@@ -144,7 +139,7 @@ class RapidataBenchmark:
         """
         Returns the prompt assets that are registered for the benchmark.
         """
-        if not self.__prompts_fetched:
+        if not self.__prompt_assets:
             self.__instantiate_prompts()
 
         return self.__prompt_assets
@@ -154,7 +149,7 @@ class RapidataBenchmark:
         """
         Returns the tags that are registered for the benchmark.
         """
-        if not self.__prompts_fetched:
+        if not self.__tags:
             self.__instantiate_prompts()
 
         return self.__tags
@@ -376,9 +371,9 @@ class RapidataBenchmark:
                 self.__tags.append(uploaded.tags)
 
             # The English translation is produced server-side and is unknown for
-            # the just-added prompts. Leave the rest of the cache intact and only
-            # mark the translations for a lazy re-fetch on next access.
-            self.__english_prompts_fetched = False
+            # the just-added prompts. Clear it so the next access lazily re-fetches
+            # the prompt set, while the rest of the cache stays intact.
+            self.__english_prompts = []
 
     def create_leaderboard(
         self,

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -45,6 +45,7 @@ class RapidataBenchmark:
         self.__leaderboards: list["RapidataLeaderboard"] = []
         self.__identifiers: list[str] = []
         self.__tags: list[list[str]] = []
+        self.__prompts_fetched: bool = False
         self.__participants: list[BenchmarkParticipant] = []
         self.__benchmark_page: str = (
             f"https://app.{self._openapi_service.environment}/mri/benchmarks/{self.id}"
@@ -59,6 +60,12 @@ class RapidataBenchmark:
         )
 
         with tracer.start_as_current_span("RapidataBenchmark.__instantiate_prompts"):
+            self.__prompts = []
+            self.__english_prompts = []
+            self.__identifiers = []
+            self.__prompt_assets = []
+            self.__tags = []
+
             current_page = 1
             total_pages = None
 
@@ -98,9 +105,11 @@ class RapidataBenchmark:
 
                 current_page += 1
 
+            self.__prompts_fetched = True
+
     @property
     def identifiers(self) -> list[str]:
-        if not self.__identifiers:
+        if not self.__prompts_fetched:
             self.__instantiate_prompts()
 
         return self.__identifiers
@@ -110,7 +119,7 @@ class RapidataBenchmark:
         """
         Returns the prompts as originally provided, in the order they were registered.
         """
-        if not self.__prompts:
+        if not self.__prompts_fetched:
             self.__instantiate_prompts()
 
         return self.__prompts
@@ -119,11 +128,8 @@ class RapidataBenchmark:
     def english_prompts(self) -> list[str | None]:
         """
         Returns the prompts translated to English, aligned by index with `prompts`.
-
-        Translation happens server-side, so prompts added in the current session
-        report `None` here until they are re-fetched.
         """
-        if not self.__english_prompts:
+        if not self.__prompts_fetched:
             self.__instantiate_prompts()
 
         return self.__english_prompts
@@ -133,7 +139,7 @@ class RapidataBenchmark:
         """
         Returns the prompt assets that are registered for the benchmark.
         """
-        if not self.__prompt_assets:
+        if not self.__prompts_fetched:
             self.__instantiate_prompts()
 
         return self.__prompt_assets
@@ -143,7 +149,7 @@ class RapidataBenchmark:
         """
         Returns the tags that are registered for the benchmark.
         """
-        if not self.__tags:
+        if not self.__prompts_fetched:
             self.__instantiate_prompts()
 
         return self.__tags
@@ -358,12 +364,11 @@ class RapidataBenchmark:
                 )
             ]
 
-            for uploaded in self._prompt_uploader.upload_many(to_upload):
-                self.__identifiers.append(uploaded.identifier)
-                self.__prompts.append(uploaded.prompt)
-                self.__english_prompts.append(None)
-                self.__prompt_assets.append(uploaded.prompt_asset)
-                self.__tags.append(uploaded.tags)
+            self._prompt_uploader.upload_many(to_upload)
+
+            # Invalidate the cache so the next access re-fetches from the server,
+            # including the English translations that are produced server-side.
+            self.__prompts_fetched = False
 
     def create_leaderboard(
         self,

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -40,6 +40,7 @@ class RapidataBenchmark:
         self.id = id
         self._openapi_service = openapi_service
         self.__prompts: list[str | None] = []
+        self.__english_prompts: list[str | None] = []
         self.__prompt_assets: list[str | None] = []
         self.__leaderboards: list["RapidataLeaderboard"] = []
         self.__identifiers: list[str] = []
@@ -76,7 +77,8 @@ class RapidataBenchmark:
                 total_pages = prompts_result.total_pages
 
                 for prompt in prompts_result.items:
-                    self.__prompts.append(prompt.prompt)
+                    self.__prompts.append(prompt.original_prompt)
+                    self.__english_prompts.append(prompt.english_prompt)
                     self.__identifiers.append(prompt.identifier)
                     if prompt.prompt_asset is None:
                         self.__prompt_assets.append(None)
@@ -106,12 +108,25 @@ class RapidataBenchmark:
     @property
     def prompts(self) -> list[str | None]:
         """
-        Returns the prompts that are registered for the leaderboard.
+        Returns the prompts as originally provided, in the order they were registered.
         """
         if not self.__prompts:
             self.__instantiate_prompts()
 
         return self.__prompts
+
+    @property
+    def english_prompts(self) -> list[str | None]:
+        """
+        Returns the prompts translated to English, aligned by index with `prompts`.
+
+        Translation happens server-side, so prompts added in the current session
+        report `None` here until they are re-fetched.
+        """
+        if not self.__english_prompts:
+            self.__instantiate_prompts()
+
+        return self.__english_prompts
 
     @property
     def prompt_assets(self) -> list[str | None]:
@@ -346,6 +361,9 @@ class RapidataBenchmark:
             for uploaded in self._prompt_uploader.upload_many(to_upload):
                 self.__identifiers.append(uploaded.identifier)
                 self.__prompts.append(uploaded.prompt)
+                # The English translation is produced server-side and is not known
+                # until the prompts are re-fetched.
+                self.__english_prompts.append(None)
                 self.__prompt_assets.append(uploaded.prompt_asset)
                 self.__tags.append(uploaded.tags)
 

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -361,8 +361,6 @@ class RapidataBenchmark:
             for uploaded in self._prompt_uploader.upload_many(to_upload):
                 self.__identifiers.append(uploaded.identifier)
                 self.__prompts.append(uploaded.prompt)
-                # The English translation is produced server-side and is not known
-                # until the prompts are re-fetched.
                 self.__english_prompts.append(None)
                 self.__prompt_assets.append(uploaded.prompt_asset)
                 self.__tags.append(uploaded.tags)

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -46,6 +46,7 @@ class RapidataBenchmark:
         self.__identifiers: list[str] = []
         self.__tags: list[list[str]] = []
         self.__prompts_fetched: bool = False
+        self.__english_prompts_fetched: bool = False
         self.__participants: list[BenchmarkParticipant] = []
         self.__benchmark_page: str = (
             f"https://app.{self._openapi_service.environment}/mri/benchmarks/{self.id}"
@@ -106,6 +107,7 @@ class RapidataBenchmark:
                 current_page += 1
 
             self.__prompts_fetched = True
+            self.__english_prompts_fetched = True
 
     @property
     def identifiers(self) -> list[str]:
@@ -128,8 +130,11 @@ class RapidataBenchmark:
     def english_prompts(self) -> list[str | None]:
         """
         Returns the prompts translated to English, aligned by index with `prompts`.
+
+        The translations are produced server-side, so accessing this after
+        `add_prompts` triggers a one-off re-fetch of the prompt set.
         """
-        if not self.__prompts_fetched:
+        if not self.__english_prompts_fetched:
             self.__instantiate_prompts()
 
         return self.__english_prompts
@@ -364,11 +369,16 @@ class RapidataBenchmark:
                 )
             ]
 
-            self._prompt_uploader.upload_many(to_upload)
+            for uploaded in self._prompt_uploader.upload_many(to_upload):
+                self.__identifiers.append(uploaded.identifier)
+                self.__prompts.append(uploaded.prompt)
+                self.__prompt_assets.append(uploaded.prompt_asset)
+                self.__tags.append(uploaded.tags)
 
-            # Invalidate the cache so the next access re-fetches from the server,
-            # including the English translations that are produced server-side.
-            self.__prompts_fetched = False
+            # The English translation is produced server-side and is unknown for
+            # the just-added prompts. Leave the rest of the cache intact and only
+            # mark the translations for a lazy re-fetch on next access.
+            self.__english_prompts_fetched = False
 
     def create_leaderboard(
         self,


### PR DESCRIPTION
## What

The `GetPromptsByBenchmark` endpoint output now carries `originalPrompt` (the prompt as originally provided) and `englishPrompt` (its English translation), replacing the now-deprecated `prompt` field.

This makes both accessible on `RapidataBenchmark`:

- `benchmark.prompts` — now backed by `originalPrompt` (unchanged semantics: the prompt as you provided it). Existing user code keeps working.
- `benchmark.english_prompts` — **new**, the English translation, index-aligned with `prompts`.

The deprecated output `prompt` field is no longer read anywhere in the client.

## Notes

- The English translation is produced server-side, so prompts added in the current session via `add_prompts` report `None` in `english_prompts` until they are re-fetched.
- The generated model still contains the deprecated `prompt` field for now. A follow-up PR updates the OpenAPI generator so deprecated properties are stripped at generation time (same as fully-deprecated endpoints already are).

## Verification

- `pyright src/rapidata/rapidata_client` → 0 errors
- `from rapidata import RapidataClient` import smoke test passes

🔗 Session: https://session-42566e2d.poseidon.rapidata.internal/