### PR TITLE
feat(job): expose locate job definition and add locate qualification examples

### DIFF
--- a/docs/examples/locate_job.md
+++ b/docs/examples/locate_job.md
@@ -59,8 +59,7 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
 
     # Qualification examples — each pairs an image with the bounding box(es)
     # covering the region a correct labeler should tap. Coordinates are image
-    # ratios (0.0–1.0); the boxes below are illustrative, mark the real artifact
-    # regions in your own images. Use only examples whose target is unambiguous.
+    # ratios (0.0–1.0);
     EXAMPLES = [
         ("https://assets.rapidata.ai/544b1210-1e91-4351-a97c-fe8263b319b4.webp",
          [Box(x_min=0.44, y_min=0.42, x_max=0.58, y_max=0.63)]),

--- a/docs/examples/locate_job.md
+++ b/docs/examples/locate_job.md
@@ -62,12 +62,20 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
     # ratios (0.0–1.0); the boxes below are illustrative, mark the real artifact
     # regions in your own images. Use only examples whose target is unambiguous.
     EXAMPLES = [
-        ("https://assets.rapidata.ai/eac11c3e-ad57-402b-90ed-23378d2ff869.jpg",
-         [Box(x_min=0.10, y_min=0.55, x_max=0.30, y_max=0.80)]),
-        ("https://assets.rapidata.ai/04e7e3c6-5554-47ca-bdb2-950e48ac3e6c.jpg",
-         [Box(x_min=0.60, y_min=0.20, x_max=0.85, y_max=0.45)]),
-        ("https://assets.rapidata.ai/91d9913c-b399-47f8-ad19-767798cc951c.jpg",
-         [Box(x_min=0.40, y_min=0.40, x_max=0.60, y_max=0.65)]),
+        ("https://assets.rapidata.ai/544b1210-1e91-4351-a97c-fe8263b319b4.webp",
+         [Box(x_min=0.44, y_min=0.42, x_max=0.58, y_max=0.63)]),
+        ("https://assets.rapidata.ai/f1e11611-7c5b-4186-8ddf-51e06c0859ff.webp",
+         [Box(x_min=0.07, y_min=0.37, x_max=0.39, y_max=0.71)]),
+        ("https://assets.rapidata.ai/ad816f8f-f7a9-4c90-90dd-9c10bc556856.webp",
+         [Box(x_min=0.04, y_min=0.10, x_max=0.31, y_max=0.28)]),
+        ("https://assets.rapidata.ai/a076ae24-4d5c-415d-9d41-6afbe2fbfcde.webp",
+         [Box(x_min=0.25, y_min=0.40, x_max=0.70, y_max=0.96)]),
+        ("https://assets.rapidata.ai/38753cb4-4b77-4fb7-b601-8a5bc3d166d7.webp",
+         [Box(x_min=0.41, y_min=0.09, x_max=0.87, y_max=0.45)]),
+        ("https://assets.rapidata.ai/50109592-b521-4dcb-a00f-453f6c026a52.webp",
+         [Box(x_min=0.25, y_min=0.03, x_max=0.71, y_max=0.48)]),
+        ("https://assets.rapidata.ai/a5a954d0-91e8-4b4e-bec6-2bb739444be8.webp",
+         [Box(x_min=0.57, y_min=0.40, x_max=0.96, y_max=0.89)]),
     ]
 
     client = RapidataClient()

--- a/docs/examples/locate_job.md
+++ b/docs/examples/locate_job.md
@@ -4,35 +4,98 @@ To learn about the basics of creating a job, please refer to the [quickstart gui
 
 In a locate job, labelers tap the points in a datapoint that match your instruction. In this example, we ask people to point out visual artifacts in AI-generated images — a common way to find where a generator went wrong.
 
-Like any other job, a locate job can be assigned to any audience. This example uses the **global** audience — the broadest pool of labelers, ready to work immediately — so it starts collecting responses right away.
+Like any other job, a locate job can be assigned to any audience — a ready-to-go curated one, or a custom audience you train with qualification examples.
 
-```python
-from rapidata import RapidataClient
+=== "Simple"
 
-IMAGE_URLS = [
-    "https://assets.rapidata.ai/eac11c3e-ad57-402b-90ed-23378d2ff869.jpg",
-    "https://assets.rapidata.ai/04e7e3c6-5554-47ca-bdb2-950e48ac3e6c.jpg",
-    "https://assets.rapidata.ai/91d9913c-b399-47f8-ad19-767798cc951c.jpg",
-]
+    The simple version runs straight away on a **generally available** audience — a pre-existing pool of labelers, ready to work immediately — so the job starts collecting responses right away.
 
-client = RapidataClient()
+    ```python
+    from rapidata import RapidataClient
 
-audience = client.audience.get_audience_by_id("global") # (1)!
+    IMAGE_URLS = [
+        "https://assets.rapidata.ai/eac11c3e-ad57-402b-90ed-23378d2ff869.jpg",
+        "https://assets.rapidata.ai/04e7e3c6-5554-47ca-bdb2-950e48ac3e6c.jpg",
+        "https://assets.rapidata.ai/91d9913c-b399-47f8-ad19-767798cc951c.jpg",
+    ]
 
-job_definition = client.job.create_locate_job_definition(
-    name="Artifact Detection Example",
-    instruction="Tap on any visual glitches or errors in the image.", # (2)!
-    datapoints=IMAGE_URLS,
-    responses_per_datapoint=35,
-)
+    client = RapidataClient()
 
-job_definition.preview()
+    audience = client.audience.get_audience_by_id("global") # (1)!
 
-job = audience.assign_job(job_definition)
-job.display_progress_bar()
-results = job.get_results()
-print(results)
-```
+    job_definition = client.job.create_locate_job_definition(
+        name="Artifact Detection Example",
+        instruction="Tap on any visual glitches or errors in the image.", # (2)!
+        datapoints=IMAGE_URLS,
+        responses_per_datapoint=35,
+    )
 
-1. The global audience (id `global`) already has labelers ready to work, so the job starts collecting responses immediately. You can assign a locate job to any audience — browse them in the [Rapidata Dashboard](https://app.rapidata.ai/audiences).
-2. The instruction tells labelers what to locate. Each response is the set of points they tapped on that datapoint.
+    job_definition.preview()
+
+    job = audience.assign_job(job_definition)
+    job.display_progress_bar()
+    results = job.get_results()
+    print(results)
+    ```
+
+    1. The global audience (id `global`) already has labelers ready to work, so the job starts collecting responses immediately. You can assign a locate job to any audience — browse them in the [Rapidata Dashboard](https://app.rapidata.ai/audiences).
+    2. The instruction tells labelers what to locate. Each response is the set of points they tapped on that datapoint.
+
+=== "Advanced"
+
+    The advanced version builds a **custom** audience and trains labelers with qualification examples before running the job. Each example carries the bounding box(es) covering the region a correct labeler should tap; only labelers who tap inside them join the audience, which raises label quality.
+
+    !!! warning "This takes significantly longer"
+        Unlike the Simple path, this first builds and trains an entirely new audience before the job can start collecting responses — expect it to take considerably longer to return results.
+
+    ```python
+    from rapidata import RapidataClient, Box
+
+    IMAGE_URLS = [
+        "https://assets.rapidata.ai/eac11c3e-ad57-402b-90ed-23378d2ff869.jpg",
+        "https://assets.rapidata.ai/04e7e3c6-5554-47ca-bdb2-950e48ac3e6c.jpg",
+        "https://assets.rapidata.ai/91d9913c-b399-47f8-ad19-767798cc951c.jpg",
+    ]
+
+    # Qualification examples — each pairs an image with the bounding box(es)
+    # covering the region a correct labeler should tap. Coordinates are image
+    # ratios (0.0–1.0); the boxes below are illustrative, mark the real artifact
+    # regions in your own images. Use only examples whose target is unambiguous.
+    EXAMPLES = [
+        ("https://assets.rapidata.ai/eac11c3e-ad57-402b-90ed-23378d2ff869.jpg",
+         [Box(x_min=0.10, y_min=0.55, x_max=0.30, y_max=0.80)]),
+        ("https://assets.rapidata.ai/04e7e3c6-5554-47ca-bdb2-950e48ac3e6c.jpg",
+         [Box(x_min=0.60, y_min=0.20, x_max=0.85, y_max=0.45)]),
+        ("https://assets.rapidata.ai/91d9913c-b399-47f8-ad19-767798cc951c.jpg",
+         [Box(x_min=0.40, y_min=0.40, x_max=0.60, y_max=0.65)]),
+    ]
+
+    client = RapidataClient()
+
+    audience = client.audience.create_audience(name="Artifact Detection Audience") # (1)!
+    for datapoint, truths in EXAMPLES:
+        audience.add_locate_example(
+            instruction="Tap on any visual glitches or errors in the image.",
+            datapoint=datapoint,
+            truths=truths,
+        )
+
+    job_definition = client.job.create_locate_job_definition(
+        name="Artifact Detection Example",
+        instruction="Tap on any visual glitches or errors in the image.",
+        datapoints=IMAGE_URLS,
+        responses_per_datapoint=35,
+    )
+
+    job_definition.preview()
+
+    job = audience.assign_job(job_definition)
+    job.display_progress_bar()
+    results = job.get_results()
+    print(results)
+    ```
+
+    1. Creates a new, empty audience. The `add_locate_example` calls train and filter the labelers who join it.
+
+    !!! note
+        Review every qualification example and its truth regions carefully, and add more than the few shown here for production workloads — see [Custom Audiences](../audiences.md) for the full guide.

--- a/docs/examples/locate_job.md
+++ b/docs/examples/locate_job.md
@@ -8,7 +8,7 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
 
 === "Simple"
 
-    The simple version runs straight away on a **generally available** audience — a pre-existing pool of labelers, ready to work immediately — so the job starts collecting responses right away.
+    The simple version runs straight away on a **curated** audience — a pre-existing pool of labelers, ready to work immediately — so the job starts collecting responses right away.
 
     ```python
     from rapidata import RapidataClient

--- a/src/rapidata/rapidata_client/audience/audience_example_handler.py
+++ b/src/rapidata/rapidata_client/audience/audience_example_handler.py
@@ -19,6 +19,16 @@ from rapidata.api_client.models.i_example_payload_compare_example_payload import
 from rapidata.api_client.models.i_example_truth_compare_example_truth import (
     IExampleTruthCompareExampleTruth,
 )
+from rapidata.api_client.models.i_example_payload_locate_example_payload import (
+    IExamplePayloadLocateExamplePayload,
+)
+from rapidata.api_client.models.i_example_truth_locate_example_truth import (
+    IExampleTruthLocateExampleTruth,
+)
+from rapidata.rapidata_client.validation.rapids.box import (
+    Box,
+    calculate_boxes_coverage,
+)
 from rapidata.service.openapi_service import OpenAPIService
 from rapidata.api_client.models.i_example_payload import IExamplePayload
 from rapidata.api_client.models.i_example_truth import IExampleTruth
@@ -182,6 +192,66 @@ class AudienceExampleHandler:
                 ),
                 explanation=explanation,
                 randomCorrectProbability=0.5,
+                featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
+            ),
+        )
+
+    def add_locate_example(
+        self,
+        instruction: str,
+        datapoint: str,
+        truths: list[Box],
+        context: str | None = None,
+        media_context: list[str] | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> None:
+        """add a locate example to the audience
+
+        Args:
+            instruction (str): The instruction telling the labeler what to locate.
+            datapoint (str): The media datapoint the labeler will be locating the target in.
+            truths (list[Box]): The bounding boxes covering the correct regions to tap. Coordinates are ratios of the image size (0.0 to 1.0).
+            context (str, optional): The context is text that will be shown in addition to the instruction. Defaults to None.
+            media_context (list[str], optional): A list of image URLs / paths that will be shown in addition to the instruction (can be combined with context). Pass a single-element list for one image, or multiple to display several images. Defaults to None.
+            explanation (str, optional): The explanation that will be shown to the labeler if the answer is wrong. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): The list of settings to apply to the example as feature flags. Controls how the example is rendered to the labeler. Defaults to None.
+        """
+        from rapidata.api_client.models.add_example_to_audience_endpoint_input import (
+            AddExampleToAudienceEndpointInput,
+        )
+
+        if not truths:
+            raise ValueError("Locate example requires at least one truth bounding box")
+
+        asset_input = self._asset_uploader.upload_and_map_asset(datapoint)
+
+        payload = IExamplePayload(
+            actual_instance=IExamplePayloadLocateExamplePayload(
+                _t="LocateExamplePayload", target=instruction
+            )
+        )
+        model_truth = IExampleTruth(
+            actual_instance=IExampleTruthLocateExampleTruth(
+                _t="LocateExampleTruth",
+                boundingBoxes=[truth.to_example_model() for truth in truths],
+            )
+        )
+
+        self._openapi_service.audience.examples_api.audience_audience_id_example_post(
+            audience_id=self._audience_id,
+            add_example_to_audience_endpoint_input=AddExampleToAudienceEndpointInput(
+                asset=asset_input,
+                payload=payload,
+                truth=model_truth,
+                context=context,
+                contextAsset=(
+                    self._asset_uploader.upload_and_map_asset(media_context)
+                    if media_context
+                    else None
+                ),
+                explanation=explanation,
+                randomCorrectProbability=calculate_boxes_coverage(truths),
                 featureFlags=[s._to_feature_flag() for s in settings] if settings else None,
             ),
         )

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     )
     from rapidata.rapidata_client.filter import RapidataFilter
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
+    from rapidata.rapidata_client.validation.rapids.box import Box
     from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
     import pandas as pd
 
@@ -258,6 +259,50 @@ class RapidataAudience(RapidataAudienceBase):
                 truth,
                 datapoint,
                 data_type,
+                context,
+                media_context,
+                explanation,
+                settings,
+            )
+            self._try_start_recruiting()
+            return self
+
+    def add_locate_example(
+        self,
+        instruction: str,
+        datapoint: str,
+        truths: list[Box],
+        context: str | None = None,
+        media_context: list[str] | None = None,
+        explanation: str | None = None,
+        settings: Sequence[RapidataSetting] | None = None,
+    ) -> RapidataAudience:
+        """Add a locate training example to this audience.
+
+        Training examples help annotators understand the task by showing them
+        a sample datapoint with the correct regions before they start labeling.
+
+        Args:
+            instruction (str): The instruction telling annotators what to locate.
+            datapoint (str): The media datapoint (URL or path) to use as the training example.
+            truths (list[Box]): The bounding boxes covering the correct regions to tap, as :class:`Box` objects with coordinates in image ratios (0.0 to 1.0).
+            context (str, optional): Additional text context to display with the example. Defaults to None.
+            media_context (list[str], optional): Additional image URLs / paths to display with the example. Pass a single-element list for one image, or multiple to display several images. Defaults to None.
+            explanation (str, optional): An explanation of why the truth is correct. Defaults to None.
+            settings (Sequence[RapidataSetting], optional): Settings applied as feature flags on this example so the qualification example matches how the actual task will be rendered. Defaults to None.
+
+        Returns:
+            RapidataAudience: The audience instance (self) for method chaining.
+        """
+        media_context = coerce_media_context(media_context)
+        with tracer.start_as_current_span("RapidataAudience.add_locate_example"):
+            logger.debug(
+                f"Adding locate example to audience: {self.id} with instruction: {instruction}, datapoint: {datapoint}, truths: {truths}, context: {context}, media_context: {media_context}, explanation: {explanation}, settings: {settings}"
+            )
+            self._example_handler.add_locate_example(
+                instruction,
+                datapoint,
+                truths,
                 context,
                 media_context,
                 explanation,

--- a/src/rapidata/rapidata_client/validation/rapids/box.py
+++ b/src/rapidata/rapidata_client/validation/rapids/box.py
@@ -1,6 +1,7 @@
 from rapidata.api_client.models.locate_box_truth_model_box import (
     LocateBoxTruthModelBox,
 )
+from rapidata.api_client.models.example_box_shape import ExampleBoxShape
 from pydantic import BaseModel, field_validator, model_validator
 
 
@@ -42,3 +43,60 @@ class Box(BaseModel):
             xMax=self.x_max * 100,
             yMax=self.y_max * 100,
         )
+
+    def to_example_model(self) -> ExampleBoxShape:
+        return ExampleBoxShape(
+            xMin=self.x_min * 100,
+            yMin=self.y_min * 100,
+            xMax=self.x_max * 100,
+            yMax=self.y_max * 100,
+        )
+
+
+def calculate_boxes_coverage(boxes: list[Box]) -> float:
+    """Calculate the ratio of image area covered by a list of boxes.
+
+    Args:
+        boxes: List of Box objects with coordinates in range [0, 1].
+
+    Returns:
+        float: Coverage ratio between 0.0 and 1.0.
+    """
+    if not boxes:
+        return 0.0
+
+    # Sweep line over x: at each x-interval, sum the merged y-coverage of the
+    # currently active boxes, weighted by the interval width.
+    events: list[tuple[float, str, int]] = []
+    for i, box in enumerate(boxes):
+        events.append((box.x_min, "start", i))
+        events.append((box.x_max, "end", i))
+
+    events.sort(key=lambda e: (e[0], e[1] == "end"))
+
+    total_area = 0.0
+    active_boxes: set[int] = set()
+    prev_x = 0.0
+
+    for x, event_type, box_id in events:
+        if active_boxes and x > prev_x:
+            y_intervals = sorted(
+                (boxes[i].y_min, boxes[i].y_max) for i in active_boxes
+            )
+            merged: list[tuple[float, float]] = []
+            for start, end in y_intervals:
+                if merged and start <= merged[-1][1]:
+                    merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+                else:
+                    merged.append((start, end))
+            y_coverage = sum(end - start for start, end in merged)
+            total_area += (x - prev_x) * y_coverage
+
+        if event_type == "start":
+            active_boxes.add(box_id)
+        else:
+            active_boxes.discard(box_id)
+
+        prev_x = x
+
+    return total_area

--- a/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
+++ b/src/rapidata/rapidata_client/validation/rapids/rapids_manager.py
@@ -6,7 +6,10 @@ if TYPE_CHECKING:
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
     from rapidata.service.openapi_service import OpenAPIService
 
-from rapidata.rapidata_client.validation.rapids.box import Box
+from rapidata.rapidata_client.validation.rapids.box import (
+    Box,
+    calculate_boxes_coverage,
+)
 
 
 class RapidsManager:
@@ -431,57 +434,7 @@ class RapidsManager:
         Returns:
             float: Coverage ratio between 0.0 and 1.0
         """
-        if not boxes:
-            return 0.0
-
-        # Convert boxes to intervals for sweep line algorithm
-        events = []
-
-        # Create events for x-coordinates
-        for i, box in enumerate(boxes):
-            events.append((box.x_min, "start", i, box))
-            events.append((box.x_max, "end", i, box))
-
-        # Sort events by x-coordinate
-        events.sort(key=lambda x: (x[0], x[1] == "end"))
-
-        total_area = 0.0
-        active_boxes = set()
-        prev_x = 0.0
-
-        for x, event_type, box_id, box in events:
-            # Calculate area for the previous x-interval
-            if active_boxes and x > prev_x:
-                # Merge y-intervals for active boxes
-                y_intervals = [(boxes[i].y_min, boxes[i].y_max) for i in active_boxes]
-                y_intervals.sort()
-
-                # Merge overlapping y-intervals
-                merged_intervals = []
-                for start, end in y_intervals:
-                    if merged_intervals and start <= merged_intervals[-1][1]:
-                        # Overlapping intervals - merge them
-                        merged_intervals[-1] = (
-                            merged_intervals[-1][0],
-                            max(merged_intervals[-1][1], end),
-                        )
-                    else:
-                        # Non-overlapping interval
-                        merged_intervals.append((start, end))
-
-                # Calculate total y-coverage for this x-interval
-                y_coverage = sum(end - start for start, end in merged_intervals)
-                total_area += (x - prev_x) * y_coverage
-
-            # Update active boxes
-            if event_type == "start":
-                active_boxes.add(box_id)
-            else:
-                active_boxes.discard(box_id)
-
-            prev_x = x
-
-        return total_area
+        return calculate_boxes_coverage(boxes)
 
     @staticmethod
     def _calculate_coverage_ratio(


### PR DESCRIPTION
## What

Exposes the **locate** rapid type as a first-class public API in the SDK and adds support for locate qualification examples on custom audiences.

### `feat(job)` — expose locate job definition
- Renames `_create_locate_job_definition` → `create_locate_job_definition` (now public), matching the existing public `create_compare_job_definition`.
- Lists locate on the docs landing page and in the parameter reference.

### `feat(audience)` — locate qualification examples
- Adds `add_locate_example` to `AudienceExampleHandler` and `RapidataAudience`, mirroring the existing `add_classification_example` / `add_compare_example` methods.
- Adds `Box.to_example_model()` and extracts the box-coverage sweep-line into a module-level `calculate_boxes_coverage` (shared by `RapidsManager` and the new audience example, so `randomCorrectProbability` is computed consistently with the locate validation rapid).

### `docs`
- New `examples/locate_job.md` (simple + advanced/custom-audience paths), nav + search-plugin wiring.
- Switches the curated-audience snippets from `find_audiences("alignment")[0]` to `get_audience_by_id(...)` for reproducibility, and points `aud_*` example jobs at curated/custom audiences so they produce results.

## Testing
- Examples were run end-to-end by the author and produce results.
- All changed modules `py_compile` clean; the coverage extraction is behaviour-preserving (existing `RapidsManager` callers unchanged).

## Notes
- This promotes locate to the public job-definition surface alongside compare; other types (classify, ranking, etc.) remain private — intentional for this change.
- `examples/locate_job.md` references a real curated audience id (`aud_MU1GZYoESyO`) for a runnable example.

🔗 Session: https://session-eb4cb58b.poseidon.rapidata.internal/