### PR TITLE
chore(github): add CODEOWNERS for default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewers for the whole repo, auto-requested as reviewers on every PR
+# once the "Require review from Code Owners" branch-protection rule is enabled.
+* @LinoGiger


### PR DESCRIPTION
Adds a repo-wide `.github/CODEOWNERS` so the default reviewers are auto-requested on every PR — once the **Require review from Code Owners** branch-protection rule is enabled on `main`.

Owners: @LinoGiger

Part of the org-wide CODEOWNERS rollout that feeds Poseidon's review-request inbox.

🔗 Session: https://node-8af68d78a71f.poseidon.rapidata.internal/