### PR TITLE
fix(job): align find_jobs with renamed jobDefinitionId field

### DIFF
--- a/src/rapidata/rapidata_client/audience/_audience_base.py
+++ b/src/rapidata/rapidata_client/audience/_audience_base.py
@@ -120,7 +120,7 @@ class RapidataAudienceBase:
                     name=job.name,
                     audience_id=job.audience_id,
                     created_at=job.created_at,
-                    definition_id=job.definition_id,
+                    definition_id=job.job_definition_id,
                     openapi_service=self._openapi_service,
                     pipeline_id=job.pipeline_id,
                 )

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -764,7 +764,7 @@ class RapidataJobManager:
                     name=job.name,
                     audience_id=job.audience_id,
                     created_at=job.created_at,
-                    definition_id=job.definition_id,
+                    definition_id=job.job_definition_id,
                     openapi_service=self._openapi_service,
                     pipeline_id=job.pipeline_id,
                 )


### PR DESCRIPTION
## Problem

Calling `audience.find_jobs(...)` (or `JobManager.find_jobs(...)`) on the latest SDK raises:

```
AttributeError: 'QueryJobsEndpointOutput' object has no attribute 'definition_id'
```

## Root cause

The OpenAPI regeneration in #606 (`chore: update OpenAPI client to 2026.06.09.0929-f9654d0`) renamed the field on `QueryJobsEndpointOutput`:

| Before | After |
|---|---|
| `definition_id` (alias `definitionId`) | `job_definition_id` (alias `jobDefinitionId`) |

That commit regenerated only the generated model — the hand-written `find_jobs` wrappers still read `job.definition_id`, which no longer exists, so the call fails at runtime.

## Fix

Update the two call sites that consume `QueryJobsEndpointOutput` (paginated `jobs_get` results) to read `job.job_definition_id`:

- `rapidata_client/audience/_audience_base.py` — `RapidataAudienceBase.find_jobs`
- `rapidata_client/job/rapidata_job_manager.py` — `JobManager.find_jobs`

`RapidataJob`'s own `definition_id` attribute is unchanged. `JobManager.get_job_by_id` is **not** affected — it returns `GetJobByIdEndpointOutput`, which still exposes `definitionId`. Only `QueryJobsEndpointOutput` was renamed in the backend contract.

`pyright src/rapidata/rapidata_client` → 0 errors.

🔗 Session: https://session-e3300696.poseidon.rapidata.internal/