### PR TITLE
docs(human-prompting): separate instruction from answer options in examples

### DIFF
--- a/docs/human_prompting.md
+++ b/docs/human_prompting.md
@@ -36,7 +36,7 @@ Frame questions in the positive rather than negative. Positive questions are eas
 ```
 
 ### Limit Decision Criteria
-Don't overload labelers with multiple criteria in a single question. The instruction and the answer options are two separate fields (`instruction` and `answer_options`) — keep them distinct.
+Don't overload labelers with multiple criteria in a single question.
 
 **Better:**
 ```

--- a/docs/human_prompting.md
+++ b/docs/human_prompting.md
@@ -36,16 +36,18 @@ Frame questions in the positive rather than negative. Positive questions are eas
 ```
 
 ### Limit Decision Criteria
-Don't overload labelers with multiple criteria in a single question.
+Don't overload labelers with multiple criteria in a single question. The instruction and the answer options are two separate fields (`instruction` and `answer_options`) — keep them distinct.
 
 **Better:**
 ```
-"What animal is in the image? - rabbit/dog/cat/other"
+Instruction:    "What animal is in the image?"
+Answer options: rabbit / dog / cat / other
 ```
 
 **Avoid:**
 ```
-"Does this image contain a rabbit, a dog, or a cat? - yes/no"
+Instruction:    "Does this image contain a rabbit, a dog, or a cat?"
+Answer options: yes / no
 ```
 
 ### Use Clear Response Options
@@ -53,12 +55,14 @@ Provide distinct, non-overlapping response options.
 
 **Better:**
 ```
-"Rate the image quality: poor/acceptable/excellent"
+Instruction:    "Rate the image quality"
+Answer options: poor / acceptable / excellent
 ```
 
 **Avoid:**
 ```
-"Rate the image quality: bad/not good/fine/good/great"
+Instruction:    "Rate the image quality"
+Answer options: bad / not good / fine / good / great
 ```
 
 ## Example Implementation


### PR DESCRIPTION
## What

Reworks the **Question Framing** examples in `docs/human_prompting.md` so the *instruction* and the *answer options* are shown as two distinct, labeled parts instead of one combined string.

## Why

The examples previously packed both into a single string:

> `"What animal is in the image? - rabbit/dog/cat/other"`

A reader could reasonably think the whole string is the instruction. In reality this maps to two separate API fields — `instruction` and `answer_options` — as shown in the Classification Tasks example lower on the same page. The examples now make that split explicit:

```
Instruction:    "What animal is in the image?"
Answer options: rabbit / dog / cat / other
```

Applied to both the `Limit Decision Criteria` and `Use Clear Response Options` sections (Better and Avoid). Content is otherwise unchanged.

## Note

The same guide is duplicated in `RapidataAI/human-use` and `RapidataAI/mcp-app`; this PR only touches the SDK docs site. Happy to mirror the change there if wanted.

🔗 Session: https://session-86989c50.poseidon.rapidata.internal/