### PR TITLE
feat(auth): request the api scope for backend access

### DIFF
--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -67,7 +67,7 @@ class RapidataClient:
         client_id: str | None = None,
         client_secret: str | None = None,
         environment: str | None = None,
-        oauth_scope: str = "openid roles email",
+        oauth_scope: str = "openid roles email api",
         cert_path: str | None = None,
         token: dict | None = None,
         leeway: int = 60,
@@ -171,9 +171,7 @@ class RapidataClient:
             self.mri = RapidataBenchmarkManager(openapi_service=self._openapi_service)
 
             logger.debug("Initializing RapidataSignalManager")
-            self.signals = RapidataSignalManager(
-                openapi_service=self._openapi_service
-            )
+            self.signals = RapidataSignalManager(openapi_service=self._openapi_service)
 
             logger.debug("Initializing RapidataAudienceManager")
             self.audience = RapidataAudienceManager(

--- a/src/rapidata/service/credential_manager.py
+++ b/src/rapidata/service/credential_manager.py
@@ -268,7 +268,7 @@ class CredentialManager:
         if not bridge_endpoint:
             return None
 
-        auth_url = f"{self.endpoint}/connect/authorize/external?clientId=rapidata-cli&scope=openid profile email roles&writeKey={bridge_endpoint.write_key}"
+        auth_url = f"{self.endpoint}/connect/authorize/external?clientId=rapidata-cli&scope=openid profile email roles api&writeKey={bridge_endpoint.write_key}"
         could_open_browser = webbrowser.open(auth_url)
 
         if not could_open_browser:


### PR DESCRIPTION
## What & why

Part of moving the platform to standard OAuth audience validation. The backend will start validating that access tokens carry its audience (`aud=https://api.rapidata.ai`). A token only gets that audience if the client **requests the `api` scope**, so the SDK needs to request it.

Adds `api` to the requested scopes on both auth paths:
- **client-credentials** — the `oauth_scope` default (`"openid roles email"` → `"openid roles email api"`).
- **interactive browser/bridge login** — the `rapidata-cli` authorize URL.

With the existing scope→resource mapping on the identity server, requesting `api` makes the issued access token carry `aud=https://api.rapidata.ai` (+ `scp:api`).

## Why now / safety
This is the **migration driver**: backend audience enforcement will be turned on only after enough customers have upgraded to an SDK version that requests `api` (a 1–2 month window, watched via token telemetry). Shipping this early is safe — the `api` scope is already granted to these clients, so it only *adds* the audience to tokens; nothing changes until enforcement flips.

## Tests / checks
`pyright src/rapidata/rapidata_client` clean; `black` formatted. No auto-generated client files touched (no mustache-template changes needed).

🔗 Session: https://session-d22747c4.poseidon.rapidata.internal/
