### PR TITLE
feat(sdk): send responsesRequired in NaiveReferee config

### DIFF
--- a/src/rapidata/rapidata_client/referee/_naive_referee.py
+++ b/src/rapidata/rapidata_client/referee/_naive_referee.py
@@ -31,7 +31,7 @@ class NaiveReferee(Referee):
     def _to_dict(self):
         return {
             "_t": "NaiveRefereeConfig",
-            "guessesRequired": self.responses,
+            "responsesRequired": self.responses,
         }
 
     def _to_model(self) -> IRefereeModel:


### PR DESCRIPTION
Completes the `guess` → `response` rename in the SDK by switching the wire field sent from `NaiveReferee._to_dict()` from `guessesRequired` to `responsesRequired`.

This was the only remaining hand-written `guess` reference (the local attribute was already named `responses`; no `examples/` or docs references exist). The auto-generated `api_client/` is left untouched — it is regenerated from the backend OpenAPI and will keep exposing `guessesRequired` until the deprecation window closes.

**Non-breaking:** the deployed backend accepts both keys — `ResponsesRequired` is the real field and `GuessesRequired` is an `[Obsolete]` alias mapping to it (accept-both window, verified on the deployed `NaiveRefereeConfigModel`).

Validated: `python3 -c "from rapidata import RapidataClient; print('OK')"`, `black`, `pyright` (0 errors).

🔗 Session: https://node-24e8c5c1.poseidon.rapidata.internal/