### PR TITLE
docs: use job.view() instead of job_definition.preview() in examples

### DIFF
--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -92,9 +92,8 @@ job_definition = client.job.create_compare_job_definition(
     contexts=["A small blue book sitting on a large red book."]
 )
 
-job_definition.preview()
-
 job = audience.assign_job(job_definition)
+job.view()
 job.display_progress_bar()
 results = job.get_results()
 print(results)
@@ -150,9 +149,8 @@ job_definition = client.job.create_compare_job_definition(
     contexts=["A small blue book sitting on a large red book."]
 )
 
-job_definition.preview()
-
 job = audience.assign_job(job_definition)
+job.view()
 job.display_progress_bar()
 results = job.get_results()
 print(results)

--- a/docs/confidence_stopping.md
+++ b/docs/confidence_stopping.md
@@ -83,8 +83,8 @@ job_definition = client.job.create_classification_job_definition(
     confidence_threshold=0.99, # (2)!
 )
 
-job_definition.preview()
 job = audience.assign_job(job_definition)
+job.view()
 job.display_progress_bar()
 results = job.get_results()
 print(results)
@@ -229,8 +229,8 @@ job_definition = client.job.create_classification_job_definition(
     quorum_threshold=7, # (2)!
 )
 
-job_definition.preview()
 job = audience.assign_job(job_definition)
+job.view()
 job.display_progress_bar()
 results = job.get_results()
 print(results)

--- a/docs/examples/classify_job.md
+++ b/docs/examples/classify_job.md
@@ -33,9 +33,8 @@ In this example, we rate images on a Likert scale to assess how well generated i
         settings=[NoShuffleSetting()] # (2)!
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)
@@ -98,9 +97,8 @@ In this example, we rate images on a Likert scale to assess how well generated i
         settings=[NoShuffleSetting()]
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)

--- a/docs/examples/compare_job.md
+++ b/docs/examples/compare_job.md
@@ -39,9 +39,8 @@ In this example, we compare images from two image generation models (Flux and Mi
         contexts=PROMPTS
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)
@@ -117,9 +116,8 @@ In this example, we compare images from two image generation models (Flux and Mi
         contexts=PROMPTS
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)

--- a/docs/examples/draw_job.md
+++ b/docs/examples/draw_job.md
@@ -31,9 +31,8 @@ Like any other job, a draw job can be assigned to any audience — a ready-to-go
         responses_per_datapoint=35,
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)
@@ -95,9 +94,8 @@ Like any other job, a draw job can be assigned to any audience — a ready-to-go
         responses_per_datapoint=35,
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)

--- a/docs/examples/free_text_job.md
+++ b/docs/examples/free_text_job.md
@@ -19,9 +19,8 @@ job_definition = client.job.create_free_text_job_definition(
     datapoints=["https://assets.rapidata.ai/ai_question.png"],
 )
 
-job_definition.preview()
-
 job = audience.assign_job(job_definition)
+job.view()
 job.display_progress_bar()
 results = job.get_results()
 print(results)

--- a/docs/examples/locate_job.md
+++ b/docs/examples/locate_job.md
@@ -30,9 +30,8 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
         responses_per_datapoint=35,
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)
@@ -94,9 +93,8 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
         responses_per_datapoint=35,
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)

--- a/docs/examples/ranking_job.md
+++ b/docs/examples/ranking_job.md
@@ -36,9 +36,8 @@ job_definition = client.job.create_ranking_job_definition(
     random_comparisons_ratio=0.5, # (4)!
 )
 
-job_definition.preview()
-
 job = audience.assign_job(job_definition)
+job.view()
 job.display_progress_bar()
 results = job.get_results()
 print(results)

--- a/docs/examples/select_words_job.md
+++ b/docs/examples/select_words_job.md
@@ -43,9 +43,8 @@ Like any other job, a select words job can be assigned to any audience — a rea
         responses_per_datapoint=15,
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)
@@ -131,9 +130,8 @@ Like any other job, a select words job can be assigned to any audience — a rea
         responses_per_datapoint=15,
     )
 
-    job_definition.preview()
-
     job = audience.assign_job(job_definition)
+    job.view()
     job.display_progress_bar()
     results = job.get_results()
     print(results)

--- a/docs/human_prompting.md
+++ b/docs/human_prompting.md
@@ -133,7 +133,7 @@ answer_options=["1: Perfectly",
 
 After assigning your job to an audience, monitor the initial responses to see if labelers are understanding your instructions as intended.
 
-You can see how users experience the task by calling the `.view()` method on the running job:
+You can watch the responses come in by calling the `.view()` method on the running job:
 ```python
 job.view()
 ```

--- a/docs/human_prompting.md
+++ b/docs/human_prompting.md
@@ -89,7 +89,8 @@ job_definition = client.job.create_compare_job_definition(
     ]
 )
 
-job_definition.preview()
+job = audience.assign_job(job_definition)
+job.view()
 ```
 
 ## Common Task Types and Recommended Instructions
@@ -132,9 +133,9 @@ answer_options=["1: Perfectly",
 
 After assigning your job to an audience, monitor the initial responses to see if labelers are understanding your instructions as intended.
 
-You can preview how users will see the task by calling the `.preview()` method on the job definition:
+You can see how users experience the task by calling the `.view()` method on the running job:
 ```python
-job_definition.preview()
+job.view()
 ```
 
 If you see that labelers are giving inconsistent or incorrect answers:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ results = job.get_results() # (3)!
 ```
 
 1. Assigns the job definition to the audience and starts collecting responses.
-2. Opens your browser on the running job so you can see exactly what labelers see.
+2. Opens your browser on the running job, where you can watch responses come in and monitor progress.
 3. Blocks until the job is complete and returns the results. You can also monitor progress on the [Rapidata Dashboard](https://app.rapidata.ai/dashboard).
 
 To understand the results format, see the [Understanding the Results](understanding_the_results.md) guide.
@@ -176,7 +176,7 @@ results = job.get_results()
 print(results)
 ```
 
-1. Optional — opens a browser on the running job so you can see what labelers see.
+1. Optional — opens a browser on the running job to watch responses come in and monitor progress.
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,26 +94,18 @@ job_definition = client.job.create_compare_job_definition(
 
 For a detailed explanation of all available parameters (including name, instruction, datapoints, contexts, quality control options, and more), see the [Job Definition Parameters Reference](job_definition_parameters.md).
 
-### Step 3: Preview the Job Definition
-
-Before running your job, preview it to see exactly what labelers will see:
-
-```py
-job_definition.preview() # (1)!
-```
-
-1. Opens your browser where you can review and adjust the job configuration.
-
-### Step 4: Run and Get Results
+### Step 3: Run and Get Results
 
 ```py
 job = audience.assign_job(job_definition) # (1)!
+job.view() # (2)!
 job.display_progress_bar()
-results = job.get_results() # (2)!
+results = job.get_results() # (3)!
 ```
 
 1. Assigns the job definition to the audience and starts collecting responses.
-2. Blocks until the job is complete and returns the results. You can also monitor progress on the [Rapidata Dashboard](https://app.rapidata.ai/dashboard).
+2. Opens your browser on the running job so you can see exactly what labelers see.
+3. Blocks until the job is complete and returns the results. You can also monitor progress on the [Rapidata Dashboard](https://app.rapidata.ai/dashboard).
 
 To understand the results format, see the [Understanding the Results](understanding_the_results.md) guide.
 
@@ -177,15 +169,14 @@ job_definition = client.job.create_compare_job_definition(
     contexts=["A small blue book sitting on a large red book."]
 )
 
-job_definition.preview() # (1)!
-
 job = audience.assign_job(job_definition)
+job.view() # (1)!
 job.display_progress_bar()
 results = job.get_results()
 print(results)
 ```
 
-1. Optional — opens a browser preview of what labelers will see.
+1. Optional — opens a browser on the running job so you can see what labelers see.
 
 ## Next Steps
 


### PR DESCRIPTION
## What

Across the SDK docs, the labeling-task examples called `job_definition.preview()` on the **unassigned** job definition *before* running it. This switches them to `job.view()` on the **running** job — called right after `audience.assign_job(...)` — so readers open the actual running job instead of a preview of the configuration.

## Why

Per request: the examples should show viewing the actual running jobs, not previewing the definition. This also aligns every example with `starting_page.md`, which already used `job.view()`.

## Changes

- Moved the call from `job_definition.preview()` (pre-`assign_job`) to `job.view()` (post-`assign_job`) in all example blocks.
- `quickstart.md`: merged the separate "Preview" step into "Run and Get Results" and renumbered the annotations.
- `human_prompting.md`: updated the prose describing the method accordingly.
- No source/interface changes — docs only. `mkdocs build` passes (pre-existing warnings unrelated).

🔗 Session: https://session-7617df5c.poseidon.rapidata.internal/