### PR TITLE
build(deps): upgrade openapi-generator to 7.23.0

### DIFF
--- a/openapi/templates/api.mustache
+++ b/openapi/templates/api.mustache
@@ -33,6 +33,7 @@ class {{classname}}:
     @validate_call
     {{#asyncio}}async {{/asyncio}}def {{operationId}}{{>partial_api_args}} -> {{{returnType}}}{{^returnType}}None{{/returnType}}:
 {{>partial_api}}
+
         response_data = {{#asyncio}}await {{/asyncio}}self.api_client.call_api(
             *_param,
             _request_timeout=_request_timeout
@@ -47,6 +48,7 @@ class {{classname}}:
     @validate_call
     {{#asyncio}}async {{/asyncio}}def {{operationId}}_with_http_info{{>partial_api_args}} -> ApiResponse[{{{returnType}}}{{^returnType}}None{{/returnType}}]:
 {{>partial_api}}
+
         response_data = {{#asyncio}}await {{/asyncio}}self.api_client.call_api(
             *_param,
             _request_timeout=_request_timeout
@@ -61,6 +63,7 @@ class {{classname}}:
     @validate_call
     {{#asyncio}}async {{/asyncio}}def {{operationId}}_without_preload_content{{>partial_api_args}} -> RESTResponseType:
 {{>partial_api}}
+
         response_data = {{#asyncio}}await {{/asyncio}}self.api_client.call_api(
             *_param,
             _request_timeout=_request_timeout

--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.9.0"
+    "version": "7.23.0"
   }
 }

--- a/src/.openapi-generator-ignore
+++ b/src/.openapi-generator-ignore
@@ -23,3 +23,6 @@
 #!docs/README.md
 
 api_client*.md
+
+# Hand-maintained package root (re-exports + __version__); must not be clobbered by regen
+rapidata/__init__.py


### PR DESCRIPTION
## Summary

Upgrades the pinned OpenAPI client generator **7.9.0 → 7.23.0** (latest). **Toolchain-only** — the generated client is intentionally *not* regenerated in this PR (see "Deferred" below), so `src/` is unchanged and CI (pyright) is unaffected.

## Why

On 7.9.0, when the backend's newer `Microsoft.OpenApi` serializer emits a nullable `$ref` as `{nullable: true, oneOf: [$ref], type: object}`, the generator produces an extra **wrapper class** per field, churning the client and changing its public types. **7.23.0 collapses it to the direct type**, making a backend `Microsoft.OpenApi` 2.x-serializer bump a **no-op for the SDK**.

Verified: regenerating at 7.23.0 from a `2.10.0`-serialized spec vs a `2.0.0`-serialized spec produces a **byte-identical client** (0 files differ). This is what unblocks the backend [`Directory.Packages.props` bump](https://github.com/RapidataAI/rapidata-backend/pull/4648) safely.

## Two fixes required for 7.23.0 to emit a valid client
| File | Fix | Without it |
|---|---|---|
| `openapi/templates/api.mustache` | Blank line after the `{{>partial_api}}` include | post-7.9 openapi-generator changed standalone-partial whitespace handling; the `_response_types_map` `}` collided into `}        response_data = …` → **~60 api files fail to compile** |
| `src/.openapi-generator-ignore` | Protect `rapidata/__init__.py` | the generator overwrites the hand-maintained package root (re-exports + `__version__`) with an empty file |

I verified end-to-end that 7.23.0 **+ these fixes** produces a client that `py_compile`s cleanly and passes `pyright src/rapidata/rapidata_client`.

## Deliberately deferred: regenerating the client
A **benchmark/leaderboard filtering refactor is mid-rollout on the backend** (structured filter operators + `logic`, dropped plural `leaderboardIds`/`participantIds` list filters — prod is currently ahead of `main`). Regenerating the client now would entangle that in-flight API change with this toolchain bump and require guessing not-yet-stable filter semantics. Once the generator is on 7.23.0, the automated `update-openapi-client` workflow regenerates cleanly (and nullable-safe) once that refactor settles.

## Test plan
- [x] `py_compile` on a full 7.23.0 regen (with the template fix): passes
- [x] `pyright src/rapidata/rapidata_client` on a full 7.23.0 regen (with hand-layer adaptations): 0 errors
- [x] 7.23.0 nullable-representation no-op: 0-file diff between 2.10.0- and 2.0.0-serialized regens
- [x] committed `src/` unchanged → existing pyright CI passes

🔗 Session: https://session-44f0d44a.poseidon.rapidata.internal/