### PR TITLE
feat(benchmark): add disable/enable and rename to participant

### DIFF
--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -173,6 +173,25 @@ elo = participant.get_elo()  # None if not computed yet
 print(f"{participant.name}: {elo}")
 ```
 
+### Renaming a Participant
+
+```python
+participant = benchmark.participants[0]
+participant.rename("New model name")
+```
+
+### Disabling Participants
+
+A disabled participant is excluded from evaluation and the computed standings. Unlike deleting, this is reversible:
+
+```python
+participant = benchmark.participants[0]
+participant.disable()
+
+# Bring it back into the evaluation later
+participant.enable()
+```
+
 ### Deleting Participants
 
 You can remove a participant — and its uploaded media — from the benchmark. This cannot be undone:

--- a/src/rapidata/rapidata_client/benchmark/participant/participant.py
+++ b/src/rapidata/rapidata_client/benchmark/participant/participant.py
@@ -101,6 +101,49 @@ class BenchmarkParticipant:
         )
         self._status = ParticipantStatus.SUBMITTED
 
+    def disable(self) -> None:
+        """Disables the participant in the benchmark.
+
+        A disabled participant is excluded from evaluation and the computed
+        standings. Use :meth:`enable` to reverse this.
+        """
+        with tracer.start_as_current_span("BenchmarkParticipant.disable"):
+            self._openapi_service.leaderboard.participant_api.participant_participant_id_disable_post(
+                participant_id=self.id
+            )
+            self._status = ParticipantStatus.DISABLED
+
+    def enable(self) -> None:
+        """Re-enables a previously disabled participant.
+
+        The participant returns to the ``Submitted`` state and is included in
+        evaluation and standings again.
+        """
+        with tracer.start_as_current_span("BenchmarkParticipant.enable"):
+            self._openapi_service.leaderboard.participant_api.participant_participant_id_enable_post(
+                participant_id=self.id
+            )
+            self._status = ParticipantStatus.SUBMITTED
+
+    def rename(self, name: str) -> None:
+        """Renames the participant.
+
+        Args:
+            name: The new name of the participant.
+        """
+        from rapidata.api_client.models.update_participant_name_endpoint_input import (
+            UpdateParticipantNameEndpointInput,
+        )
+
+        with tracer.start_as_current_span("BenchmarkParticipant.rename"):
+            self._openapi_service.leaderboard.participant_api.participant_participant_id_name_put(
+                participant_id=self.id,
+                update_participant_name_endpoint_input=UpdateParticipantNameEndpointInput(
+                    name=name
+                ),
+            )
+            self.name = name
+
     def __str__(self) -> str:
         return f"BenchmarkParticipant(name={self.name}, id={self.id}, status={self._status})"
 


### PR DESCRIPTION
## What

Adds three lifecycle methods to `BenchmarkParticipant` in the Python SDK:

- **`disable()`** — disables the participant, excluding it from evaluation and standings (sets status to `Disabled`).
- **`enable()`** — re-enables a previously disabled participant (sets status back to `Submitted`). Added as the natural inverse so `disable()` is reversible from the SDK.
- **`rename(name)`** — updates the participant's name and reflects it on the local object.

All three wrap existing backend endpoints (`participant/{id}/disable`, `.../enable`, `.../name`) via the generated `participant_api`, and follow the existing tracing-span pattern used by `delete()` / `get_elo()`.

## Docs

Added "Renaming a Participant" and "Disabling Participants" sections to `docs/mri_advanced.md`.

## Checks

- `uv run pyright src/rapidata/rapidata_client` → 0 errors
- `uv run black src/rapidata/rapidata_client` → clean
- `uv run --group docs mkdocs build` → builds (only pre-existing unrelated warnings)

🔗 Session: ${POSEIDON_SESSION_URL:-$HOSTNAME}