### PR TITLE
fix(auth): reload token file when expiry cannot be determined

### DIFF
--- a/docs/distributed_training.md
+++ b/docs/distributed_training.md
@@ -111,7 +111,13 @@ contacts the auth server once the token is within `leeway` of expiry.
 
 Whatever the transport, pass the **complete token object** around and keep
 its absolute `expires_at` field — it's how a client decides when a token has
-expired. If you produce tokens without the SDK (e.g. a `curl` call to the
-token endpoint), the response only carries the relative `expires_in`, so add
-`expires_at` yourself. And if your transport is a shared file, write it
-atomically (temp file + `os.replace`) so readers never see a partial token.
+expired. `expires_at` is **Unix epoch seconds** (`time.time()`-style), which
+is timezone-independent: the coordinator and the workers can run in
+different timezones or regions without any conversion. If you produce tokens
+without the SDK (e.g. a `curl` call to the token endpoint), the response
+only carries the relative `expires_in`, so add
+`expires_at = time.time() + expires_in` yourself — as epoch seconds, never a
+formatted datetime string or local wall-clock arithmetic, otherwise clients
+cannot check expiry and keep using the token after it has expired. And if
+your transport is a shared file, write it atomically (temp file +
+`os.replace`) so readers never see a partial token.

--- a/openapi/templates/rest.mustache
+++ b/openapi/templates/rest.mustache
@@ -111,9 +111,12 @@ class RESTClientObject:
     def _reload_token_from_file_if_expired(self, token_file: str):
         # A pre-supplied token has no refresh path of its own; an external
         # process keeps the token file fresh, so re-read it once ours expires.
+        # is_expired() returns None when expires_at is missing or not epoch
+        # seconds — treat that as expired so a malformed token keeps being
+        # re-read instead of being trusted as never expiring.
         assert self.session is not None
         token = self.session.token
-        if token is not None and not token.is_expired(leeway=self._token_leeway):
+        if token is not None and token.is_expired(leeway=self._token_leeway) is False:
             return
         with open(token_file) as f:
             self.session.token = json.load(f)
@@ -146,6 +149,18 @@ class RESTClientObject:
                 "token_type, and an absolute expires_at timestamp.",
                 ", ".join(missing),
             )
+        else:
+            try:
+                int(token["expires_at"])
+            except (TypeError, ValueError):
+                _logger.warning(
+                    "set_token received a token whose expires_at (%r) is not "
+                    "Unix epoch seconds, so its expiry cannot be checked and "
+                    "it will be treated as never expiring. Produce expires_at "
+                    "with time.time()-style epoch seconds, not a formatted "
+                    "datetime.",
+                    token["expires_at"],
+                )
         self.session.token = token
 
     def request(

--- a/src/rapidata/api_client/rest.py
+++ b/src/rapidata/api_client/rest.py
@@ -120,9 +120,12 @@ class RESTClientObject:
     def _reload_token_from_file_if_expired(self, token_file: str):
         # A pre-supplied token has no refresh path of its own; an external
         # process keeps the token file fresh, so re-read it once ours expires.
+        # is_expired() returns None when expires_at is missing or not epoch
+        # seconds — treat that as expired so a malformed token keeps being
+        # re-read instead of being trusted as never expiring.
         assert self.session is not None
         token = self.session.token
-        if token is not None and not token.is_expired(leeway=self._token_leeway):
+        if token is not None and token.is_expired(leeway=self._token_leeway) is False:
             return
         with open(token_file) as f:
             self.session.token = json.load(f)
@@ -155,6 +158,18 @@ class RESTClientObject:
                 "token_type, and an absolute expires_at timestamp.",
                 ", ".join(missing),
             )
+        else:
+            try:
+                int(token["expires_at"])
+            except (TypeError, ValueError):
+                _logger.warning(
+                    "set_token received a token whose expires_at (%r) is not "
+                    "Unix epoch seconds, so its expiry cannot be checked and "
+                    "it will be treated as never expiring. Produce expires_at "
+                    "with time.time()-style epoch seconds, not a formatted "
+                    "datetime.",
+                    token["expires_at"],
+                )
         self.session.token = token
 
     def request(


### PR DESCRIPTION
## Context

Follow-up review of the new [Distributed Training](https://docs.rapidata.ai/latest/distributed_training/) docs: checked whether coordinator and workers running in **different timezones** can break token sharing.

**The SDK-to-SDK path is timezone-safe.** `expires_at` is produced by authlib as Unix epoch seconds (`int(time.time()) + expires_in`) and checked against `time.time()` — both UTC-based regardless of local timezone. Verified empirically: a token minted under `TZ=Asia/Tokyo` and read under `TZ=America/Los_Angeles` shows exactly the same remaining validity.

**But the documented DIY path has a real trap.** The docs say *"if you produce tokens without the SDK … add `expires_at` yourself"* without specifying the format. If someone writes a formatted datetime string (or local wall-clock arithmetic), `OAuth2Token.is_expired()` returns `None`, and the reload check in `rest.py`

```python
if token is not None and not token.is_expired(leeway=self._token_leeway):
    return  # <- None -> "not expired" -> file never re-read again
```

treated `None` as "not expired", so a worker **silently never re-read the token file** and rode the stale token into 401s — surfacing exactly when people hand-roll timestamps across timezones.

## Changes

- `rest.py` (+ `openapi/templates/rest.mustache`, kept in sync): `_reload_token_from_file_if_expired` now only skips the re-read when `is_expired()` is explicitly `False` — unknown expiry re-reads the file instead of trusting the token forever.
- `set_token` warns when `expires_at` is present but not parseable as epoch seconds (numeric strings stay silent, matching authlib).
- `docs/distributed_training.md`: states that `expires_at` is timezone-independent Unix epoch seconds and shows `expires_at = time.time() + expires_in` for the curl path.

## Verification

- Behavior test against the patched code: fresh token → kept; expired → reloaded; ISO-string / missing `expires_at` → now re-read (previously never); `set_token` warns once for ISO, silent for int and numeric string.
- `uv run pyright src/rapidata/rapidata_client` → 0 errors.
- `uv run --group docs mkdocs build` → success.

🔗 Session: [https://session-a17860c3.poseidon.rapidata.internal/](https://session-a17860c3.poseidon.rapidata.internal/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)