### PR TITLE
feat(settings): make feature-flag settings task-type-aware

### DIFF
--- a/docs/job_definition_parameters.md
+++ b/docs/job_definition_parameters.md
@@ -295,6 +295,8 @@ Settings allow you to customize how tasks are displayed.
 | **Required** | No |
 | **Default** | `[]` |
 
+Most settings only apply to specific task types (see each setting's docstring, e.g. *"Supported task types: Compare."*). If you add a setting that the job's task type does not support, the SDK logs a non-fatal warning and still sends the flag — it is never dropped and no error is raised. Ranking jobs are treated as Compare for this check.
+
 ### Commonly Used Settings
 
 #### `NoShuffleSetting()`

--- a/scripts/generate_settings.py
+++ b/scripts/generate_settings.py
@@ -5,6 +5,7 @@ Usage:
     uv run python scripts/generate_settings.py <path-to-settings.json>          # Generate all files
     uv run python scripts/generate_settings.py <path-to-settings.json> --check  # Verify files are up-to-date
 """
+
 from __future__ import annotations
 
 import json
@@ -25,6 +26,27 @@ GENERATED_HEADER = (
 HANDWRITTEN_FILES = {
     "_rapidata_setting.py",
     "custom_setting.py",
+}
+
+# Which task types honor each setting, keyed by class_name. Absent == "all"
+# (every task type). Values use the SDK public task-type names.
+#
+# This is the SDK's hand-mirrored copy of the shared support matrix. There is no
+# package shared across the three repos, so keep this in sync with rapids-frontend's
+# FEATURE_FLAG_SUPPORTED_RAPID_TYPES (src/types/rapid.ts, the source of truth) and
+# app-frontend's supportedRapidTypes catalog field. New settings not listed here
+# default to "all" (no filtering / no warning), which is the safe fallback.
+SUPPORTED_RAPID_TYPES: dict[str, tuple[str, ...]] = {
+    "NoShuffleSetting": ("Classification", "Compare"),
+    "AllowNeitherBothSetting": ("Compare",),
+    "ComparePanoramaSetting": ("Compare",),
+    "CompareEquirectangularSetting": ("Compare",),
+    "ClassifyEquirectangularSetting": ("Classification",),
+    "FreeTextMinimumCharactersSetting": ("Free Text",),
+    "FreeTextMaxCharactersSetting": ("Free Text",),
+    "KeyboardNumericSetting": ("Free Text",),
+    "LocateMaxPointsSetting": ("Locate",),
+    "LocateMinPointsSetting": ("Locate",),
 }
 
 
@@ -57,15 +79,24 @@ def generate_setting_module(s: dict[str, Any]) -> str:
     lines.append("from __future__ import annotations\n")
 
     has_warnings = s.get("warnings") is not None
+    supported = SUPPORTED_RAPID_TYPES.get(s["class_name"], "all")
+    has_supported = supported != "all"
 
-    lines.append(
-        "from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting"
-    )
+    if has_supported:
+        lines.append("from typing import ClassVar")
+        lines.append(
+            "from rapidata.rapidata_client.settings._rapidata_setting import (\n"
+            "    RapidataSetting,\n"
+            "    SupportedRapidTypes,\n"
+            ")"
+        )
+    else:
+        lines.append(
+            "from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting"
+        )
 
     if has_warnings:
-        lines.append(
-            "from rapidata.rapidata_client.config import managed_print"
-        )
+        lines.append("from rapidata.rapidata_client.config import managed_print")
 
     lines.append("")
     lines.append("")
@@ -86,6 +117,9 @@ def generate_setting_module(s: dict[str, Any]) -> str:
         else:
             lines.append("")
     lines.append("")
+    supported_str = "all" if supported == "all" else ", ".join(supported)
+    lines.append(f"    Supported task types: {supported_str}.")
+    lines.append("")
     lines.append("    Args:")
 
     # Build type annotation string for docstring
@@ -95,12 +129,22 @@ def generate_setting_module(s: dict[str, Any]) -> str:
             f"        {param_name} ({type_str}, optional): {param_description}"
         )
     else:
-        lines.append(
-            f"        {param_name} ({type_str}): {param_description}"
-        )
+        lines.append(f"        {param_name} ({type_str}): {param_description}")
 
     lines.append('    """')
     lines.append("")
+
+    # Machine-readable support matrix (metadata only; not serialized).
+    if has_supported:
+        # Match black's tuple formatting so regeneration stays idempotent.
+        if len(supported) == 1:
+            tuple_repr = f'("{supported[0]}",)'
+        else:
+            tuple_repr = "(" + ", ".join(f'"{t}"' for t in supported) + ")"
+        lines.append(
+            f"    supported_rapid_types: ClassVar[SupportedRapidTypes] = {tuple_repr}"
+        )
+        lines.append("")
 
     # __init__ signature
     if default is not None:
@@ -117,9 +161,7 @@ def generate_setting_module(s: dict[str, Any]) -> str:
     # Validation
     if value_type == "bool":
         lines.append(f"        if not isinstance({param_name}, bool):")
-        lines.append(
-            f'            raise ValueError("The value must be a boolean.")'
-        )
+        lines.append(f'            raise ValueError("The value must be a boolean.")')
 
     validation = s.get("validation")
     if validation:
@@ -164,14 +206,10 @@ def generate_setting_module(s: dict[str, Any]) -> str:
 
     # super().__init__
     if validation or warnings_def:
-        lines.append(
-            f'        super().__init__(key="{s["key"]}", value={param_name})'
-        )
+        lines.append(f'        super().__init__(key="{s["key"]}", value={param_name})')
     else:
         lines.append("")
-        lines.append(
-            f'        super().__init__(key="{s["key"]}", value={param_name})'
-        )
+        lines.append(f'        super().__init__(key="{s["key"]}", value={param_name})')
 
     lines.append("")
     return "\n".join(lines)
@@ -203,15 +241,15 @@ def generate_rapidata_settings(settings: list[dict[str, Any]]) -> str:
     for s in settings:
         file_name = s["file_name"]
         class_name = s["class_name"]
-        lines.append(f"from rapidata.rapidata_client.settings.{file_name} import {class_name}")
+        lines.append(
+            f"from rapidata.rapidata_client.settings.{file_name} import {class_name}"
+        )
 
     lines.append("")
     lines.append("")
     lines.append("class RapidataSettings:")
     lines.append('    """')
-    lines.append(
-        "    Container class for all setting factory functions"
-    )
+    lines.append("    Container class for all setting factory functions")
     lines.append("")
     lines.append(
         "    Settings can be added to an order to determine the behaviour of the task."
@@ -223,9 +261,7 @@ def generate_rapidata_settings(settings: list[dict[str, Any]]) -> str:
         container_name = s["container_name"]
         class_name = s["class_name"]
         short_desc = s["description"].split("\n")[0]
-        lines.append(
-            f"        {container_name} ({class_name}): {short_desc}"
-        )
+        lines.append(f"        {container_name} ({class_name}): {short_desc}")
 
     lines.append("")
     lines.append("    Example:")
@@ -279,8 +315,12 @@ def generate_types_imports_block(settings: list[dict[str, Any]]) -> str:
         lines.append(
             f"from rapidata.rapidata_client.settings.{s['file_name']} import {s['class_name']}"
         )
-    lines.append("from rapidata.rapidata_client.settings.custom_setting import CustomSetting")
-    lines.append("from rapidata.rapidata_client.settings.rapidata_settings import RapidataSettings")
+    lines.append(
+        "from rapidata.rapidata_client.settings.custom_setting import CustomSetting"
+    )
+    lines.append(
+        "from rapidata.rapidata_client.settings.rapidata_settings import RapidataSettings"
+    )
     return "\n".join(lines)
 
 
@@ -296,7 +336,11 @@ def generate_types_all_block(settings: list[dict[str, Any]]) -> str:
 
 
 def replace_between_markers(
-    file_path: Path, start_marker: str, end_marker: str, new_content: str, check_mode: bool
+    file_path: Path,
+    start_marker: str,
+    end_marker: str,
+    new_content: str,
+    check_mode: bool,
 ) -> bool:
     """Replace content between marker comments. Returns True if changed."""
     text = file_path.read_text(encoding="utf-8")
@@ -417,7 +461,9 @@ def main():
     # types/__init__.py — imports section
     types_init = REPO_ROOT / "src" / "rapidata" / "types" / "__init__.py"
     block = generate_types_imports_block(settings)
-    if replace_between_markers(types_init, IMPORTS_START, IMPORTS_END, block, check_mode):
+    if replace_between_markers(
+        types_init, IMPORTS_START, IMPORTS_END, block, check_mode
+    ):
         changed_files.append(str(types_init.relative_to(REPO_ROOT)))
     else:
         unchanged_files.append(str(types_init.relative_to(REPO_ROOT)))

--- a/scripts/generate_settings.py
+++ b/scripts/generate_settings.py
@@ -28,26 +28,39 @@ HANDWRITTEN_FILES = {
     "custom_setting.py",
 }
 
-# Which task types honor each setting, keyed by class_name. Absent == "all"
-# (every task type). Values use the SDK public task-type names.
+# The support matrix (which task types honor each setting) is NOT defined here.
+# It is the source of truth in rapids-frontend (FEATURE_FLAG_SUPPORTED_RAPID_TYPES
+# in src/types/rapid.ts) and is baked into settings.json per setting as a
+# `supported_rapid_types` field (rapids-frontend `type` names, or "all"). We only
+# translate those native names into the SDK public task-type names below.
 #
-# This is the SDK's hand-mirrored copy of the shared support matrix. There is no
-# package shared across the three repos, so keep this in sync with rapids-frontend's
-# FEATURE_FLAG_SUPPORTED_RAPID_TYPES (src/types/rapid.ts, the source of truth) and
-# app-frontend's supportedRapidTypes catalog field. New settings not listed here
-# default to "all" (no filtering / no warning), which is the safe fallback.
-SUPPORTED_RAPID_TYPES: dict[str, tuple[str, ...]] = {
-    "NoShuffleSetting": ("Classification", "Compare"),
-    "AllowNeitherBothSetting": ("Compare",),
-    "ComparePanoramaSetting": ("Compare",),
-    "CompareEquirectangularSetting": ("Compare",),
-    "ClassifyEquirectangularSetting": ("Classification",),
-    "FreeTextMinimumCharactersSetting": ("Free Text",),
-    "FreeTextMaxCharactersSetting": ("Free Text",),
-    "KeyboardNumericSetting": ("Free Text",),
-    "LocateMaxPointsSetting": ("Locate",),
-    "LocateMinPointsSetting": ("Locate",),
+# Keep this map in sync with the RapidType union in rapids-frontend's rapid.ts.
+RAPID_TYPE_TO_SDK_TASK_TYPE: dict[str, str] = {
+    "Classify": "Classification",
+    "Compare": "Compare",
+    "FreeText": "Free Text",
+    "Locate": "Locate",
+    "Line": "Draw",
+    "Transcription": "Select Words",
+    "Scrub": "Timestamp",
 }
+
+
+def supported_rapid_types_for(s: dict[str, Any]) -> tuple[str, ...] | str:
+    """Return the setting's supported task types as SDK public names, or "all".
+
+    Reads the ``supported_rapid_types`` field baked into settings.json by
+    rapids-frontend. A missing field (older settings.json) defaults to "all".
+    """
+    raw = s.get("supported_rapid_types", "all")
+    if raw == "all" or not isinstance(raw, list):
+        return "all"
+    mapped: list[str] = []
+    for name in raw:
+        sdk_name = RAPID_TYPE_TO_SDK_TASK_TYPE.get(name, name)
+        if sdk_name not in mapped:
+            mapped.append(sdk_name)
+    return tuple(mapped) if mapped else "all"
 
 
 def class_name_to_file_name(class_name: str) -> str:
@@ -79,7 +92,7 @@ def generate_setting_module(s: dict[str, Any]) -> str:
     lines.append("from __future__ import annotations\n")
 
     has_warnings = s.get("warnings") is not None
-    supported = SUPPORTED_RAPID_TYPES.get(s["class_name"], "all")
+    supported = supported_rapid_types_for(s)
     has_supported = supported != "all"
 
     if has_supported:

--- a/scripts/generate_settings.py
+++ b/scripts/generate_settings.py
@@ -29,12 +29,12 @@ HANDWRITTEN_FILES = {
 }
 
 # The support matrix (which task types honor each setting) is NOT defined here.
-# It is the source of truth in rapids-frontend (FEATURE_FLAG_SUPPORTED_RAPID_TYPES
-# in src/types/rapid.ts) and is baked into settings.json per setting as a
-# `supported_rapid_types` field (rapids-frontend `type` names, or "all"). We only
-# translate those native names into the SDK public task-type names below.
+# It is the source of truth in rapids-frontend's settings.ts and ships in
+# settings.json per setting as a `supported_rapid_types` field (rapids-frontend
+# `type` names, or "all"/omitted for global). We only translate those native
+# names into the SDK public task-type names below.
 #
-# Keep this map in sync with the RapidType union in rapids-frontend's rapid.ts.
+# Keep this map in sync with the RapidType union in rapids-frontend.
 RAPID_TYPE_TO_SDK_TASK_TYPE: dict[str, str] = {
     "Classify": "Classification",
     "Compare": "Compare",

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -37,6 +37,34 @@ class RapidataJobManager:
         self.__priority: int | None = None
         logger.debug("JobManager initialized")
 
+    @staticmethod
+    def _warn_unsupported_settings(
+        workflow: Workflow, settings: Sequence[RapidataSetting]
+    ) -> None:
+        """Warn (never raise) about settings the job's task type does not honor.
+
+        Task-type-agnostic settings (``supported_rapid_types == "all"``, incl.
+        CustomSetting) are skipped. Ranking is compare-based, so it honors
+        Compare-scoped settings. The flag is still sent regardless.
+        """
+        if workflow.task_type is None:
+            return
+
+        effective_task_type = (
+            "Compare" if workflow.task_type == "Ranking" else workflow.task_type
+        )
+        for setting in settings:
+            supported = setting.supported_rapid_types
+            if supported == "all" or effective_task_type in supported:
+                continue
+            logger.warning(
+                "%s is not supported for %s tasks (supported task types: %s). "
+                "The setting will still be sent but may have no effect.",
+                type(setting).__name__,
+                workflow.task_type,
+                ", ".join(supported),
+            )
+
     def _create_general_job_definition(
         self,
         name: str,
@@ -49,6 +77,8 @@ class RapidataJobManager:
     ) -> RapidataJobDefinition:
         if settings is None:
             settings = []
+
+        self._warn_unsupported_settings(workflow, settings)
 
         self.__context_manager._enforce_context_length(
             datapoints=datapoints,

--- a/src/rapidata/rapidata_client/settings/_rapidata_setting.py
+++ b/src/rapidata/rapidata_client/settings/_rapidata_setting.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 from pydantic import BaseModel
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, ClassVar, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from rapidata.api_client.models.feature_flag import FeatureFlag
 
 
 FeatureFlagTarget = Literal["rapids", "campaign"]
+
+# Which task types honor a given setting. ``"all"`` means every task type.
+# This is metadata only and is NOT serialized into the FeatureFlag sent to the
+# API. Keep the per-setting values in sync with the other two repos (there is no
+# shared package): rapids-frontend's FEATURE_FLAG_SUPPORTED_RAPID_TYPES
+# (src/types/rapid.ts) and app-frontend's supportedRapidTypes catalog field.
+# Values use the SDK public task-type names (e.g. "Compare", "Free Text").
+SupportedRapidTypes = tuple[str, ...] | Literal["all"]
 
 
 class RapidataSetting(BaseModel):
@@ -24,6 +32,10 @@ class RapidataSetting(BaseModel):
     key: str
     value: Any
     target: FeatureFlagTarget = "rapids"
+
+    # Task types that honor this setting; ``"all"`` == every task type.
+    # Subclasses narrow this (see ``SupportedRapidTypes``). Metadata only.
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = "all"
 
     def _to_feature_flag(self) -> FeatureFlag:
         from rapidata.api_client.models.feature_flag import FeatureFlag

--- a/src/rapidata/rapidata_client/settings/_rapidata_setting.py
+++ b/src/rapidata/rapidata_client/settings/_rapidata_setting.py
@@ -11,9 +11,9 @@ FeatureFlagTarget = Literal["rapids", "campaign"]
 # Which task types honor a given setting. ``"all"`` means every task type.
 # This is metadata only and is NOT serialized into the FeatureFlag sent to the
 # API. The per-setting values are generated (see scripts/generate_settings.py)
-# from the source-of-truth support matrix in rapids-frontend
-# (FEATURE_FLAG_SUPPORTED_RAPID_TYPES in src/types/rapid.ts), translated into the
-# SDK public task-type names (e.g. "Compare", "Free Text").
+# from the source-of-truth `supported_rapid_types` in rapids-frontend's
+# settings.ts (via settings.json), translated into the SDK public task-type
+# names (e.g. "Compare", "Free Text").
 SupportedRapidTypes = tuple[str, ...] | Literal["all"]
 
 

--- a/src/rapidata/rapidata_client/settings/_rapidata_setting.py
+++ b/src/rapidata/rapidata_client/settings/_rapidata_setting.py
@@ -10,10 +10,10 @@ FeatureFlagTarget = Literal["rapids", "campaign"]
 
 # Which task types honor a given setting. ``"all"`` means every task type.
 # This is metadata only and is NOT serialized into the FeatureFlag sent to the
-# API. Keep the per-setting values in sync with the other two repos (there is no
-# shared package): rapids-frontend's FEATURE_FLAG_SUPPORTED_RAPID_TYPES
-# (src/types/rapid.ts) and app-frontend's supportedRapidTypes catalog field.
-# Values use the SDK public task-type names (e.g. "Compare", "Free Text").
+# API. The per-setting values are generated (see scripts/generate_settings.py)
+# from the source-of-truth support matrix in rapids-frontend
+# (FEATURE_FLAG_SUPPORTED_RAPID_TYPES in src/types/rapid.ts), translated into the
+# SDK public task-type names (e.g. "Compare", "Free Text").
 SupportedRapidTypes = tuple[str, ...] | Literal["all"]
 
 

--- a/src/rapidata/rapidata_client/settings/allow_neither_both.py
+++ b/src/rapidata/rapidata_client/settings/allow_neither_both.py
@@ -4,7 +4,11 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class AllowNeitherBothSetting(RapidataSetting):
@@ -13,9 +17,13 @@ class AllowNeitherBothSetting(RapidataSetting):
 
     The delay controls how many milliseconds before the unsure button appears.
 
+    Supported task types: Compare.
+
     Args:
         delay_ms (int, optional): Delay in milliseconds before the unsure button appears. Defaults to 5000.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Compare",)
 
     def __init__(self, delay_ms: int = 5000):
         if delay_ms < 0:

--- a/src/rapidata/rapidata_client/settings/classify_equirectangular.py
+++ b/src/rapidata/rapidata_client/settings/classify_equirectangular.py
@@ -4,16 +4,24 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class ClassifyEquirectangularSetting(RapidataSetting):
     """
     Enables equirectangular (360-degree) image mode for classify tasks. Renders a single spherical viewer instead of the standard image view.
 
+    Supported task types: Classification.
+
     Args:
         value (bool, optional): Whether to enable 360-degree classify mode. Defaults to True.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Classification",)
 
     def __init__(self, value: bool = True):
         if not isinstance(value, bool):

--- a/src/rapidata/rapidata_client/settings/compare_equirectangular.py
+++ b/src/rapidata/rapidata_client/settings/compare_equirectangular.py
@@ -4,16 +4,24 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class CompareEquirectangularSetting(RapidataSetting):
     """
     Enables equirectangular (360-degree) image comparison mode for compare tasks. Renders a special spherical viewer instead of the standard comparison view.
 
+    Supported task types: Compare.
+
     Args:
         value (bool, optional): Whether to enable 360-degree comparison mode. Defaults to True.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Compare",)
 
     def __init__(self, value: bool = True):
         if not isinstance(value, bool):

--- a/src/rapidata/rapidata_client/settings/compare_panorama.py
+++ b/src/rapidata/rapidata_client/settings/compare_panorama.py
@@ -4,16 +4,24 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class ComparePanoramaSetting(RapidataSetting):
     """
     Enables panorama comparison mode for compare tasks. Renders a special panoramic image viewer instead of the standard comparison view.
 
+    Supported task types: Compare.
+
     Args:
         value (bool, optional): Whether to enable panorama comparison mode. Defaults to True.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Compare",)
 
     def __init__(self, value: bool = True):
         if not isinstance(value, bool):

--- a/src/rapidata/rapidata_client/settings/custom_setting.py
+++ b/src/rapidata/rapidata_client/settings/custom_setting.py
@@ -12,6 +12,9 @@ class CustomSetting(RapidataSetting):
     """
     Set a custom setting with the given key and value. Use this to enable features that do not have a dedicated method (yet).
 
+    Supported task types: all. As an arbitrary escape hatch it is never filtered
+    by task type and never triggers a support warning.
+
     Args:
         key (str): The key for the custom setting.
         value (str): The value for the custom setting.

--- a/src/rapidata/rapidata_client/settings/disable_autoloop.py
+++ b/src/rapidata/rapidata_client/settings/disable_autoloop.py
@@ -11,6 +11,8 @@ class DisableAutoloopSetting(RapidataSetting):
     """
     Disables automatic looping of video media. When enabled, videos will not automatically restart when they finish playing.
 
+    Supported task types: all.
+
     Args:
         value (bool, optional): Whether to disable video autoloop. Defaults to True.
     """

--- a/src/rapidata/rapidata_client/settings/free_text_max_characters.py
+++ b/src/rapidata/rapidata_client/settings/free_text_max_characters.py
@@ -4,16 +4,24 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class FreeTextMaxCharactersSetting(RapidataSetting):
     """
     Set the maximum number of characters allowed in a free text answer.
 
+    Supported task types: Free Text.
+
     Args:
         value (int, optional): The maximum number of characters for free text. Defaults to 1024.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Free Text",)
 
     def __init__(self, value: int = 1024):
         if value < 1:

--- a/src/rapidata/rapidata_client/settings/free_text_minimum_characters.py
+++ b/src/rapidata/rapidata_client/settings/free_text_minimum_characters.py
@@ -4,7 +4,11 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 from rapidata.rapidata_client.config import managed_print
 
 
@@ -12,9 +16,13 @@ class FreeTextMinimumCharactersSetting(RapidataSetting):
     """
     Set the minimum number of characters a user has to type.
 
+    Supported task types: Free Text.
+
     Args:
         value (int): The minimum number of characters for free text.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Free Text",)
 
     def __init__(self, value: int):
         if value < 1:

--- a/src/rapidata/rapidata_client/settings/keyboard_numeric.py
+++ b/src/rapidata/rapidata_client/settings/keyboard_numeric.py
@@ -4,16 +4,24 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class KeyboardNumericSetting(RapidataSetting):
     """
     Changes the virtual keyboard input type to numeric-only for free text input fields. Useful when expecting numeric answers.
 
+    Supported task types: Free Text.
+
     Args:
         value (bool, optional): Whether to show a numeric keyboard. Defaults to True.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Free Text",)
 
     def __init__(self, value: bool = True):
         if not isinstance(value, bool):

--- a/src/rapidata/rapidata_client/settings/locate_max_points.py
+++ b/src/rapidata/rapidata_client/settings/locate_max_points.py
@@ -4,16 +4,24 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class LocateMaxPointsSetting(RapidataSetting):
     """
     Sets the maximum number of points a user can place on a locate task. Once the limit is reached, no more points can be added.
 
+    Supported task types: Locate.
+
     Args:
         value (int, optional): The maximum number of points allowed. Defaults to 3.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Locate",)
 
     def __init__(self, value: int = 3):
         if value < 1:

--- a/src/rapidata/rapidata_client/settings/locate_min_points.py
+++ b/src/rapidata/rapidata_client/settings/locate_min_points.py
@@ -4,16 +4,24 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class LocateMinPointsSetting(RapidataSetting):
     """
     Sets the minimum number of points required for a valid locate submission. The submit button is disabled until enough points are placed.
 
+    Supported task types: Locate.
+
     Args:
         value (int, optional): The minimum number of points required. Defaults to 1.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Locate",)
 
     def __init__(self, value: int = 1):
         if value < 1:

--- a/src/rapidata/rapidata_client/settings/markdown.py
+++ b/src/rapidata/rapidata_client/settings/markdown.py
@@ -12,6 +12,8 @@ class MarkdownSetting(RapidataSetting):
     Enables limited markdown rendering for text datapoints.
     Useful when comparing formatted text like LLM outputs.
 
+    Supported task types: all.
+
     Args:
         value (bool, optional): Whether to enable markdown rendering. Defaults to True.
     """

--- a/src/rapidata/rapidata_client/settings/mute_video.py
+++ b/src/rapidata/rapidata_client/settings/mute_video.py
@@ -11,6 +11,8 @@ class MuteVideoSetting(RapidataSetting):
     """
     Mute the video. If this setting is not supplied, the video will not be muted.
 
+    Supported task types: all.
+
     Args:
         value (bool, optional): Whether to mute the video. Defaults to True.
     """

--- a/src/rapidata/rapidata_client/settings/no_instruction_display.py
+++ b/src/rapidata/rapidata_client/settings/no_instruction_display.py
@@ -13,6 +13,8 @@ class NoInstructionDisplaySetting(RapidataSetting):
 
     Note: If SwapContextInstructionSetting is also applied, this will hide the context instead, since the positions are swapped.
 
+    Supported task types: all.
+
     Args:
         value (bool, optional): Whether to hide the instruction display. Defaults to True.
     """

--- a/src/rapidata/rapidata_client/settings/no_mistake_option.py
+++ b/src/rapidata/rapidata_client/settings/no_mistake_option.py
@@ -11,6 +11,8 @@ class NoMistakeOptionSetting(RapidataSetting):
     """
     Enables a "No mistakes" button that allows users to skip task by confirming they found no errors in the media.
 
+    Supported task types: all.
+
     Args:
         value (bool, optional): Whether to enable the no mistakes button. Defaults to True.
     """

--- a/src/rapidata/rapidata_client/settings/no_shuffle.py
+++ b/src/rapidata/rapidata_client/settings/no_shuffle.py
@@ -4,7 +4,11 @@
 
 from __future__ import annotations
 
-from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+from typing import ClassVar
+from rapidata.rapidata_client.settings._rapidata_setting import (
+    RapidataSetting,
+    SupportedRapidTypes,
+)
 
 
 class NoShuffleSetting(RapidataSetting):
@@ -13,9 +17,13 @@ class NoShuffleSetting(RapidataSetting):
 
     If this is not added to the order, the shuffling will be active.
 
+    Supported task types: Classification, Compare.
+
     Args:
         value (bool, optional): Whether to disable shuffling. Defaults to True for function call.
     """
+
+    supported_rapid_types: ClassVar[SupportedRapidTypes] = ("Classification", "Compare")
 
     def __init__(self, value: bool = True):
         if not isinstance(value, bool):

--- a/src/rapidata/rapidata_client/settings/original_language_only.py
+++ b/src/rapidata/rapidata_client/settings/original_language_only.py
@@ -13,6 +13,8 @@ class OriginalLanguageOnlySetting(RapidataSetting):
 
     Use this when task content should not be translated: it disables the automatic translation / localization of the content and prevents annotators from switching languages. Search terms: translation, translate, translated, multilingual, localization, localize, i18n, language switch.
 
+    Supported task types: all.
+
     Args:
         value (bool, optional): Whether to display the content in the original language only. Defaults to True.
     """

--- a/src/rapidata/rapidata_client/settings/play_percentage_video.py
+++ b/src/rapidata/rapidata_client/settings/play_percentage_video.py
@@ -11,6 +11,8 @@ class PlayPercentageVideoSetting(RapidataSetting):
     """
     Requires users to watch a certain percentage of the video before they can submit their answer.
 
+    Supported task types: all.
+
     Args:
         percentage (int, optional): The percentage of the video that must be played before the user can submit. Must be between 0 and 95.
     """

--- a/src/rapidata/rapidata_client/settings/swap_context_instruction.py
+++ b/src/rapidata/rapidata_client/settings/swap_context_instruction.py
@@ -15,6 +15,8 @@ class SwapContextInstructionSetting(RapidataSetting):
 
     By default, the context will be shown on top and the instruction below.
 
+    Supported task types: all.
+
     Args:
         value (bool, optional): Whether to swap the place of the context and instruction.
     """

--- a/src/rapidata/rapidata_client/workflow/_base_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_base_workflow.py
@@ -12,6 +12,12 @@ from rapidata.api_client.models.rapid_modality import RapidModality
 class Workflow(ABC):
     modality: RapidModality
 
+    # SDK public task-type name used to filter task-type-aware settings.
+    # ``None`` means the workflow has no rapid task type (e.g. evaluation) and
+    # is never checked. Keep the values in sync with the settings support matrix
+    # mirrored across the other two repos (rapids-frontend / app-frontend).
+    task_type: str | None = None
+
     def __init__(self, type: str):
         self._type = type
 

--- a/src/rapidata/rapidata_client/workflow/_classify_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_classify_workflow.py
@@ -39,6 +39,7 @@ class ClassifyWorkflow(Workflow):
     """
 
     modality = RapidModality.CLASSIFY
+    task_type = "Classification"
 
     def __init__(self, instruction: str, answer_options: list[str]):
         super().__init__(type="SimpleWorkflowConfig")

--- a/src/rapidata/rapidata_client/workflow/_compare_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_compare_workflow.py
@@ -33,6 +33,7 @@ class CompareWorkflow(Workflow):
     """
 
     modality = RapidModality.COMPARE
+    task_type = "Compare"
 
     def __init__(self, instruction: str, a_b_names: list[str] | None = None):
         super().__init__(type="CompareWorkflowConfig")

--- a/src/rapidata/rapidata_client/workflow/_draw_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_draw_workflow.py
@@ -19,6 +19,7 @@ from rapidata.api_client.models.rapid_modality import RapidModality
 
 class DrawWorkflow(Workflow):
     modality = RapidModality.LINE
+    task_type = "Draw"
 
     def __init__(self, target: str):
         super().__init__(type="SimpleWorkflowConfig")

--- a/src/rapidata/rapidata_client/workflow/_free_text_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_free_text_workflow.py
@@ -35,6 +35,7 @@ class FreeTextWorkflow(Workflow):
     """
 
     modality = RapidModality.FREETEXT
+    task_type = "Free Text"
 
     def __init__(self, instruction: str, validation_system_prompt: str | None = None):
         super().__init__(type="SimpleWorkflowConfig")

--- a/src/rapidata/rapidata_client/workflow/_locate_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_locate_workflow.py
@@ -19,6 +19,7 @@ from rapidata.api_client.models.rapid_modality import RapidModality
 
 class LocateWorkflow(Workflow):
     modality = RapidModality.LOCATE
+    task_type = "Locate"
 
     def __init__(self, target: str):
         super().__init__(type="SimpleWorkflowConfig")

--- a/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
@@ -18,6 +18,7 @@ BRADLEY_TERRY_DEFAULT_STARTING_SCORE = 1200
 
 class MultiRankingWorkflow(Workflow):
     modality = RapidModality.COMPARE
+    task_type = "Ranking"
 
     def __init__(
         self,

--- a/src/rapidata/rapidata_client/workflow/_select_words_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_select_words_workflow.py
@@ -33,6 +33,7 @@ class SelectWordsWorkflow(Workflow):
     """
 
     modality = RapidModality.TRANSCRIPTION
+    task_type = "Select Words"
 
     def __init__(self, instruction: str):
         super().__init__(type="SimpleWorkflowConfig")

--- a/src/rapidata/rapidata_client/workflow/_timestamp_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_timestamp_workflow.py
@@ -32,6 +32,7 @@ class TimestampWorkflow(Workflow):
     """
 
     modality = RapidModality.SCRUB
+    task_type = "Timestamp"
 
     def __init__(self, instruction: str):
         super().__init__(type="SimpleWorkflowConfig")


### PR DESCRIPTION
## What

Makes the exposed feature-flag settings **task-type-aware** in the Python SDK.

Each setting now carries:
- a machine-readable `supported_rapid_types` attribute (SDK public task-type names, or `"all"` = every type) — **metadata only, not serialized into the FeatureFlag**, and
- a docstring disclaimer line, e.g. *"Supported task types: Compare."*

Job-definition creation now logs a **non-fatal** `logger.warning` when a provided setting does not support the job's task type. The flag is **never dropped and no error is raised**. Ranking jobs are treated as Compare (they are compare-based); evaluation jobs have no rapid task type and are skipped. **Order creation is untouched.**

## How

- `settings/_rapidata_setting.py`: add `SupportedRapidTypes` alias + `supported_rapid_types: ClassVar[...] = "all"` on the base.
- `scripts/generate_settings.py`: the setting classes are auto-generated and `settings.json` lives in **rapids-frontend** (fetched at CI time by `update-settings.yml`), so the support matrix lives in the generator as the SDK's hand-mirrored copy. The generator emits the per-setting attribute + docstring line and regenerates the setting modules. New settings not in the matrix default to `"all"` (safe: no filtering / no warning).
- `workflow/*`: add a public `task_type` to each Workflow.
- `job/rapidata_job_manager.py`: warn in `_create_general_job_definition` only.
- Docs: brief note in `docs/job_definition_parameters.md`.

## Sibling PRs

This is **1 of 3 sibling PRs** for the feature *"make the exposed feature-flag settings task-type-aware"*. The support matrix is hand-mirrored (no shared package) into:
- **rapids-frontend** — source-of-truth `FEATURE_FLAG_SUPPORTED_RAPID_TYPES` in `src/types/rapid.ts`.
- **app-frontend** — `supportedRapidTypes` on each setting catalog entry (filters the picker).
- **rapidata-python-sdk** — this PR.

## Validation

- `python -c "from rapidata import RapidataClient"` ✅
- `pyright src/rapidata/rapidata_client` → 0 errors ✅
- `black` clean on handwritten files; generated files kept as raw generator output (matches CI) ✅
- `mkdocs build` ✅
- Functional test of the warning matrix (Compare/Ranking/Classify/Evaluation × supported/global/Custom) behaves as expected.

🔗 Session: https://node-d55f0863.poseidon.rapidata.internal/