### PR TITLE
fix(workflow): use input config variants in MultiRankingWorkflow

### DIFF
--- a/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
@@ -30,17 +30,17 @@ class MultiRankingWorkflow(Workflow):
         from rapidata.api_client.models.i_pair_maker_config import (
             IPairMakerConfig,
         )
-        from rapidata.api_client.models.i_pair_maker_config_model_online_pair_maker_config_model import (
-            IPairMakerConfigModelOnlinePairMakerConfigModel,
+        from rapidata.api_client.models.i_pair_maker_config_online_pair_maker_config import (
+            IPairMakerConfigOnlinePairMakerConfig,
         )
-        from rapidata.api_client.models.i_pair_maker_config_model_full_permutation_pair_maker_config_model import (
-            IPairMakerConfigModelFullPermutationPairMakerConfigModel,
+        from rapidata.api_client.models.i_pair_maker_config_full_permutation_pair_maker_config import (
+            IPairMakerConfigFullPermutationPairMakerConfig,
         )
         from rapidata.api_client.models.i_ranking_config import (
             IRankingConfig,
         )
-        from rapidata.api_client.models.i_ranking_config_model_bradley_terry_ranking_config_model import (
-            IRankingConfigModelBradleyTerryRankingConfigModel,
+        from rapidata.api_client.models.i_ranking_config_bradley_terry_ranking_config import (
+            IRankingConfigBradleyTerryRankingConfig,
         )
 
         super().__init__(type="CompareWorkflowConfig")
@@ -52,13 +52,13 @@ class MultiRankingWorkflow(Workflow):
 
         if max_group_size <= FULL_PERMUTATION_GROUP_SIZE_THRESHOLD:
             self.pair_maker_config = IPairMakerConfig(
-                actual_instance=IPairMakerConfigModelFullPermutationPairMakerConfigModel(
+                actual_instance=IPairMakerConfigFullPermutationPairMakerConfig(
                     _t="FullPermutationPairMaker",
                 ),
             )
         else:
             self.pair_maker_config = IPairMakerConfig(
-                actual_instance=IPairMakerConfigModelOnlinePairMakerConfigModel(
+                actual_instance=IPairMakerConfigOnlinePairMakerConfig(
                     _t="OnlinePairMaker",
                     totalComparisonBudget=comparison_budget_per_ranking,
                     randomMatchesRatio=random_comparisons_ratio,
@@ -66,7 +66,7 @@ class MultiRankingWorkflow(Workflow):
             )
 
         self.ranking_config = IRankingConfig(
-            actual_instance=IRankingConfigModelBradleyTerryRankingConfigModel(
+            actual_instance=IRankingConfigBradleyTerryRankingConfig(
                 _t="BradleyTerryRankingConfig",
                 startingScore=BRADLEY_TERRY_DEFAULT_STARTING_SCORE,
             ),


### PR DESCRIPTION
## Problem

The nightly **Run SDK Orders** test ([failing run](https://github.com/RapidataAI/rapidata-testing/actions/runs/29622981132/job/88021578844)) fails on the **ranking order** step:

```
pydantic_core.ValidationError: 2 validation errors for IPairMakerConfig
  Input should be a valid instance of IPairMakerConfigFullPermutationPairMakerConfig
  Input should be a valid instance of IPairMakerConfigOnlinePairMakerConfig
  input_type=IPairMakerConfigModelOnlinePairMakerConfigModel
```

## Root cause

The generated client carries two parallel one-of unions:

| Union | Accepts |
|---|---|
| `IPairMakerConfig` (request) | `IPairMakerConfigFullPermutationPairMakerConfig`, `IPairMakerConfigOnlinePairMakerConfig` |
| `IPairMakerConfigModel` (read) | `...ModelFullPermutation...Model`, `...ModelOnline...Model` |

`IOrderWorkflowInputGroupedRankingWorkflowInput.pairMakerConfig` / `.rankingConfig` expect the **non-`Model`** request unions, but `MultiRankingWorkflow.__init__` instantiated the **`...Model...`** read-side classes, which the request union rejects at construction. The OpenAPI client itself is up to date — only this hand-written wrapper was stale, and nothing type-checks the union membership, so only the integration run caught it.

## Fix

Swap to the matching request-side variants in `_multi_ranking_workflow.py`:

- `IPairMakerConfigModelFullPermutationPairMakerConfigModel` → `IPairMakerConfigFullPermutationPairMakerConfig`
- `IPairMakerConfigModelOnlinePairMakerConfigModel` → `IPairMakerConfigOnlinePairMakerConfig`
- `IRankingConfigModelBradleyTerryRankingConfigModel` → `IRankingConfigBradleyTerryRankingConfig`

The variants have identical fields, so the serialized payload is byte-for-byte unchanged:

```
max_group_size=5:  {"_t":"GroupedRankingWorkflow","pairMakerConfig":{"_t":"FullPermutationPairMaker"},"rankingConfig":{"_t":"BradleyTerryRankingConfig","startingScore":1200}}
max_group_size=25: {"_t":"GroupedRankingWorkflow","pairMakerConfig":{"_t":"OnlinePairMaker","randomMatchesRatio":0.5,"totalComparisonBudget":10},"rankingConfig":{"_t":"BradleyTerryRankingConfig","startingScore":1200}}
```

## Verification

- Reproduced the crash and confirmed both pair-maker paths (full-permutation ≤10, online >10) now construct and serialize.
- `black` clean, `pyright src/rapidata/rapidata_client` → 0 errors.

🔗 Session: https://session-0deec1d3.poseidon.rapidata.internal/