### PR TITLE
feat(tracing): send OTLP traces to the target environment's collector

### DIFF
--- a/src/rapidata/rapidata_client/config/logger.py
+++ b/src/rapidata/rapidata_client/config/logger.py
@@ -46,6 +46,7 @@ class RapidataLogger:
         self._otlp_handler = None
         self._otlp_enabled = True  # Default to enabled
         self._otlp_attached = False
+        self._environment = "rapidata.ai"
 
         # Register this logger to receive configuration updates
         register_config_handler(self._handle_config_update)
@@ -75,7 +76,7 @@ class RapidataLogger:
                 set_logger_provider(logger_provider)
 
                 exporter = OTLPLogExporter(
-                    endpoint="https://otlp-sdk.rapidata.ai/v1/logs",
+                    endpoint=f"https://otlp-sdk.{self._environment}/v1/logs",
                     timeout=30,
                 )
 
@@ -104,6 +105,7 @@ class RapidataLogger:
         """Update the logger based on the new configuration."""
         self._otlp_enabled = config.enable_otlp
         self._otlp_attached = False
+        self._environment = config.environment
 
         # Console handler with configurable level
         console_handler = logging.StreamHandler()

--- a/src/rapidata/rapidata_client/config/logging_config.py
+++ b/src/rapidata/rapidata_client/config/logging_config.py
@@ -42,6 +42,8 @@ class LoggingConfig(BaseModel):
         silent_mode (bool): Whether to disable the prints and progress bars. Does NOT affect the logging. Defaults to False.
         enable_otlp (bool): Whether to enable OpenTelemetry trace logs. Defaults to True.
             Can also be disabled via the RAPIDATA_DISABLE_OTLP=1 environment variable.
+        environment (str): The API environment the client targets, used to derive the
+            OTLP collector host (``otlp-sdk.<environment>``). Set by RapidataClient.
     """
 
     @model_validator(mode="before")
@@ -56,6 +58,7 @@ class LoggingConfig(BaseModel):
     format: str = Field(default="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     silent_mode: bool = Field(default=False)
     enable_otlp: bool = Field(default_factory=_default_enable_otlp)
+    environment: str = Field(default="rapidata.ai")
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/src/rapidata/rapidata_client/config/tracer.py
+++ b/src/rapidata/rapidata_client/config/tracer.py
@@ -132,6 +132,7 @@ class RapidataTracer:
         self._real_tracer = None
         self._no_op_tracer = NoOpTracer()
         self._enabled = True  # Default to enabled
+        self._environment = "rapidata.ai"
         self.session_id: str | None = None
         self.client_id: str | None = None
         self.email: str | None = None
@@ -146,6 +147,7 @@ class RapidataTracer:
     def _update_tracer(self, config: LoggingConfig) -> None:
         """Update the tracer based on the new configuration."""
         self._enabled = config.enable_otlp
+        self._environment = config.environment
 
     def _ensure_initialized(self) -> None:
         """Lazily initialize OTLP tracing on first use."""
@@ -168,7 +170,7 @@ class RapidataTracer:
                 self._tracer_provider = TracerProvider(resource=resource)
 
                 exporter = OTLPSpanExporter(
-                    endpoint="https://otlp-sdk.rapidata.ai/v1/traces",
+                    endpoint=f"https://otlp-sdk.{self._environment}/v1/traces",
                     timeout=30,
                 )
 

--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -58,6 +58,11 @@ _USERINFO_CACHE_TTL_SECONDS = 24 * 60 * 60
 _userinfo_cache: dict[tuple[str, str], _UserInfoCacheEntry] = {}
 _userinfo_cache_lock = threading.Lock()
 
+# Environments with a deployed SDK OTLP collector at otlp-sdk.<environment>.
+# Other environments (e.g. local rapidata.dev) have no collector, so OTLP is
+# left disabled there to avoid noisy failed exports.
+_OTLP_COLLECTOR_ENVIRONMENTS = frozenset({"rapidata.ai", "rabbitdata.ch"})
+
 
 class RapidataClient:
     """The Rapidata client is the main entry point for interacting with the Rapidata API. It allows you to create orders and validation sets."""
@@ -134,11 +139,13 @@ class RapidataClient:
         self._client_id = client_id
         self._environment = environment
 
+        rapidata_config.logging.environment = environment
+        if environment not in _OTLP_COLLECTOR_ENVIRONMENTS:
+            rapidata_config.logging.enable_otlp = False
+
         with tracer.start_as_current_span("RapidataClient.__init__"):
             logger.debug("Checking version")
             self._check_version()
-            if environment != "rapidata.ai":
-                rapidata_config.logging.enable_otlp = False
 
             logger.debug("Initializing OpenAPIService")
             self._openapi_service = OpenAPIService(


### PR DESCRIPTION
## What

SDK traces (and logs) only ever reached the **prod** collector. Two things blocked non-prod:

1. `RapidataClient.__init__` disabled OTLP entirely whenever `environment != "rapidata.ai"`.
2. The trace/log exporters hard-coded `https://otlp-sdk.rapidata.ai/v1/{traces,logs}`.

This derives the collector host from the client's `environment` — `otlp-sdk.<environment>` — the same way `api.<env>` / `auth.<env>` are built, and enables OTLP for the environments that actually have a deployed collector.

## Environments

| Environment | `environment` string | Collector | Traces |
|---|---|---|---|
| prod | `rapidata.ai` | `otlp-sdk.rapidata.ai` | ✅ (unchanged) |
| **test** | `rabbitdata.ch` | `otlp-sdk.rabbitdata.ch` | ✅ now on |
| dev (local) | `rapidata.dev` | — | ⏸️ left off (no collector) |

The test collector already exists — `infrastructure`'s `observability/overlays/test/httproute-otlp-sdk.yaml` routes `otlp-sdk.rabbitdata.ch`, and `POST /v1/traces` returns 200 (verified against both prod and test). Local dev is intentionally excluded (per request): its local collector is exposed under a different host (`otlp.rapidata.dev`) and uses a self-signed cert, so enabling it there would only produce failed exports. Unknown environments stay off for the same reason.

## How

- `LoggingConfig` gains an `environment` field (the existing config-update channel the tracer/logger already listen on).
- `RapidataTracer` / `RapidataLogger` build their endpoint from that value.
- `RapidataClient` sets `environment` on the config and enables OTLP only for `_OTLP_COLLECTOR_ENVIRONMENTS` (prod + test).

## Checks

- `pyright src/rapidata/rapidata_client` → 0 errors.
- Verified endpoint derivation + gating for prod/test/dev.

🔗 Session: https://session-7f001dc5.poseidon.rapidata.internal/