### PR TITLE
fix(results): read canonical info.type in to_pandas

### DIFF
--- a/src/rapidata/rapidata_client/results/rapidata_results.py
+++ b/src/rapidata/rapidata_client/results/rapidata_results.py
@@ -42,7 +42,8 @@ class RapidataResults(dict):
         if "results" not in self or not self["results"]:
             return pd.DataFrame()
 
-        if self["info"].get("orderType") is None:
+        task_type = self._task_type()
+        if task_type is None:
             managed_print(
                 "Warning: Results are old and Order type is not specified. Dataframe might be wrong."
             )
@@ -53,7 +54,7 @@ class RapidataResults(dict):
         # Compare/Ranking have an asset-aware shape; route them to the
         # compare-specific path even when split_details=True so we keep the
         # A_/B_ (or per-asset) column splitting.
-        if self["info"].get("orderType") in ("Compare", "Ranking"):
+        if task_type in ("Compare", "Ranking"):
             return self._compare_to_pandas(split_details=split_details)
 
         if split_details:
@@ -77,6 +78,16 @@ class RapidataResults(dict):
             data.append(row)
 
         return pd.DataFrame(data, columns=Index(columns))
+
+    def _task_type(self) -> str | None:
+        """Return the task type from ``info``, tolerant of the field rename.
+
+        The aggregator emits it as ``type`` (canonical). ``orderType`` is an
+        older name kept as a read fallback so results generated before the
+        rename still route correctly.
+        """
+        info = self.get("info", {})
+        return info.get("type") or info.get("orderType")
 
     def _has_detailed_results(self) -> bool:
         """


### PR DESCRIPTION
## Problem

The result aggregator (`rapidata-evaluator`) emits the task type as **`info.type`** (schema `version` `4.0.0`), and the docs match. But `RapidataResults.to_pandas()` read **`info.orderType`** — a field the server does not emit anywhere in v4 (it exists only in this reader; not in the evaluator, OpenAPI schemas, docs, or any example).

Consequences for **every** current Compare/Ranking result:
1. `orderType` is `None` → prints the misleading *"Results are old and Order type is not specified"* warning on brand-new results.
2. Never routes to the compare-aware path → `to_pandas()` silently falls through to the generic flattener and **loses the `A_`/`B_` asset columns**.

Reported from integration testing: SDK 3.16.5, Python 3.12, Compare task.

## Fix

Client-side tolerant reader: `_task_type()` reads canonical **`type`** with **`orderType`** as a read fallback, so results generated before the rename still route correctly. No server change — this fixes every result already in the wild without re-aggregation.

Verified locally: a v4 (`type: Compare`) payload now yields `A_/B_` columns; an `orderType` payload still works; the warning fires only when the type is genuinely absent. `pyright` and `black` clean.

## Scope

Minimal fix so the broken parsing can be merged now. A typed result-model design (typed accessors over the raw dict) is being drafted separately and coordinated with the sibling *raw-vs-weighted winner fields* work.

🔗 Session: https://node-25c37285.poseidon.rapidata.internal/