### PR TITLE
docs(mri): document leaderboard jobs property

### DIFF
--- a/docs/mri.md
+++ b/docs/mri.md
@@ -197,8 +197,20 @@ leaderboard = benchmark.leaderboards[0]
 
 # Get the standings
 standings = leaderboard.get_standings() # Returns a pandas dataframe
-
-# Access the jobs that ran for this leaderboard
-for job in leaderboard.jobs:
-    results = job.get_results()
 ```
+
+Every model evaluation on a leaderboard is carried out by a **job**. The `jobs`
+property exposes those jobs so you can drill into the raw comparison results
+behind the standings:
+
+```python
+# All jobs that have run for this leaderboard (most recent first)
+for job in leaderboard.jobs:
+    print(job.name, job.get_status())
+    results = job.get_results() # RapidataResults for that evaluation
+```
+
+Each entry is a full `RapidataJob`, so the usual methods (`get_results()`,
+`get_status()`, `view()`, ...) are available. See
+[Model Ranking Insights Advanced](mri_advanced.md#accessing-the-underlying-jobs)
+for more.

--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -201,6 +201,34 @@ participant = benchmark.participants[0]
 participant.delete()
 ```
 
+## Accessing the Underlying Jobs
+
+The standings and win/loss matrix are aggregates. If you need the raw responses
+behind them, use the leaderboard's `jobs` property: every model evaluation on a
+leaderboard runs as a job, and this returns all of them, most recent first.
+
+```python
+leaderboard = benchmark.leaderboards[0]
+
+jobs = leaderboard.jobs # list[RapidataJob], newest first
+print(f"{len(jobs)} evaluations have run for this leaderboard")
+```
+
+Each item is a full `RapidataJob`, so you can pull the detailed comparison
+results, check status, or open a job in the dashboard:
+
+```python
+for job in leaderboard.jobs:
+    if job.get_status() != "Completed":
+        continue
+
+    results = job.get_results() # RapidataResults — the individual matchups
+    df = results.to_pandas()    # or work with the raw dict directly
+```
+
+Runs that don't yet have an associated job (for example, an evaluation still
+being set up) are skipped, so the list only contains jobs you can act on.
+
 ## References
 - [RapidataBenchmarkManager](/reference/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager/)
 - [RapidataBenchmark](/reference/rapidata/rapidata_client/benchmark/rapidata_benchmark/)


### PR DESCRIPTION
## What

Expands the documentation for the `RapidataLeaderboard.jobs` property added in #651.

- **`docs/mri.md`** — the "Retrieving Results" section now explains that each evaluation runs as a job and shows how to iterate `leaderboard.jobs`, with a pointer to the advanced guide.
- **`docs/mri_advanced.md`** — adds an "Accessing the Underlying Jobs" section covering how to reach the raw comparison results behind the standings via `job.get_results()` / `.to_pandas()`, and notes that runs without an associated job are skipped.

## Notes

- `uv run --group docs mkdocs build` succeeds (remaining warnings are pre-existing and unrelated).
- Docs-only change.

🔗 Session: https://session-ed5c819e.poseidon.rapidata.internal/