### PR TITLE
fix(docs): default example tabs to Simple on each page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,7 +162,6 @@ theme:
   features:
     - content.code.copy
     - content.code.annotate
-    - content.tabs.link
     - navigation.instant
     - navigation.instant.progress
     - navigation.sections


### PR DESCRIPTION
## Problem
On the Python SDK docs, content tabs (Simple / Advanced) were synced across all pages. If you opened the **Advanced** tab on one example and then navigated to a different example, that page would immediately show **Advanced** instead of starting on **Simple**.

## Cause
The Material `content.tabs.link` feature links all content tabs that share the same label across the entire site and persists the choice, so selecting "Advanced" anywhere activated "Advanced" everywhere.

## Fix
Remove `content.tabs.link` from `theme.features` in `mkdocs.yml`. Each tab group is now independent and defaults to its first tab (Simple) on every page.

No tab group on the site relies on cross-page linking (the only groups are Simple/Advanced on the examples and Text/Audio/Video on the overview), so removing the feature has no downside.

Verified with `uv run --group docs mkdocs build` — builds cleanly (only pre-existing unrelated warnings).

> Targeting `feat(job)/expose-all-job-definitions` instead of `main` to avoid merge conflicts, per request.

🔗 Session: ${POSEIDON_SESSION_URL:-$HOSTNAME}