### PR TITLE
perf(benchmark): avoid per-identifier prompt re-fetch in add_prompts

### DIFF
--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -324,10 +324,15 @@ class RapidataBenchmark:
                     "Identifiers, prompts, media assets, and tags must have the same length or set to None."
                 )
 
+            # Snapshot once: `self.identifiers` is a property whose getter re-fetches
+            # over HTTP while the cache is empty, so testing it inside the comprehension
+            # fired one request per identifier (a full re-fetch each time on a fresh,
+            # empty benchmark). One lookup into a set instead.
+            existing_identifiers = set(self.identifiers)
             already_registered = [
                 identifier
                 for identifier in identifiers
-                if identifier in self.identifiers
+                if identifier in existing_identifiers
             ]
             if already_registered:
                 raise ValueError(


### PR DESCRIPTION
## Problem

Creating a benchmark and calling `add_prompts` with a large prompt list spent **~55s before a single prompt was uploaded**. Observed in an SDK session adding ~3,787 prompts: ~3,787 redundant `GET /benchmark/{id}/prompts?page=1` calls fired before the first `POST …/prompt`.

## Root cause

The duplicate-identifier guard in `add_prompts` tested membership against the `self.identifiers` **property** inside a list comprehension:

```python
already_registered = [i for i in identifiers if i in self.identifiers]
```

`self.identifiers`' getter calls `__instantiate_prompts()` (a full HTTP fetch) whenever its cache `self.__identifiers` is empty. For a freshly created, empty benchmark the cache never populates (there are no prompts to populate it with), so the getter re-fetches over HTTP on **every** iteration — one round-trip per identifier being added. It's also O(n²) on the list-membership test even when the cache is warm.

## Fix

Snapshot the property into a `set` once, then test against it — one fetch, O(1) lookups.

## Validation

- `pyright src/rapidata/rapidata_client` → 0 errors, 0 warnings.
- Expected effect: pre-upload wait for the ~3.8k-prompt case drops from ~55s to <1s. (The subsequent ~152s of actual `POST …/prompt` uploads is unchanged and a separate, legitimate cost.)

🔗 Session: https://session-4cfcfa5d.poseidon.rapidata.internal/

🤖 Generated with [Claude Code](https://claude.com/claude-code)