### PR TITLE
feat(audience): warn when a job is assigned to an unrecruited audience

### DIFF
--- a/src/rapidata/rapidata_client/audience/_audience_base.py
+++ b/src/rapidata/rapidata_client/audience/_audience_base.py
@@ -93,7 +93,18 @@ class RapidataAudienceBase:
                 f"Job '{job.name}' is now viewable under: {job.job_details_page}"
             )
             self._warn_if_cost_exceeds_balance(job, response.cost_warning)
+            self._warn_if_no_graduated_annotators(job)
             return job
+
+    def _warn_if_no_graduated_annotators(self, job: RapidataJob) -> None:
+        """Hook: warn when no annotator has graduated to answer the job yet.
+
+        A filtered audience always reuses its base audience's already-qualified
+        pool, so it has annotators by construction — only :class:`RapidataAudience`
+        overrides this to warn about a dimension audience that has yet to graduate
+        anyone.
+        """
+        return None
 
     @staticmethod
     def _warn_if_cost_exceeds_balance(

--- a/src/rapidata/rapidata_client/audience/rapidata_audience.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from rapidata.rapidata_client.validation.rapids.rapids import Rapid
     from rapidata.rapidata_client.validation.rapids.box import Box
     from rapidata.rapidata_client.settings._rapidata_setting import RapidataSetting
+    from rapidata.rapidata_client.job.rapidata_job import RapidataJob
     import pandas as pd
 
 
@@ -494,3 +495,39 @@ class RapidataAudience(RapidataAudienceBase):
             logger.info(f"Started recruiting for audience: {self.id}")
             self._recruiting_started = True
             return self
+
+    def _warn_if_no_graduated_annotators(self, job: RapidataJob) -> None:
+        """Warn when no annotator has graduated into this audience yet.
+
+        A job only draws responses from graduated annotators, and annotators only
+        graduate once the audience has enough qualification examples and recruiting
+        has started. Until one does, the job receives nothing, so surface it.
+        Advisory only — the job is created regardless — so a failure to read the
+        recruiting funnel must not break assignment.
+        """
+        try:
+            metrics = self.get_recruiting_metrics()
+        except Exception:
+            logger.debug(
+                "Could not read recruiting metrics for audience '%s'",
+                self.id,
+                exc_info=True,
+            )
+            return
+
+        if metrics.graduated > 0:
+            return
+
+        logger.warning(
+            "Audience '%s' (%s) has no graduated annotators yet (%d still distilling), "
+            "so job '%s' will receive 0 responses until annotators graduate into it. "
+            "Annotators only graduate once the audience has at least 3 qualification "
+            "examples and recruiting has started: if recruiting is already underway "
+            "this may just need time, otherwise add examples and call "
+            "start_recruiting(). For a task that needs no special qualification, assign "
+            'the job to the ready-to-go "global" audience instead.',
+            self._name,
+            self.id,
+            metrics.distilling,
+            job.name,
+        )

--- a/src/rapidata/rapidata_client/audience/recruiting.py
+++ b/src/rapidata/rapidata_client/audience/recruiting.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping
+from typing import TYPE_CHECKING, Mapping
+
+if TYPE_CHECKING:
+    from rapidata.api_client.models.audience_status import AudienceStatus
 
 
 @dataclass(frozen=True)
@@ -55,3 +58,25 @@ class RecruitingMetrics:
             dropped=dropped,
             inactive=inactive,
         )
+
+
+def audience_will_never_produce_responses(
+    status: AudienceStatus, metrics: RecruitingMetrics | None
+) -> bool:
+    """Whether an audience can never answer a job assigned to it without the caller acting.
+
+    A job only draws responses from graduated annotators, so this is ``True`` only when
+    nobody has graduated *and* nobody ever will on the audience's own: recruiting was
+    never started, or the audience is marked ready yet its pool is empty. An audience
+    that is still recruiting (someone distilling, or status still Pending/Recruiting) is
+    filling up — waiting, not stuck — and a curated audience (no funnel of its own,
+    ``metrics is None``) draws on its own ready pool, so neither returns ``True``.
+    """
+    from rapidata.api_client.models.audience_status import AudienceStatus
+
+    if metrics is not None and (metrics.graduated > 0 or metrics.distilling > 0):
+        return False
+    if status == AudienceStatus.CREATED:
+        return True
+    # Marked ready but the funnel confirms nobody graduated or is distilling.
+    return status == AudienceStatus.READY and metrics is not None

--- a/src/rapidata/rapidata_client/job/rapidata_job.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job.py
@@ -117,6 +117,51 @@ class RapidataJob:
             f"once approved, call this again."
         )
 
+    def _raise_if_audience_cannot_produce_responses(self) -> None:
+        """Raises if the job's audience can never produce a response.
+
+        A job only draws responses from graduated annotators. When none have
+        graduated *and* none ever will without action — recruiting never started, or
+        the audience is marked ready yet its pool is empty — the job can never reach
+        Completed, so waiting on it would block the caller forever, exactly like the
+        ManualApproval / SpendLimited states. A pool that is merely early in recruiting
+        (0 graduated but still distilling, or status Pending/Recruiting) is not stuck
+        and does not raise, and neither does a curated audience (no funnel of its own).
+        A failed read is treated as "unknown" and does not raise.
+        """
+        from rapidata.rapidata_client.audience.recruiting import (
+            audience_will_never_produce_responses,
+        )
+
+        metrics = self._get_recruiting_metrics()
+        if metrics is not None and (metrics.graduated > 0 or metrics.distilling > 0):
+            return
+
+        try:
+            with suppress_rapidata_error_logging():
+                audience = self._openapi_service.audience.audience_api.audience_audience_id_get(
+                    self.audience_id
+                )
+        except Exception:
+            logger.debug(
+                "Could not read audience status for job '%s'", self, exc_info=True
+            )
+            return
+
+        if not audience_will_never_produce_responses(audience.status, metrics):
+            return
+
+        raise Exception(
+            f"Job '{self}' is assigned to audience '{audience.name}' "
+            f"({self.audience_id}), which can never produce responses: no annotators "
+            f"have graduated and none are being recruited. A job only receives "
+            f"responses from graduated annotators, and annotators only graduate once "
+            f"the audience has at least 3 qualification examples and recruiting has "
+            f"started, so the job will never complete. Add examples and call "
+            f'start_recruiting(), or assign the job to the ready-to-go "global" '
+            f"audience for tasks that need no special qualification."
+        )
+
     def _retry_operation(
         self,
         operation: Callable[[], T],
@@ -177,6 +222,7 @@ class RapidataJob:
                 (``ManualApproval`` or ``SpendLimited``) while a different status is
                 being awaited — with the review reason when the API provides one.
         """
+        self._raise_if_audience_cannot_produce_responses()
         while True:
             job = self._fetch_job()
             current_status = job.state.value
@@ -317,9 +363,11 @@ class RapidataJob:
             RapidataResults: The results of the job.
 
         Raises:
-            Exception: If failed to get job results, or if the job is in manual
-                review (``ManualApproval``) or spend-limited (``SpendLimited``) and
-                therefore cannot complete without intervention.
+            Exception: If failed to get job results, or if the job cannot complete
+                without intervention — it is in manual review (``ManualApproval``),
+                spend-limited (``SpendLimited``), or assigned to an audience that can
+                never graduate annotators (recruiting never started, or its pool is
+                empty).
         """
         with tracer.start_as_current_span("RapidataJob.get_results"):
             from rapidata.api_client.exceptions import ApiException
@@ -358,8 +406,10 @@ class RapidataJob:
 
         Raises:
             ValueError: If refresh_rate is less than 1.
-            Exception: If the job has failed, or is in a state it can't progress out
-                of on its own (``ManualApproval`` or ``SpendLimited``).
+            Exception: If the job has failed, or can't progress on its own — it is
+                in ``ManualApproval`` or ``SpendLimited``, or assigned to an audience
+                that can never graduate annotators (recruiting never started, or its
+                pool is empty).
         """
         if refresh_rate < 1:
             raise ValueError("refresh_rate must be at least 1")
@@ -374,6 +424,8 @@ class RapidataJob:
 
         if job.state in self._BLOCKING_STATUSES:
             self._raise_for_blocking_status(job)
+
+        self._raise_if_audience_cannot_produce_responses()
 
         # Get progress from pipeline if available
         with tqdm(

--- a/tests/rapidata_client/audience/test_rapidata_audience.py
+++ b/tests/rapidata_client/audience/test_rapidata_audience.py
@@ -1,0 +1,63 @@
+"""Tests for the no-graduated-annotators warning surfaced by assign_job.
+
+A dimension audience only produces responses once annotators graduate into it,
+which needs qualification examples and started recruiting. Assigning a job while
+no annotator has graduated means the job receives zero responses, so assign_job
+logs an advisory warning. The job is created regardless; a filtered audience
+(which reuses its base's qualified pool) never warns.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import rapidata.rapidata_client.audience.rapidata_audience as audience_module
+from rapidata.rapidata_client.audience.rapidata_audience import RapidataAudience
+
+
+def _make_audience(
+    users_per_state: dict[str, int],
+) -> tuple[RapidataAudience, MagicMock]:
+    openapi_service = MagicMock()
+    openapi_service.environment = "rapidata.ai"
+
+    response = MagicMock()
+    response.job_id = "job-1"
+    response.cost_warning = None
+    openapi_service.order.job_api.job_post.return_value = response
+
+    openapi_service.audience.audience_api.audience_audience_id_user_metrics_get.return_value.users_per_state = (
+        users_per_state
+    )
+
+    audience = RapidataAudience(
+        id="aud-1", name="My Audience", filters=[], openapi_service=openapi_service
+    )
+    return audience, openapi_service
+
+
+def test_assign_job_warns_when_no_annotators_have_graduated(monkeypatch):
+    # Recruiting is underway (some distilling) but nobody has graduated yet.
+    audience, _ = _make_audience({"Distilling": 5})
+
+    warn = MagicMock()
+    monkeypatch.setattr(audience_module.logger, "warning", warn)
+
+    audience.assign_job(MagicMock(id="def-1", name="My Job"))
+
+    warn.assert_called_once()
+    message = warn.call_args.args[0].lower()
+    assert "graduate" in message
+    assert "global" in message
+
+
+def test_assign_job_no_warning_when_audience_has_graduated_annotators(monkeypatch):
+    audience, _ = _make_audience({"Graduated": 12, "Distilling": 3})
+
+    warn = MagicMock()
+    monkeypatch.setattr(audience_module.logger, "warning", warn)
+
+    job = audience.assign_job(MagicMock(id="def-1", name="My Job"))
+
+    warn.assert_not_called()
+    assert job.id == "job-1"

--- a/tests/rapidata_client/audience/test_recruiting.py
+++ b/tests/rapidata_client/audience/test_recruiting.py
@@ -1,0 +1,53 @@
+"""Tests for the audience_will_never_produce_responses verdict.
+
+The verdict tells a stuck audience (recruiting never started, or marked ready with
+an empty pool) apart from one that is merely early in recruiting — the latter must
+NOT be judged stuck, or a blocking get_results() would raise on a healthy audience
+that just needs time. Curated audiences (no funnel of their own) are never stuck.
+"""
+
+from __future__ import annotations
+
+from rapidata.api_client.models.audience_status import AudienceStatus
+from rapidata.rapidata_client.audience.recruiting import (
+    RecruitingMetrics,
+    audience_will_never_produce_responses,
+)
+
+
+def _metrics(graduated=0, distilling=0, dropped=0, inactive=0) -> RecruitingMetrics:
+    return RecruitingMetrics(
+        graduated=graduated, distilling=distilling, dropped=dropped, inactive=inactive
+    )
+
+
+def test_graduated_annotators_can_answer():
+    m = _metrics(graduated=4)
+    assert not audience_will_never_produce_responses(AudienceStatus.READY, m)
+
+
+def test_distilling_is_filling_up_not_stuck():
+    m = _metrics(distilling=6)
+    assert not audience_will_never_produce_responses(AudienceStatus.RECRUITING, m)
+
+
+def test_created_never_recruited_is_stuck():
+    # Never-recruited audience has no funnel of its own.
+    assert audience_will_never_produce_responses(AudienceStatus.CREATED, None)
+
+
+def test_early_recruiting_with_empty_funnel_is_not_stuck():
+    # Recruiting has started but nobody has entered the funnel yet — give it time.
+    assert not audience_will_never_produce_responses(AudienceStatus.PENDING, None)
+    assert not audience_will_never_produce_responses(AudienceStatus.RECRUITING, None)
+
+
+def test_curated_audience_is_not_stuck():
+    # Curated audiences report no funnel (None) and draw on their own ready pool.
+    assert not audience_will_never_produce_responses(AudienceStatus.READY, None)
+
+
+def test_ready_but_empty_pool_is_stuck():
+    # Marked ready, yet the funnel confirms nobody graduated or is distilling.
+    m = _metrics(dropped=3, inactive=1)
+    assert audience_will_never_produce_responses(AudienceStatus.READY, m)

--- a/tests/rapidata_client/job/test_rapidata_job.py
+++ b/tests/rapidata_client/job/test_rapidata_job.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from rapidata.api_client.models.audience_job_state import AudienceJobState
+from rapidata.api_client.models.audience_status import AudienceStatus
 from rapidata.api_client.models.review_reason_model import ReviewReasonModel
 from rapidata.rapidata_client.job.rapidata_job import RapidataJob
 
@@ -26,14 +27,32 @@ def _job_get(state: str, review_reason: ReviewReasonModel | None = None) -> Magi
     return job
 
 
-def _make_job(job_get: MagicMock) -> tuple[RapidataJob, MagicMock]:
+def _make_job(
+    job_get: MagicMock,
+    audience_status: AudienceStatus = AudienceStatus.READY,
+    users_per_state: dict[str, int] | None = None,
+    audience_id: str = "aud-1",
+) -> tuple[RapidataJob, MagicMock]:
+    # Default to a healthy pool with graduated annotators so the readiness check is a
+    # no-op unless a test opts into an empty/stuck funnel.
+    if users_per_state is None:
+        users_per_state = {"Graduated": 5}
     openapi_service = MagicMock()
     openapi_service.environment = "rapidata.ai"
     openapi_service.order.job_api.job_job_id_get.return_value = job_get
+    audience = MagicMock()
+    audience.name = "My Audience"
+    audience.status = audience_status
+    openapi_service.audience.audience_api.audience_audience_id_get.return_value = (
+        audience
+    )
+    openapi_service.audience.audience_api.audience_audience_id_user_metrics_get.return_value.users_per_state = (
+        users_per_state
+    )
     job = RapidataJob(
         job_id="job-1",
         name="My Job",
-        audience_id="aud-1",
+        audience_id=audience_id,
         created_at=MagicMock(),
         definition_id="def-1",
         openapi_service=openapi_service,
@@ -85,6 +104,65 @@ def test_display_progress_bar_raises_on_spend_limited():
         job.display_progress_bar()
 
     assert "spend-limited" in str(excinfo.value).lower()
+
+
+def test_get_results_raises_when_recruiting_never_started():
+    # Never-recruited audience: empty funnel, status Created.
+    job, _ = _make_job(
+        _job_get("Running"),
+        audience_status=AudienceStatus.CREATED,
+        users_per_state={},
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        job.get_results()
+
+    message = str(excinfo.value)
+    assert "can never produce responses" in message.lower()
+    assert "start_recruiting()" in message
+    assert "global" in message.lower()
+
+
+def test_get_results_raises_when_pool_empty_but_marked_ready():
+    # Marked ready, but the funnel shows nobody graduated or distilling.
+    job, _ = _make_job(
+        _job_get("Running"),
+        audience_status=AudienceStatus.READY,
+        users_per_state={"Dropped": 3, "Inactive": 1},
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        job.get_results()
+
+    assert "can never produce responses" in str(excinfo.value).lower()
+
+
+def test_display_progress_bar_raises_when_recruiting_never_started():
+    job, _ = _make_job(
+        _job_get("Running"),
+        audience_status=AudienceStatus.CREATED,
+        users_per_state={},
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        job.display_progress_bar()
+
+    assert "can never produce responses" in str(excinfo.value).lower()
+
+
+def test_get_results_skips_status_probe_when_annotators_graduated():
+    # With graduated annotators the funnel already proves the job can be answered,
+    # so there is no need to fetch the audience status.
+    job, openapi_service = _make_job(
+        _job_get("Completed"), users_per_state={"Graduated": 8}
+    )
+    openapi_service.order.job_api.job_job_id_download_results_get.return_value = (
+        json.dumps({"info": {}, "results": []})
+    )
+
+    job.get_results()
+
+    openapi_service.audience.audience_api.audience_audience_id_get.assert_not_called()
 
 
 def test_get_results_happy_path_returns_results():


### PR DESCRIPTION
## Problem

A job only draws responses from **graduated** annotators, and annotators only graduate once the audience has enough qualification examples (min 3) **and** recruiting has started. If either is missing, a job assigned to the audience silently receives **0 responses and never completes**.

Confirmed in prod on `aud_1Pqes9kpUE7GYN`: `status='created'`, `recruiting_started_at IS NULL`, 0 examples. The app UI shows a warning banner, but a headless SDK/agent flow never renders that page.

## Change

Reuses the existing recruiting-metrics machinery (`get_recruiting_metrics` / `_get_recruiting_metrics` / `RecruitingMetrics`, added in #691) rather than the denormalised `qualifiedUserCount` — which **is not maintained (0 for every one of the 207 prod audiences)** and would misfire on healthy pools.

A new `audience_will_never_produce_responses(status, metrics)` verdict (in `recruiting.py`) separates three cases — the middle one is the whole point:

| state | verdict |
|---|---|
| someone graduated | can answer now |
| 0 graduated but **distilling**, or status Pending/Recruiting | filling up — *waiting, not stuck* |
| `status == Created`, or Ready with an empty funnel | will never produce responses |

1. **`assign_job(...)`** logs an advisory `logger.warning` (mirroring the cost-exceeds-balance warning) when the audience has **no graduated annotators yet** — reusing `get_recruiting_metrics()`. Scoped to `RapidataAudience` via an overridable hook; `RapidataFilteredAudience` reuses its base's pool and never warns.
2. **`get_results()` / `display_progress_bar()`** raise instead of blocking forever — like the existing `ManualApproval` / `SpendLimited` sites — but **only for the genuinely-stuck case**. A pool still recruiting is not raised on (the blocking wait is preserved), and a curated audience (no funnel of its own → `metrics is None`) never trips it.

Detection: live recruiting funnel + `AudienceStatus`, both best-effort (a failed read is treated as unknown and never blocks assignment or fabricates a stuck error). No generated-client / mustache changes.

## Tests

`pytest` 24 passed, `pyright` 0 errors, `black` clean. New: verdict unit tests (incl. *early-recruiting is not stuck*, *curated not stuck*), assign_job warn/silent, get_results/display raise for never-recruited and ready-but-empty, and status-probe short-circuit when annotators graduated.

> Note: an earlier revision used `qualifiedUserCount` + an examples-count probe; reworked per review to reuse the recruiting funnel after confirming `qualifiedUserCount` is a dead column in prod.
>
> A companion docs PR is being opened in RapidataAI/skills.

Session: https://node-4963476f.poseidon.rapidata.internal/