### PR TITLE
feat(audience): explicit recruiting lifecycle + local instruction length validation

### DIFF
--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -79,22 +79,20 @@ for prompt, datapoint in zip(PROMPTS, DATAPOINTS):
 
 ### Step 3: Start Recruiting
 
-Adding examples no longer starts recruiting on its own. Once all your
-qualification examples are added **and reviewed**, call `start_recruiting()`
-to begin the distilling/onboarding campaign that qualifies labelers against
-them. Until you call it, the audience stays in its `Created` state and
-recruits nobody — so a mid-upload failure never leaves you with a partially
-configured, live audience.
+Once all your qualification examples are added **and reviewed**, call
+`start_recruiting()` to begin the distilling/onboarding campaign that qualifies
+labelers against them. Recruiting starts only when you call this — until then,
+the audience stays in its `Created` state and recruits nobody, so a mid-upload
+failure never leaves you with a partially configured, live audience.
 
 ```py
 audience.start_recruiting()
 ```
 
 !!! warning "Recruiting is explicit"
-    Earlier SDK versions started recruiting automatically on the first
-    qualification example. That is no longer the case: you must call
-    `start_recruiting()` yourself, after the examples are reviewed. Calling it
-    more than once on the same audience is a no-op.
+    Adding qualification examples does not start recruiting; it is a deliberate
+    step you trigger yourself with `start_recruiting()` once the examples are
+    reviewed. Calling it more than once on the same audience is a no-op.
 
 ### Step 4: Create and Assign a Job
 

--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -77,9 +77,28 @@ for prompt, datapoint in zip(PROMPTS, DATAPOINTS):
 !!! note
     In practice you'd want to add more examples to the audience to improve the quality of the results.
 
-### Step 3: Create and Assign a Job
+### Step 3: Start Recruiting
 
-Once your audience is set up, create a job definition and assign it to the audience:
+Adding examples no longer starts recruiting on its own. Once all your
+qualification examples are added **and reviewed**, call `start_recruiting()`
+to begin the distilling/onboarding campaign that qualifies labelers against
+them. Until you call it, the audience stays in its `Created` state and
+recruits nobody — so a mid-upload failure never leaves you with a partially
+configured, live audience.
+
+```py
+audience.start_recruiting()
+```
+
+!!! warning "Recruiting is explicit"
+    Earlier SDK versions started recruiting automatically on the first
+    qualification example. That is no longer the case: you must call
+    `start_recruiting()` yourself, after the examples are reviewed. Calling it
+    more than once on the same audience is a no-op.
+
+### Step 4: Create and Assign a Job
+
+Once recruiting has started, create a job definition and assign it to the audience:
 
 ```py
 job_definition = client.job.create_compare_job_definition(
@@ -152,6 +171,8 @@ for prompt, datapoint in zip(PROMPTS, DATAPOINTS):
         context=prompt
     )
 
+audience.start_recruiting() # (1)!
+
 job_definition = client.job.create_compare_job_definition(
     name="Prompt Alignment Job",
     instruction="Which image follows the prompt more accurately?",
@@ -168,6 +189,8 @@ job.display_progress_bar()
 results = job.get_results()
 print(results)
 ```
+
+1. Recruiting is explicit: call `start_recruiting()` once all qualification examples are added and reviewed, before assigning a job.
 
 ## Matching the Job UI with Settings
 

--- a/docs/confidence_stopping.md
+++ b/docs/confidence_stopping.md
@@ -74,15 +74,15 @@ audience.add_classification_example(
     truth=["Cat"]
 )
 
-audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+audience.start_recruiting() # (1)!
 
 job_definition = client.job.create_classification_job_definition(
     name="Test Classification with Early Stopping",
     instruction="What do you see in the image?",
     answer_options=["Cat", "Dog"],
     datapoints=["https://assets.rapidata.ai/dog.jpeg"],
-    responses_per_datapoint=50, # (1)!
-    confidence_threshold=0.99, # (2)!
+    responses_per_datapoint=50, # (2)!
+    confidence_threshold=0.99, # (3)!
 )
 
 job = audience.assign_job(job_definition)
@@ -92,8 +92,9 @@ results = job.get_results()
 print(results)
 ```
 
-1. Sets the **maximum** number of responses per datapoint.
-2. Stops collecting once 99% confidence is reached — for clear-cut tasks like this, expect roughly 4 responses.
+1. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
+2. Sets the **maximum** number of responses per datapoint.
+3. Stops collecting once 99% confidence is reached — for clear-cut tasks like this, expect roughly 4 responses.
 
 ### When to Use Confidence Stopping
 
@@ -222,15 +223,15 @@ audience.add_classification_example(
     truth=["Cat"]
 )
 
-audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+audience.start_recruiting() # (1)!
 
 job_definition = client.job.create_classification_job_definition(
     name="Test Classification with Quorum Stopping",
     instruction="What do you see in the image?",
     answer_options=["Cat", "Dog"],
     datapoints=["https://assets.rapidata.ai/dog.jpeg"],
-    responses_per_datapoint=10, # (1)!
-    quorum_threshold=7, # (2)!
+    responses_per_datapoint=10, # (2)!
+    quorum_threshold=7, # (3)!
 )
 
 job = audience.assign_job(job_definition)
@@ -240,8 +241,9 @@ results = job.get_results()
 print(results)
 ```
 
-1. Sets the **maximum** number of responses per datapoint.
-2. Stops collecting once 7 responses agree on the same answer.
+1. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
+2. Sets the **maximum** number of responses per datapoint.
+3. Stops collecting once 7 responses agree on the same answer.
 
 ### When to Use Quorum Stopping
 

--- a/docs/confidence_stopping.md
+++ b/docs/confidence_stopping.md
@@ -74,6 +74,8 @@ audience.add_classification_example(
     truth=["Cat"]
 )
 
+audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+
 job_definition = client.job.create_classification_job_definition(
     name="Test Classification with Early Stopping",
     instruction="What do you see in the image?",
@@ -219,6 +221,8 @@ audience.add_classification_example(
     datapoint="https://assets.rapidata.ai/cat.jpeg",
     truth=["Cat"]
 )
+
+audience.start_recruiting()  # begin recruiting once examples are added and reviewed
 
 job_definition = client.job.create_classification_job_definition(
     name="Test Classification with Quorum Stopping",

--- a/docs/examples/classify_job.md
+++ b/docs/examples/classify_job.md
@@ -87,7 +87,7 @@ In this example, we rate images on a Likert scale to assess how well generated i
             settings=[NoShuffleSetting()] # (2)!
         )
 
-    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+    audience.start_recruiting() # (3)!
 
     job_definition = client.job.create_classification_job_definition(
         name="Likert Scale Example",
@@ -108,6 +108,7 @@ In this example, we rate images on a Likert scale to assess how well generated i
 
     1. Creates a new, empty audience. The `add_classification_example` calls below define who qualifies to join it.
     2. Qualify labelers on the same UI they'll see in the job. Since the job uses `NoShuffleSetting`, the examples use it too — see [Custom Audiences](../audiences.md#matching-the-job-ui-with-settings).
+    3. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
 
     !!! note
         Review every qualification example and its truth carefully, and add more than the few shown here for production workloads — see [Custom Audiences](../audiences.md) for the full guide.

--- a/docs/examples/classify_job.md
+++ b/docs/examples/classify_job.md
@@ -87,6 +87,8 @@ In this example, we rate images on a Likert scale to assess how well generated i
             settings=[NoShuffleSetting()] # (2)!
         )
 
+    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+
     job_definition = client.job.create_classification_job_definition(
         name="Likert Scale Example",
         instruction="How well does the image match the description?",

--- a/docs/examples/compare_job.md
+++ b/docs/examples/compare_job.md
@@ -108,7 +108,7 @@ In this example, we compare images from two image generation models (Flux and Mi
             context=prompt
         )
 
-    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+    audience.start_recruiting() # (2)!
 
     job_definition = client.job.create_compare_job_definition(
         name="Example Image Prompt Alignment Job",
@@ -126,6 +126,7 @@ In this example, we compare images from two image generation models (Flux and Mi
     ```
 
     1. Creates a new, empty audience. The `add_compare_example` calls train and filter the labelers who join it.
+    2. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
 
     !!! note
         Review every qualification example and its truth carefully, and add more than the few shown here for production workloads — see [Custom Audiences](../audiences.md) for the full guide.

--- a/docs/examples/compare_job.md
+++ b/docs/examples/compare_job.md
@@ -108,6 +108,8 @@ In this example, we compare images from two image generation models (Flux and Mi
             context=prompt
         )
 
+    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+
     job_definition = client.job.create_compare_job_definition(
         name="Example Image Prompt Alignment Job",
         instruction="Which image follows the prompt more accurately?",

--- a/docs/examples/draw_job.md
+++ b/docs/examples/draw_job.md
@@ -87,6 +87,8 @@ Like any other job, a draw job can be assigned to any audience — a ready-to-go
             truths=truths,
         )
 
+    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+
     job_definition = client.job.create_draw_job_definition(
         name="Artifact Drawing Example",
         instruction="Color in the visual glitches or errors in the image.",

--- a/docs/examples/draw_job.md
+++ b/docs/examples/draw_job.md
@@ -87,7 +87,7 @@ Like any other job, a draw job can be assigned to any audience — a ready-to-go
             truths=truths,
         )
 
-    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+    audience.start_recruiting() # (2)!
 
     job_definition = client.job.create_draw_job_definition(
         name="Artifact Drawing Example",
@@ -104,6 +104,7 @@ Like any other job, a draw job can be assigned to any audience — a ready-to-go
     ```
 
     1. Creates a new, empty audience. The `add_draw_example` calls train and filter the labelers who join it.
+    2. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
 
     !!! note
         Review every qualification example and its truth regions carefully, and add more than the few shown here for production workloads — see [Custom Audiences](../audiences.md) for the full guide.

--- a/docs/examples/locate_job.md
+++ b/docs/examples/locate_job.md
@@ -86,6 +86,8 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
             truths=truths,
         )
 
+    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+
     job_definition = client.job.create_locate_job_definition(
         name="Artifact Detection Example",
         instruction="Tap on any visual glitches or errors in the image.",

--- a/docs/examples/locate_job.md
+++ b/docs/examples/locate_job.md
@@ -86,7 +86,7 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
             truths=truths,
         )
 
-    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+    audience.start_recruiting() # (2)!
 
     job_definition = client.job.create_locate_job_definition(
         name="Artifact Detection Example",
@@ -103,6 +103,7 @@ Like any other job, a locate job can be assigned to any audience — a ready-to-
     ```
 
     1. Creates a new, empty audience. The `add_locate_example` calls train and filter the labelers who join it.
+    2. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
 
     !!! note
         Review every qualification example and its truth regions carefully, and add more than the few shown here for production workloads — see [Custom Audiences](../audiences.md) for the full guide.

--- a/docs/examples/select_words_job.md
+++ b/docs/examples/select_words_job.md
@@ -122,6 +122,8 @@ Like any other job, a select words job can be assigned to any audience — a rea
             truths=truths,
         )
 
+    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+
     job_definition = client.job.create_select_words_job_definition(
         name="Image-Text Alignment Example",
         instruction="The image is based on the text below. Select mistakes, i.e., words that are not aligned with the image.",

--- a/docs/examples/select_words_job.md
+++ b/docs/examples/select_words_job.md
@@ -122,7 +122,7 @@ Like any other job, a select words job can be assigned to any audience — a rea
             truths=truths,
         )
 
-    audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+    audience.start_recruiting() # (2)!
 
     job_definition = client.job.create_select_words_job_definition(
         name="Image-Text Alignment Example",
@@ -140,6 +140,7 @@ Like any other job, a select words job can be assigned to any audience — a rea
     ```
 
     1. Creates a new, empty audience. The `add_select_words_example` calls train and filter the labelers who join it.
+    2. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
 
     !!! note
         Review every qualification example and its truth words carefully, and add more than the few shown here for production workloads — see [Custom Audiences](../audiences.md) for the full guide.

--- a/docs/human_prompting.md
+++ b/docs/human_prompting.md
@@ -84,6 +84,8 @@ audience.add_compare_example(
     truth="https://assets.rapidata.ai/bad_ai_generated_image.png"
 )
 
+audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+
 job_definition = client.job.create_compare_job_definition(
     name="Image Coherence Comparison",
     instruction="Which image has more glitches and is more likely to be AI generated?",

--- a/docs/human_prompting.md
+++ b/docs/human_prompting.md
@@ -84,7 +84,7 @@ audience.add_compare_example(
     truth="https://assets.rapidata.ai/bad_ai_generated_image.png"
 )
 
-audience.start_recruiting()  # begin recruiting once examples are added and reviewed
+audience.start_recruiting() # (1)!
 
 job_definition = client.job.create_compare_job_definition(
     name="Image Coherence Comparison",
@@ -98,6 +98,8 @@ job_definition = client.job.create_compare_job_definition(
 job = audience.assign_job(job_definition)
 job.view()
 ```
+
+1. Starts recruiting once all qualification examples are added and reviewed. Adding examples does not start recruiting on its own.
 
 ## Common Task Types and Recommended Instructions
 

--- a/src/rapidata/rapidata_client/audience/audience_example_handler.py
+++ b/src/rapidata/rapidata_client/audience/audience_example_handler.py
@@ -51,6 +51,9 @@ from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.datapoints._truth_translator import (
     translate_compare_truth,
 )
+from rapidata.rapidata_client.workflow._base_workflow import (
+    validate_instruction_length,
+)
 
 
 def _validate_ratio(name: str, value: float | None) -> None:
@@ -96,6 +99,8 @@ class AudienceExampleHandler:
         from rapidata.api_client.models.add_example_to_audience_endpoint_input import (
             AddExampleToAudienceEndpointInput,
         )
+
+        validate_instruction_length(instruction)
 
         if not isinstance(truth, list):
             raise ValueError("Truth must be a list of strings")
@@ -167,6 +172,8 @@ class AudienceExampleHandler:
         from rapidata.api_client.models.add_example_to_audience_endpoint_input import (
             AddExampleToAudienceEndpointInput,
         )
+
+        validate_instruction_length(instruction)
 
         if truth not in datapoint:
             raise ValueError("Truth must be one of the datapoints")
@@ -240,6 +247,8 @@ class AudienceExampleHandler:
             AddExampleToAudienceEndpointInput,
         )
 
+        validate_instruction_length(instruction)
+
         if not truths:
             raise ValueError("Locate example requires at least one truth bounding box")
 
@@ -311,6 +320,8 @@ class AudienceExampleHandler:
             AddExampleToAudienceEndpointInput,
         )
 
+        validate_instruction_length(instruction)
+
         if not truths:
             raise ValueError("Draw example requires at least one truth bounding box")
 
@@ -379,6 +390,8 @@ class AudienceExampleHandler:
         from rapidata.api_client.models.add_example_to_audience_endpoint_input import (
             AddExampleToAudienceEndpointInput,
         )
+
+        validate_instruction_length(instruction)
 
         transcription_words = [
             ExampleTranscriptionWord(word=word, wordIndex=i)

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -219,7 +219,6 @@ class RapidataAudience(RapidataAudienceBase):
                 explanation,
                 settings,
             )
-            self._try_start_recruiting()
             return self
 
     def add_compare_example(
@@ -266,7 +265,6 @@ class RapidataAudience(RapidataAudienceBase):
                 explanation,
                 settings,
             )
-            self._try_start_recruiting()
             return self
 
     def add_locate_example(
@@ -310,7 +308,6 @@ class RapidataAudience(RapidataAudienceBase):
                 explanation=explanation,
                 settings=settings,
             )
-            self._try_start_recruiting()
             return self
 
     def add_draw_example(
@@ -354,7 +351,6 @@ class RapidataAudience(RapidataAudienceBase):
                 explanation=explanation,
                 settings=settings,
             )
-            self._try_start_recruiting()
             return self
 
     def add_select_words_example(
@@ -400,7 +396,6 @@ class RapidataAudience(RapidataAudienceBase):
                 explanation,
                 settings,
             )
-            self._try_start_recruiting()
             return self
 
     def get_examples(
@@ -448,35 +443,32 @@ class RapidataAudience(RapidataAudienceBase):
         with tracer.start_as_current_span("RapidataAudience._add_rapid_example"):
             logger.debug(f"Adding rapid example to audience: {self.id}")
             self._example_handler._add_rapid_example(rapid)
-            self._try_start_recruiting()
             return self
 
-    def _try_start_recruiting(self) -> None:
-        """Try to start recruiting annotators for this audience.
+    def start_recruiting(self) -> RapidataAudience:
+        """Start recruiting annotators for this audience.
 
-        This will begin the process of onboarding annotators for this audience.
-        If the recruiting has already started, it will do nothing.
+        This begins the distilling/onboarding campaign that qualifies annotators
+        against the examples added to this audience. Call it once — after all
+        qualification examples have been added and reviewed. Until it is called,
+        the audience stays in its ``Created`` status and recruits nobody, so adding
+        examples never implicitly starts recruiting.
+
+        Calling this more than once on the same instance is a no-op. A genuine
+        backend failure is raised so the caller knows recruiting did not start.
+
+        Returns:
+            RapidataAudience: The audience instance (self) for method chaining.
         """
-        from rapidata.rapidata_client.exceptions.rapidata_error import RapidataError
-
         if self._recruiting_started:
             logger.debug(f"Recruiting already started for audience: {self.id}")
-            return
+            return self
 
-        with tracer.start_as_current_span("RapidataAudience._try_start_recruiting"):
-            from rapidata.rapidata_client.api.rapidata_api_client import (
-                suppress_rapidata_error_logging,
-            )
-
+        with tracer.start_as_current_span("RapidataAudience.start_recruiting"):
             logger.debug(f"Sending request to start recruiting for audience: {self.id}")
-            with suppress_rapidata_error_logging():
-                try:
-                    self._openapi_service.audience.audience_api.audience_audience_id_recruit_post(
-                        audience_id=self.id,
-                    )
-                    logger.info(f"Started recruiting for audience: {self.id}")
-                    self._recruiting_started = True
-                except RapidataError as e:
-                    logger.debug(
-                        f"Error starting recruiting for audience: {self.id} - {e}"
-                    )
+            self._openapi_service.audience.audience_api.audience_audience_id_recruit_post(
+                audience_id=self.id,
+            )
+            logger.info(f"Started recruiting for audience: {self.id}")
+            self._recruiting_started = True
+            return self

--- a/src/rapidata/rapidata_client/workflow/_base_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_base_workflow.py
@@ -8,9 +8,28 @@ from rapidata.api_client.models.i_rapid_payload import IRapidPayload
 from rapidata.rapidata_client.datapoints._datapoint import Datapoint
 from rapidata.api_client.models.rapid_modality import RapidModality
 
+MAX_INSTRUCTION_LENGTH: int = 250
+
+
+def validate_instruction_length(
+    instruction: str, max_length: int = MAX_INSTRUCTION_LENGTH
+) -> None:
+    """Raise ``ValueError`` if ``instruction`` is longer than ``max_length``.
+
+    Shared by the workflow base class and the audience example handler so the
+    limit (and its message) live in exactly one place. The limit mirrors the
+    backend's unified instruction limit across all SDK-reachable task types.
+    """
+    if len(instruction) > max_length:
+        raise ValueError(
+            f"instruction is {len(instruction)} characters; maximum is {max_length}"
+        )
+
 
 class Workflow(ABC):
     modality: RapidModality
+
+    MAX_INSTRUCTION_LENGTH: int = MAX_INSTRUCTION_LENGTH
 
     # SDK public task-type name used to filter task-type-aware settings.
     # ``None`` means the workflow has no rapid task type (e.g. evaluation) and
@@ -20,6 +39,9 @@ class Workflow(ABC):
 
     def __init__(self, type: str):
         self._type = type
+
+    def _validate_instruction(self, instruction: str) -> None:
+        validate_instruction_length(instruction, self.MAX_INSTRUCTION_LENGTH)
 
     def _to_dict(self) -> dict[str, Any]:
         return {

--- a/src/rapidata/rapidata_client/workflow/_classify_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_classify_workflow.py
@@ -43,6 +43,7 @@ class ClassifyWorkflow(Workflow):
 
     def __init__(self, instruction: str, answer_options: list[str]):
         super().__init__(type="SimpleWorkflowConfig")
+        self._validate_instruction(instruction)
         self._instruction = instruction
         self._answer_options = answer_options
 

--- a/src/rapidata/rapidata_client/workflow/_compare_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_compare_workflow.py
@@ -37,6 +37,7 @@ class CompareWorkflow(Workflow):
 
     def __init__(self, instruction: str, a_b_names: list[str] | None = None):
         super().__init__(type="CompareWorkflowConfig")
+        self._validate_instruction(instruction)
         self._instruction = instruction
         self._a_b_names = a_b_names
 

--- a/src/rapidata/rapidata_client/workflow/_draw_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_draw_workflow.py
@@ -23,6 +23,7 @@ class DrawWorkflow(Workflow):
 
     def __init__(self, target: str):
         super().__init__(type="SimpleWorkflowConfig")
+        self._validate_instruction(target)
         self._target = target
 
     def _get_instruction(self) -> str:

--- a/src/rapidata/rapidata_client/workflow/_free_text_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_free_text_workflow.py
@@ -39,6 +39,7 @@ class FreeTextWorkflow(Workflow):
 
     def __init__(self, instruction: str, validation_system_prompt: str | None = None):
         super().__init__(type="SimpleWorkflowConfig")
+        self._validate_instruction(instruction)
         self._instruction = instruction
         self._validation_system_prompt = validation_system_prompt
 

--- a/src/rapidata/rapidata_client/workflow/_locate_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_locate_workflow.py
@@ -23,6 +23,7 @@ class LocateWorkflow(Workflow):
 
     def __init__(self, target: str):
         super().__init__(type="SimpleWorkflowConfig")
+        self._validate_instruction(target)
         self._target = target
 
     def _get_instruction(self) -> str:

--- a/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
@@ -45,6 +45,7 @@ class MultiRankingWorkflow(Workflow):
 
         super().__init__(type="CompareWorkflowConfig")
 
+        self._validate_instruction(instruction)
         self.instruction = instruction
         self.comparison_budget_per_ranking = comparison_budget_per_ranking
         self.random_comparisons_ratio = random_comparisons_ratio

--- a/src/rapidata/rapidata_client/workflow/_select_words_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_select_words_workflow.py
@@ -39,6 +39,7 @@ class SelectWordsWorkflow(Workflow):
 
     def __init__(self, instruction: str):
         super().__init__(type="SimpleWorkflowConfig")
+        self._validate_instruction(instruction)
         self._instruction = instruction
 
     def _get_instruction(self) -> str:

--- a/src/rapidata/rapidata_client/workflow/_timestamp_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_timestamp_workflow.py
@@ -36,6 +36,7 @@ class TimestampWorkflow(Workflow):
 
     def __init__(self, instruction: str):
         super().__init__(type="SimpleWorkflowConfig")
+        self._validate_instruction(instruction)
         self._instruction = instruction
 
     def _get_instruction(self) -> str:


### PR DESCRIPTION
## What & why

Two changes from SDK integration feedback (SDK 3.16.5, Compare task).

### 1. Explicit audience recruiting lifecycle ⚠️ BREAKING

Previously, adding the **first** qualification example to a custom audience implicitly started recruiting: every `RapidataAudience.add_*_example(...)` called the private `_try_start_recruiting()`, which POSTed to the recruit endpoint on the first example. This meant recruiting could begin before all examples were uploaded and reviewed, and a mid-upload failure could leave a partially-configured **live** audience.

Recruiting is now **explicit**:

- Removed the implicit `_try_start_recruiting()` call from every `add_*_example` method and from `_add_rapid_example`.
- Replaced the private helper with a public, chainable **`start_recruiting() -> RapidataAudience`**. It is idempotent per instance (a second call is a no-op via the existing `_recruiting_started` guard), and — unlike the old private version — it **no longer swallows `RapidataError`**, so a genuine failure propagates and the caller knows recruiting did not start.

New lifecycle: `create_audience(...)` → `add_*_example(...)` (no recruiting) → `start_recruiting()`. The backend audience stays in its existing `Created` status until `start_recruiting()` is called; no backend change is involved for this part.

**🚨 Breaking change:** code relying on auto-recruit-on-first-example must now call `audience.start_recruiting()` after all qualification examples are added and reviewed. Without it, the audience never recruits.

### 2. Local instruction length validation (uniform 250)

Instructions over the limit were only rejected by the backend mid-mutation (after assets/datasets were already uploaded), surfacing as a generic `RapidataError`. This validates locally at object construction and raises immediately with a clear message:

```
instruction is 256 characters; maximum is 250
```

- Added `Workflow.MAX_INSTRUCTION_LENGTH = 250` and a shared `validate_instruction_length(...)` helper (single source of truth) on the workflow base class.
- Called it in `__init__` of every instruction-bearing workflow: compare, classify, free text, locate (target), draw (target), select words, multi-ranking, timestamp. (Evaluation workflow has no user-facing instruction field, so nothing to validate.)
- Applied the **same** 250 check to audience qualification examples (which write criteria/title/target directly without building a Workflow) in `audience_example_handler.py` — classification (title), compare (criteria), locate (target), draw (target), select words (title) — **before any asset upload**, reusing the same shared validator so the number isn't duplicated.

The backend limit has been unified to 250 across all SDK-reachable task types; the sibling backend PR lowers Compare/FreeText/Locate/Line from 255 to 250 (Classify/Transcription were already 250).

**Sibling PR:** RapidataAI/rapidata-backend#4798 — `fix(rapid): unify instruction length limit 250`

### 3. Docs & examples

Because recruiting is no longer automatic, every doc that creates a custom audience, adds examples, then runs a job now calls `start_recruiting()` before assigning the job: `docs/audiences.md` (new explicit "Start Recruiting" step + prose note + complete example), `docs/human_prompting.md`, `docs/confidence_stopping.md` (both snippets), and the custom-audience sections of the compare/classify/locate/draw/select-words example docs.

## Verification

- `pyright src/rapidata/rapidata_client` → 0 errors
- `black --check` on touched files → clean
- `from rapidata import RapidataClient` → OK
- `mkdocs build` (docs group) → builds (only pre-existing warnings)
- Boundary check: 250 chars accepted, 256 raises `instruction is 256 characters; maximum is 250`

🔗 Session: https://node-6fff3183.poseidon.rapidata.internal/