### PR TITLE
fix(job): read job state field renamed from status

### DIFF
--- a/src/rapidata/rapidata_client/job/rapidata_job.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job.py
@@ -160,7 +160,9 @@ class RapidataJob:
             The current status of the job as a string.
         """
         with tracer.start_as_current_span("RapidataJob.get_status"):
-            return self._openapi_service.order.job_api.job_job_id_get(self.id).status
+            return self._openapi_service.order.job_api.job_job_id_get(
+                self.id
+            ).state.value
 
     def get_results(self) -> RapidataResults:
         """


### PR DESCRIPTION
## What

`RapidataJob.get_status()` read `.status` off the job endpoint response, but the generated model `GetJobByIdEndpointOutput` was regenerated in **3.14.2** (commit `38d0a17`, *"update OpenAPI client to 2026.06.17.1403"*) with that field renamed:

```diff
- status: StrictStr = Field(description="The job status.")
+ state: AudienceJobState = Field(description="The job state.")
```

So every job status check raised:

```
AttributeError: 'GetJobByIdEndpointOutput' object has no attribute 'status'. Did you mean: 'state'?
```

This surfaced in the scheduled `rapidata-testing` **Run SDK Orders** workflow — `job_test.py` → `display_progress_bar()` → `get_status()` ([failing run](https://github.com/RapidataAI/rapidata-testing/actions/runs/27798370256/job/82263043919)).

## Fix

Read `.state.value`. `AudienceJobState` is a `str` enum whose values (`Completed`, `Failed`, …) already match the strings `_wait_for_status` and `display_progress_bar` compare against, so `get_status()` keeps its `-> str` contract and no caller needs changing.

`pyright src/rapidata/rapidata_client` passes clean.

🔗 Session: https://session-0eb86da9.poseidon.rapidata.internal/