### PR TITLE
fix(sdk): handle "bytes" binary response type in deserializer

### DIFF
--- a/openapi/templates/api_client.mustache
+++ b/openapi/templates/api_client.mustache
@@ -315,7 +315,7 @@ class ApiClient:
         response_text = None
         return_data = None
         try:
-            if response_type == "bytearray":
+            if response_type in ("bytearray", "bytes"):
                 return_data = response_data.data
             elif response_type == "file":
                 return_data = self.__deserialize_file(response_data)

--- a/src/rapidata/api_client/api_client.py
+++ b/src/rapidata/api_client/api_client.py
@@ -306,7 +306,7 @@ class ApiClient:
         response_text = None
         return_data = None
         try:
-            if response_type == "bytearray":
+            if response_type in ("bytearray", "bytes"):
                 return_data = response_data.data
             elif response_type == "file":
                 return_data = self.__deserialize_file(response_data)


### PR DESCRIPTION
## What broke

After the OpenAPI-client regeneration landed on `main`, `order.get_results()` fails at runtime:

```
AttributeError: module 'rapidata.api_client.models' has no attribute 'bytes'
```

(seen in [rapidata-testing run](https://github.com/RapidataAI/rapidata-testing/actions/runs/29100143120/job/86386615017), `run-classify`).

## Root cause

The regenerated client now emits **`"bytes"`** as the `_response_types_map` value for binary-download endpoints, where it previously emitted **`"bytearray"`**. But `ApiClient.response_deserialize` only special-cases `"bytearray"` (returning the raw bytes); `"bytes"` falls through to the generic path, which tries `getattr(rapidata.api_client.models, "bytes")` and raises.

This is collateral from the generator change, **not** the `in`-filter work — and Pyright can't catch it, because the response type is just a string that only fails at deserialization time (which is why the SDK's type-check CI stayed green and only the integration test caught it).

Scope: **9 endpoints** across `order` / `asset` / `job` return `"bytes"` — all affected, all fixed by this one change.

## Fix

In the custom `openapi/templates/api_client.mustache`, treat `"bytes"` the same as `"bytearray"`:

```python
if response_type in ("bytearray", "bytes"):
    return_data = response_data.data
```

and regenerate. Diff is 2 lines (template + the generated `api_client.py`).

## Verification
- Confirmed `response_deserialize` now short-circuits `"bytes"` to raw response data.
- `pyright src/rapidata/rapidata_client` → 0 errors.
- Regeneration produced a minimal diff (only `api_client.py`), no other churn.

Session: https://session-3e431d5b.poseidon.rapidata.internal/