### PR TITLE
feat(mcp): add stdio MCP server for labeling tasks

### DIFF
--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -1,0 +1,78 @@
+# MCP Server
+
+The Rapidata MCP server lets an MCP-capable agent (Claude Desktop, Cursor, an
+IDE assistant, or your own client) run human labeling tasks on Rapidata
+directly through tool calls — without writing SDK code.
+
+It is a thin wrapper over this SDK and currently exposes the core loop: create a
+classification or comparison task, start it, poll its status, and fetch results.
+
+## Install and run
+
+```bash
+pip install "rapidata[mcp]"
+```
+
+The server authenticates with the same credentials as the SDK. Set your client
+credentials in the environment:
+
+```bash
+export RAPIDATA_CLIENT_ID="..."
+export RAPIDATA_CLIENT_SECRET="..."
+```
+
+Add it to your MCP client's configuration:
+
+```json
+{
+  "mcpServers": {
+    "rapidata": {
+      "command": "rapidata-mcp",
+      "env": {
+        "RAPIDATA_CLIENT_ID": "...",
+        "RAPIDATA_CLIENT_SECRET": "..."
+      }
+    }
+  }
+}
+```
+
+That's it — the agent can now create and manage labeling tasks.
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `create_classification_task` | Create a task where humans pick one option per item. Created in draft; does not spend. |
+| `create_comparison_task` | Create a pairwise comparison task (choose between two items). Created in draft; does not spend. |
+| `run_task` | Start collecting responses. **This is the step that spends.** |
+| `get_task_status` | Current status of a task. |
+| `get_task_results` | Fetch results — partial while running, final once complete. Never blocks. |
+| `list_tasks` | List your most recent tasks. |
+| `pause_task` | Pause a running task to stop collecting responses. |
+
+### Spending is an explicit step
+
+Creating a task never spends. `create_*` returns `total_responses` (the number
+of human responses that will be collected) and a `details_url` to inspect the
+task. Only `run_task` starts collection. Have the agent confirm the cost before
+calling it.
+
+### Datapoints are URLs
+
+Provide datapoints as publicly reachable URLs (image, video, audio, or text).
+Local file upload is not supported by the server.
+
+### Results never block
+
+`get_task_results` returns immediately whatever the task's state. While the task
+is processing it returns the partial snapshot collected so far
+(`result_status: "partial"`); once finished it returns the final aggregated
+results (`result_status: "complete"`). Per-annotator detail is omitted unless
+you pass `include_details=true`.
+
+## Notes
+
+- Use `python -m rapidata.mcp` if you prefer not to rely on the console script.
+- The transport defaults to stdio; set `RAPIDATA_MCP_TRANSPORT=streamable-http`
+  to serve over HTTP.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - Getting Started: mri.md
       - Advanced: mri_advanced.md
     - AI Agents: ai_agents.md
+    - MCP Server: mcp_server.md
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ dependencies = [
     "qrcode>=8.0,<9",
 ]
 
+[project.optional-dependencies]
+mcp = ["mcp>=1.8.0"]
+
+[project.scripts]
+rapidata-mcp = "rapidata.mcp.server:main"
+
 [dependency-groups]
 dev = [
     "python-dotenv>=1.0.1,<2",

--- a/src/rapidata/mcp/__init__.py
+++ b/src/rapidata/mcp/__init__.py
@@ -1,0 +1,18 @@
+"""Rapidata MCP server — expose Rapidata labeling tasks to MCP-capable agents.
+
+This is an optional integration. Install it with ``pip install 'rapidata[mcp]'``
+and run the ``rapidata-mcp`` console script, or ``python -m rapidata.mcp``.
+"""
+
+from __future__ import annotations
+
+from rapidata.mcp.auth import ClientProvider, EnvClientProvider, TokenClientProvider
+from rapidata.mcp.server import build_server, main
+
+__all__ = [
+    "build_server",
+    "main",
+    "ClientProvider",
+    "EnvClientProvider",
+    "TokenClientProvider",
+]

--- a/src/rapidata/mcp/__main__.py
+++ b/src/rapidata/mcp/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from rapidata.mcp.server import main
+
+if __name__ == "__main__":
+    main()

--- a/src/rapidata/mcp/auth.py
+++ b/src/rapidata/mcp/auth.py
@@ -1,0 +1,63 @@
+"""Client-resolution seam for the Rapidata MCP server.
+
+Tools never construct a :class:`RapidataClient` themselves; they ask a
+``ClientProvider`` for one. This is the boundary that lets the same tool code
+run under different auth models:
+
+* ``EnvClientProvider`` — ambient credentials from the SDK's own resolution
+  chain (``RAPIDATA_CLIENT_ID`` / ``RAPIDATA_CLIENT_SECRET`` env vars, then the
+  on-disk credential file). One stdio server process serves exactly one
+  customer, so the client is built once and reused.
+* ``TokenClientProvider`` — a pre-obtained OAuth token. This is the entry point
+  a hosted, multi-tenant transport plugs into: validate the caller's bearer
+  token, then build a per-request client scoped to that customer. The SDK
+  already accepts a ``token`` object, so no SDK change is needed to get here.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from rapidata import RapidataClient
+
+
+class ClientProvider(Protocol):
+    """Resolves an authenticated :class:`RapidataClient` for a tool call."""
+
+    def get_client(self) -> RapidataClient: ...
+
+
+class EnvClientProvider:
+    """Builds one :class:`RapidataClient` from ambient credentials and reuses it."""
+
+    def __init__(self) -> None:
+        self._client: RapidataClient | None = None
+        self._lock = threading.Lock()
+
+    def get_client(self) -> RapidataClient:
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    from rapidata import RapidataClient
+
+                    self._client = RapidataClient()
+        return self._client
+
+
+class TokenClientProvider:
+    """Builds a :class:`RapidataClient` from a caller-supplied OAuth token.
+
+    The token must be the complete object the SDK expects (access token, token
+    type, expiry) — the same shape returned by the OAuth token endpoint.
+    """
+
+    def __init__(self, token: dict, environment: str | None = None) -> None:
+        self._token = token
+        self._environment = environment
+
+    def get_client(self) -> RapidataClient:
+        from rapidata import RapidataClient
+
+        return RapidataClient(token=self._token, environment=self._environment)

--- a/src/rapidata/mcp/results.py
+++ b/src/rapidata/mcp/results.py
@@ -1,0 +1,50 @@
+"""Shaping of order results for return over MCP.
+
+Raw results carry one ``detailedResults`` entry per individual response — each
+with the annotator's country, language, demographics and reliability score.
+For an order with thousands of responses that payload is far too large to hand
+back to an agent verbatim, so detail is dropped unless explicitly requested and
+the datapoint list is capped.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from rapidata.rapidata_client.results.rapidata_results import RapidataResults
+
+_DETAIL_KEY = "detailedResults"
+
+
+def summarize_results(
+    results: RapidataResults,
+    include_details: bool = False,
+    max_datapoints: int = 50,
+) -> dict[str, Any]:
+    """Return a JSON-serialisable summary of an order's results.
+
+    Args:
+        results: The raw results from the SDK.
+        include_details: Keep per-annotator ``detailedResults``. Off by default.
+        max_datapoints: Cap on how many per-datapoint entries are returned.
+    """
+    items = results.get("results", []) or []
+    total = len(items)
+    shown = items[:max_datapoints]
+
+    out_items: list[dict[str, Any]] = []
+    for item in shown:
+        if include_details:
+            out_items.append(item)
+        else:
+            out_items.append({k: v for k, v in item.items() if k != _DETAIL_KEY})
+
+    return {
+        "info": results.get("info", {}),
+        "summary": results.get("summary", {}),
+        "datapoint_count": total,
+        "returned_datapoints": len(out_items),
+        "truncated": total > len(out_items),
+        "results": out_items,
+    }

--- a/src/rapidata/mcp/server.py
+++ b/src/rapidata/mcp/server.py
@@ -1,0 +1,279 @@
+"""The Rapidata MCP server.
+
+Exposes a small, curated set of tools that let an MCP-capable agent run human
+labeling tasks on Rapidata: create a classification or comparison task, start
+it (the single money-spending step), poll its status, and fetch shaped results.
+
+Stage 1 runs over stdio with ambient credentials. The two seams that make later
+stages additive rather than a rewrite are kept explicit:
+
+* **auth** — tools resolve their client through a :class:`ClientProvider`, so a
+  hosted transport swaps in per-request, token-scoped clients without touching
+  tool code.
+* **transport** — selected by ``RAPIDATA_MCP_TRANSPORT`` (``stdio`` default),
+  so moving to ``streamable-http`` is configuration, not code.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from rapidata.mcp.auth import ClientProvider, EnvClientProvider
+from rapidata.mcp.results import summarize_results
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+    from rapidata.rapidata_client.order.rapidata_order import RapidataOrder
+
+# States in which an order is not yet producing results. Mapped to the
+# result_status an agent should poll on, so get_task_results never blocks
+# waiting for a long-running or stalled order.
+_PENDING_STATES: dict[str, str] = {
+    "Created": "not_started",
+    "Preview": "not_started",
+    "Submitted": "in_review",
+    "ManualReview": "manual_review",
+    "StaleResults": "regenerating",
+}
+# States from which the final result file is available immediately.
+_FINISHED_STATES = {"Completed", "Paused"}
+
+
+def _silence_sdk_stdout() -> None:
+    """Keep the SDK off stdout — it is the stdio transport's JSON-RPC channel."""
+    from rapidata.rapidata_client.config import rapidata_config
+
+    rapidata_config.logging.silent_mode = True
+    rapidata_config.logging.enable_otlp = False
+
+
+def build_server(provider: ClientProvider | None = None) -> FastMCP:
+    """Build the FastMCP server with all tools registered."""
+    from mcp.server.fastmcp import FastMCP
+
+    _silence_sdk_stdout()
+    provider = provider or EnvClientProvider()
+    mcp = FastMCP("rapidata")
+
+    def _order(order_id: str) -> RapidataOrder:
+        return provider.get_client().order.get_order_by_id(order_id)
+
+    @mcp.tool()
+    def create_classification_task(
+        name: str,
+        instruction: str,
+        answer_options: list[str],
+        datapoint_urls: list[str],
+        responses_per_datapoint: int = 10,
+        confidence_threshold: float | None = None,
+    ) -> dict[str, Any]:
+        """Create a classification task where humans pick one answer option per item.
+
+        The task is created in draft and does NOT start collecting responses (or
+        spend) until you call ``run_task``. Datapoints must be publicly
+        reachable URLs (image/video/audio, or plain text). Returns the order id,
+        a details URL to inspect it, and ``total_responses`` — the number of
+        human responses that will be collected (datapoints x
+        responses_per_datapoint), which is what drives cost.
+
+        Args:
+            name: Internal label for the task (not shown to annotators).
+            instruction: What annotators should do.
+            answer_options: The options annotators choose from (at least two).
+            datapoint_urls: One URL per item to be labeled.
+            responses_per_datapoint: Human responses collected per item.
+            confidence_threshold: Optional early-stop; stops a datapoint once
+                this confidence is reached or the response cap is hit.
+        """
+        if len(answer_options) < 2:
+            raise ValueError("answer_options must contain at least two options")
+        if not datapoint_urls:
+            raise ValueError("datapoint_urls must not be empty")
+
+        order = provider.get_client().order.create_classification_order(
+            name=name,
+            instruction=instruction,
+            answer_options=answer_options,
+            datapoints=datapoint_urls,
+            responses_per_datapoint=responses_per_datapoint,
+            confidence_threshold=confidence_threshold,
+        )
+        return {
+            "order_id": order.id,
+            "name": order.name,
+            "status": order.get_status(),
+            "details_url": order.order_details_page,
+            "total_responses": len(datapoint_urls) * responses_per_datapoint,
+            "next_step": "Call run_task to start collecting responses (this spends).",
+        }
+
+    @mcp.tool()
+    def create_comparison_task(
+        name: str,
+        instruction: str,
+        comparison_pairs: list[list[str]],
+        responses_per_datapoint: int = 10,
+        confidence_threshold: float | None = None,
+    ) -> dict[str, Any]:
+        """Create a pairwise comparison task: humans choose between two items each.
+
+        Useful for evaluating or ranking outputs (e.g. which of two images
+        better matches a prompt). Like classification, it is created in draft and
+        only spends once ``run_task`` is called. Each pair must hold exactly two
+        publicly reachable URLs.
+
+        Args:
+            name: Internal label for the task (not shown to annotators).
+            instruction: The question annotators answer for each pair.
+            comparison_pairs: List of [item_a_url, item_b_url] pairs.
+            responses_per_datapoint: Human responses collected per pair.
+            confidence_threshold: Optional early-stop per pair.
+        """
+        if not comparison_pairs:
+            raise ValueError("comparison_pairs must not be empty")
+        for i, pair in enumerate(comparison_pairs):
+            if len(pair) != 2:
+                raise ValueError(f"comparison_pairs[{i}] must have exactly two items")
+
+        order = provider.get_client().order.create_compare_order(
+            name=name,
+            instruction=instruction,
+            datapoints=comparison_pairs,
+            responses_per_datapoint=responses_per_datapoint,
+            confidence_threshold=confidence_threshold,
+        )
+        return {
+            "order_id": order.id,
+            "name": order.name,
+            "status": order.get_status(),
+            "details_url": order.order_details_page,
+            "total_responses": len(comparison_pairs) * responses_per_datapoint,
+            "next_step": "Call run_task to start collecting responses (this spends).",
+        }
+
+    @mcp.tool()
+    def run_task(order_id: str) -> dict[str, Any]:
+        """Start collecting responses for a created task. This is the step that spends.
+
+        Only call this after confirming the task's cost (``total_responses``) and
+        reviewing its ``details_url`` is acceptable.
+        """
+        order = _order(order_id)
+        order.run()
+        return {"order_id": order.id, "status": order.get_status(), "started": True}
+
+    @mcp.tool()
+    def get_task_status(order_id: str) -> dict[str, Any]:
+        """Get the current status of a task without fetching results."""
+        order = _order(order_id)
+        return {
+            "order_id": order.id,
+            "status": order.get_status(),
+            "details_url": order.order_details_page,
+        }
+
+    @mcp.tool()
+    def get_task_results(
+        order_id: str,
+        include_details: bool = False,
+        max_datapoints: int = 50,
+    ) -> dict[str, Any]:
+        """Fetch results for a task. Never blocks on a long-running task.
+
+        If the task is still processing, returns the partial snapshot collected
+        so far with ``result_status: "partial"``; if it has finished, returns the
+        final results with ``result_status: "complete"``. If it has not started
+        producing results yet, returns a ``result_status`` to poll on (e.g.
+        ``not_started``, ``in_review``) and no results.
+
+        Args:
+            order_id: The task to fetch.
+            include_details: Include per-annotator detail (country, language,
+                demographics, reliability score). Large; off by default.
+            max_datapoints: Cap on per-datapoint entries returned.
+        """
+        order = _order(order_id)
+        status = order.get_status()
+
+        if status in _PENDING_STATES:
+            return {
+                "order_id": order.id,
+                "status": status,
+                "result_status": _PENDING_STATES[status],
+                "results": None,
+            }
+
+        if status == "Failed":
+            return {
+                "order_id": order.id,
+                "status": status,
+                "result_status": "failed",
+                "error": order._get_order_failure_message() or "Order failed.",
+                "results": None,
+            }
+
+        finished = status in _FINISHED_STATES
+        try:
+            results = order.get_results(preliminary_results=not finished)
+        except Exception as e:
+            # Partial snapshots can be briefly unavailable while the first
+            # responses are still being aggregated — surface as pollable, not error.
+            return {
+                "order_id": order.id,
+                "status": status,
+                "result_status": "pending",
+                "detail": f"Results not available yet: {e}",
+                "results": None,
+            }
+
+        return {
+            "order_id": order.id,
+            "status": status,
+            "result_status": "complete" if finished else "partial",
+            **summarize_results(results, include_details, max_datapoints),
+        }
+
+    @mcp.tool()
+    def list_tasks(name_contains: str = "", limit: int = 10) -> dict[str, Any]:
+        """List your most recent tasks, newest first."""
+        orders = provider.get_client().order.find_orders(
+            name=name_contains, amount=limit
+        )
+        return {
+            "tasks": [
+                {
+                    "order_id": o.id,
+                    "name": o.name,
+                    "status": o.get_status(),
+                    "details_url": o.order_details_page,
+                }
+                for o in orders
+            ]
+        }
+
+    @mcp.tool()
+    def pause_task(order_id: str) -> dict[str, Any]:
+        """Pause a running task to stop collecting further responses (and spending)."""
+        order = _order(order_id)
+        order.pause()
+        return {"order_id": order.id, "status": order.get_status(), "paused": True}
+
+    return mcp
+
+
+def main() -> None:
+    """Console-script entry point."""
+    try:
+        server = build_server()
+    except ImportError as e:
+        raise SystemExit(
+            "The Rapidata MCP server requires the 'mcp' extra. "
+            "Install it with: pip install 'rapidata[mcp]'"
+        ) from e
+    transport = os.environ.get("RAPIDATA_MCP_TRANSPORT", "stdio")
+    server.run(transport=transport)  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -769,6 +769,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1313,6 +1322,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -2292,6 +2326,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2307,6 +2355,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2375,6 +2428,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2390,6 +2452,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -2570,7 +2657,7 @@ wheels = [
 
 [[package]]
 name = "rapidata"
-version = "3.15.1"
+version = "3.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -2591,6 +2678,11 @@ dependencies = [
     { name = "requests" },
     { name = "tinytag" },
     { name = "tqdm" },
+]
+
+[package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
 ]
 
 [package.dev-dependencies]
@@ -2623,6 +2715,7 @@ requires-dist = [
     { name = "diskcache", specifier = ">=5.6.3,<6" },
     { name = "hatchling", specifier = ">=1.28.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.8.0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
@@ -2636,6 +2729,7 @@ requires-dist = [
     { name = "tinytag", specifier = ">=2.0.0,<3" },
     { name = "tqdm", specifier = ">=4.66.5,<5" },
 ]
+provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2968,6 +3062,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2979,6 +3086,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -3160,6 +3280,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds an **MCP server** that lets MCP-capable agents (Claude Desktop, Cursor, IDE assistants, custom clients) run Rapidata labeling tasks directly via tool calls — a thin wrapper over this SDK. This is **Stage 1** of the customer-facing MCP roadmap.

### Tools (7)
| Tool | Purpose |
|---|---|
| `create_classification_task` | Humans pick one option per item. Draft only — no spend. |
| `create_comparison_task` | Pairwise comparison (choose between two). Draft only — no spend. |
| `run_task` | Start collecting responses — **the single step that spends.** |
| `get_task_status` | Current status. |
| `get_task_results` | Partial while running, final once complete; **never blocks.** |
| `list_tasks` | Recent tasks. |
| `pause_task` | Stop collecting (and spending). |

## Design choices

- **Optional extra.** `pip install "rapidata[mcp]"`, console script `rapidata-mcp` (or `python -m rapidata.mcp`). Default install is unchanged; `mcp` is not pulled in unless the extra is requested.
- **Two explicit seams** so later roadmap stages are additive, not a rewrite:
  - *Auth* — tools resolve their client through a `ClientProvider`. Stage 1 uses `EnvClientProvider` (ambient/BYO creds). A hosted, multi-tenant transport plugs in a `TokenClientProvider` (the SDK already accepts a `token=`, so no SDK change is needed to get there).
  - *Transport* — selected by `RAPIDATA_MCP_TRANSPORT` (default `stdio`); flipping to `streamable-http` is config.
- **Spending is explicit.** Creating never spends; `create_*` returns `total_responses` (datapoints × responses_per_datapoint) as the honest cost driver — the SDK exposes no price estimate, so none is fabricated. `run_task` is the only spend step.
- **Results never block.** `get_task_results` uses preliminary snapshots while processing and the final file once complete; per-annotator detail is omitted unless `include_details=true`, and datapoints are capped.
- **stdio safety.** `silent_mode` is forced on so the SDK never prints to stdout (the JSON-RPC channel); logging already goes to stderr.

## Scope / not in this PR
URL datapoints only (no local upload), classify + compare only, default audience (no targeting/filters), no validation sets / signals / flows / leaderboards, no hosting. Those are later stages.

The order-manager API used here is marked deprecated in the SDK in favour of `job` + `audience`; kept for Stage 1 simplicity, migration is a sensible follow-up.

## Testing
- Server builds and registers all 7 tools; `silent_mode`/OTLP forced off.
- End-to-end stdio handshake via the MCP client: `initialize` + `tools/list` succeed, input schemas/required fields correct, stdout stays clean JSON-RPC.
- `black` clean; `pyright src/rapidata/mcp` → 0 errors (note: CI's pyright is scoped to `rapidata_client`, and the `mcp` dep is only in the optional extra, so the new package is intentionally outside the CI type-check include).

🔗 Session: https://session-7604b651.poseidon.rapidata.internal/

🤖 Generated with [Claude Code](https://claude.com/claude-code)