### PR TITLE
feat(order): auto-regenerate stale results on get_results

### DIFF
--- a/src/rapidata/rapidata_client/job/rapidata_job.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job.py
@@ -164,12 +164,28 @@ class RapidataJob:
                 self.id
             ).state.value
 
+    def _regenerate_results(self) -> None:
+        """Triggers regeneration of a job whose results have gone stale.
+
+        A ``StaleResults`` job no longer has a valid/available result file; retrying it
+        re-runs the pipeline so a fresh result file is produced and the job completes
+        again.
+        """
+        logger.info("Job '%s' has stale results, triggering regeneration", self)
+        managed_print(
+            f"Job '{self.name}' has stale results — regenerating, "
+            "this may take a few minutes..."
+        )
+        self._openapi_service.order.job_api.job_job_id_retry_post(self.id)
+
     def get_results(self) -> RapidataResults:
         """
         Gets the results of the job.
 
-        If wait_for_completion is True and the job is still processing, this method
-        will block until the job is completed and then return the results.
+        If the job is still processing, this method will block until the job is
+        completed and then return the results.
+        If the job's results have gone stale, regeneration is triggered automatically
+        and this method blocks until the fresh results are ready.
 
         Returns:
             RapidataResults: The results of the job.
@@ -184,6 +200,11 @@ class RapidataJob:
             )
 
             logger.info("Getting results for job '%s'...", self)
+
+            # Stale results have no downloadable file until the pipeline is re-run;
+            # trigger that automatically before waiting for the re-completion.
+            if self.get_status() == "StaleResults":
+                self._regenerate_results()
 
             self._wait_for_status(
                 target_statuses=["Completed", "Failed"],

--- a/src/rapidata/rapidata_client/order/rapidata_order.py
+++ b/src/rapidata/rapidata_client/order/rapidata_order.py
@@ -294,7 +294,8 @@ class RapidataOrder:
             Processing: The order is actively being processed.\n
             Paused: The order has been paused.\n
             Completed: The order has been completed.\n
-            Failed: The order has failed.
+            Failed: The order has failed.\n
+            StaleResults: The order completed but its result file is no longer valid; calling get_results regenerates it automatically.
         """
         with tracer.start_as_current_span("RapidataOrder.get_status"):
             return self._openapi_service.order.order_api.order_order_id_get(
@@ -370,10 +371,25 @@ class RapidataOrder:
 
                 sleep(refresh_rate)
 
+    def _regenerate_results(self) -> None:
+        """Triggers regeneration of an order whose results have gone stale.
+
+        A ``StaleResults`` order no longer has a valid/available result file; retrying it
+        re-runs the pipeline so a fresh result file is produced and the order completes
+        again.
+        """
+        logger.info("Order '%s' has stale results, triggering regeneration", self)
+        managed_print(
+            f"Order '{self.name}' has stale results — regenerating, "
+            "this may take a few minutes..."
+        )
+        self._openapi_service.order.order_api.order_order_id_retry_post(self.id)
+
     def get_results(self, preliminary_results: bool = False) -> RapidataResults:
         """
         Gets the results of the order.
         If the order is still processing, this method will block until the order is completed and then return the results.
+        If the order's results have gone stale, regeneration is triggered automatically and this method blocks until the fresh results are ready.
 
         Args:
             preliminary_results: If True, returns the preliminary results of the order. Defaults to False.
@@ -396,6 +412,11 @@ class RapidataOrder:
 
             if preliminary_results and self.get_status() == OrderState.COMPLETED:
                 managed_print("Order is already completed. Returning final results.")
+
+            # Stale results have no downloadable file until the pipeline is re-run;
+            # trigger that automatically before waiting for the re-completion.
+            if self.get_status() == OrderState.STALERESULTS:
+                self._regenerate_results()
 
             self._wait_for_state(
                 target_states=[


### PR DESCRIPTION
## Problem

Orders/jobs whose stored result file was lost get marked **`StaleResults`** (e.g. by the `dobby order repair-missing-results` scan). In that state the result file no longer exists — it has to be rebuilt by re-running the pipeline before results can be downloaded.

But `get_results()` only waited for `Completed` / `Paused` / `ManualReview` / `Failed` (orders) and `Completed` / `Failed` (jobs). `StaleResults` is none of those and never transitions on its own, so **`get_results()` on a stale order/job blocked forever.**

## Fix

`RapidataOrder.get_results()` and `RapidataJob.get_results()` now detect `StaleResults` and **automatically trigger regeneration** via the existing retry endpoint (`order_order_id_retry_post` / `job_job_id_retry_post`). That moves the order/job back to `Processing` and re-runs the pipeline, after which the normal completion-wait + download proceeds and returns the fresh results.

- A clear message is printed (\"…has stale results — regenerating, this may take a few minutes…\") since regeneration re-runs the pipeline and can take a while. `get_results()` already blocks until completion, so this is consistent with existing behaviour.
- **No public signature change** — existing callers automatically benefit.
- The `StaleResults` → `Processing` transition is exactly what the retry endpoints already do (the backend allows retry from `StaleResults`), so this reuses existing, supported behaviour.

## Scope / notes

- Only the blocking `get_results()` path is affected. `preliminary_results=True` keeps its existing snapshot behaviour (regeneration is a heavy pipeline re-run, not appropriate for a \"preliminary\" snapshot).
- No generated-client changes: `OrderState.STALERESULTS` / `AudienceJobState.STALERESULTS` and both retry endpoints already exist, so no `openapi/templates` mustache edits were needed.
- Also added `StaleResults` to the `get_status()` docstring (it was missing).

## Testing

- `uv run pyright src/rapidata/rapidata_client` → **0 errors, 0 warnings**.
- `uv run black src/rapidata/rapidata_client` → clean.
- Verified the retry endpoints and `OrderState.STALERESULTS` resolve at runtime.
- (Repo has no unit-test harness; CLAUDE.md gates on pyright + black, both pass.)

🔗 Session: https://session-d65856b7.poseidon.rapidata.internal/

🤖 Generated with [Claude Code](https://claude.com/claude-code)