### PR TITLE
feat(audience): print job link when assigning to audience

### DIFF
--- a/src/rapidata/rapidata_client/audience/_audience_base.py
+++ b/src/rapidata/rapidata_client/audience/_audience_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from rapidata.rapidata_client.config import logger, tracer
+from rapidata.rapidata_client.config import logger, managed_print, tracer
 
 if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
@@ -86,6 +86,9 @@ class RapidataAudienceBase:
                 openapi_service=self._openapi_service,
             )
             logger.info(f"Assigned job to audience: {self.id}")
+            managed_print(
+                f"Job '{job.name}' is now viewable under: {job.job_details_page}"
+            )
             return job
 
     def find_jobs(


### PR DESCRIPTION
## What

`RapidataAudienceBase.assign_job()` now prints the job's dashboard link after creating the job, mirroring how `RapidataOrder.run()` prints the order link.

## Why

Orders already give you two nudges: creating an order prints a preview QR + dashboard link, and `run()` prints the live order link. Job definitions already had the first half (creating a definition prints the preview QR + dashboard link via `_qr_preview`), but **assigning a job to an audience** — the analog of running an order — printed nothing. This closes that gap so the job flow matches the order flow.

| Step | Order | Job |
|---|---|---|
| Create | `create_*_order` → QR + link | `create_*_job_definition` → QR + link |
| Start | `run()` → order link | `assign_job()` → **job link (new)** |

## Change

One line (plus a `managed_print` import) in `audience/_audience_base.py`:

```
Job '<name>' is now viewable under: https://app.<env>/audiences/<audience_id>/job/<job_id>
```

Wording matches `run()` verbatim, and `managed_print` respects `silent_mode`.

## Checks

- `uv run black src/rapidata/rapidata_client` — clean
- `uv run pyright src/rapidata/rapidata_client` — 0 errors, 0 warnings

🔗 Session: https://session-e5579afc.poseidon.rapidata.internal/