### PR TITLE
build(openapi): strip deprecated properties and parameters when generating

### DIFF
--- a/openapi/generate-schema.sh
+++ b/openapi/generate-schema.sh
@@ -101,6 +101,7 @@ npx -y @redocly/cli join ./${SCHEMA_DIR}/*.openapi.json -o ./${SCHEMA_DIR}/rapid
 # deprecated parameters and deprecated schema properties (also pruning the
 # latter from any `required` list). This mirrors the endpoint filtering for
 # partly-deprecated surfaces like a single deprecated field on a model.
+# Note: the `walk` builtin requires jq >= 1.6.
 jq '
   del(.paths[][] | select(.deprecated == true))
   | walk(

--- a/openapi/generate-schema.sh
+++ b/openapi/generate-schema.sh
@@ -96,8 +96,28 @@ done
 
 npx -y @redocly/cli join ./${SCHEMA_DIR}/*.openapi.json -o ./${SCHEMA_DIR}/rapidata.openapi.json
 
-# Filter out deprecated endpoints
-jq 'del(.paths[][] | select(.deprecated == true))' \
+# Filter out anything deprecated so it is not generated into the SDK:
+# fully-deprecated operations (whole endpoints), and — recursively —
+# deprecated parameters and deprecated schema properties (also pruning the
+# latter from any `required` list). This mirrors the endpoint filtering for
+# partly-deprecated surfaces like a single deprecated field on a model.
+jq '
+  del(.paths[][] | select(.deprecated == true))
+  | walk(
+      if type == "object" then
+        ( if (.parameters | type) == "array"
+          then .parameters |= map(select(.deprecated != true))
+          else . end )
+        | ( if (.properties | type) == "object"
+            then
+              ( [ .properties | to_entries[] | select(.value.deprecated == true) | .key ] ) as $deprecated
+              | .properties |= with_entries(select(.value.deprecated != true))
+              | ( if (.required | type) == "array"
+                  then .required |= map(select(. as $name | ($deprecated | index($name)) | not))
+                  else . end )
+            else . end )
+      else . end
+    )' \
    ${SCHEMA_DIR}/rapidata.openapi.json \
    > ${SCHEMA_DIR}/rapidata.filtered.openapi.json
 


### PR DESCRIPTION
## What

Follow-up to #609. The OpenAPI schema filter in `openapi/generate-schema.sh` already removed **fully-deprecated operations** (whole endpoints) before code generation:

```jq
del(.paths[][] | select(.deprecated == true))
```

…but **partly-deprecated** surfaces were still generated into the SDK — a single deprecated field on an otherwise-current model (e.g. `GetPromptsByBenchmarkEndpoint_Output.prompt`), or a deprecated parameter.

This extends the filter to recursively also drop:

- **deprecated schema properties** (and prune them from any `required` list)
- **deprecated parameters** on operations

so the same "don't generate deprecated things" rule that applies to whole endpoints now applies to individual members.

## Effect

Takes effect on the **next** run of `generate-schema.sh` (the `update-openapi-client` workflow). On that run, the 27 currently-deprecated properties across the spec — including the benchmark `prompt` field that #609 stops using — will no longer be emitted into the generated client.

## Verification

Ran the new filter against the committed joined spec:
- 27 deprecated properties → **0** remaining
- `GetPromptsByBenchmarkEndpoint_Output` keeps `englishPrompt` + `originalPrompt`, drops `prompt`, and `required` is pruned accordingly
- fully-deprecated `PUT /campaign/boost` still removed (no regression)
- output is valid JSON; `sh -n` on the script passes

🔗 Session: https://session-42566e2d.poseidon.rapidata.internal/