### PR TITLE
fix(upload): reduce disk-cache file-descriptor use to avoid EMFILE

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -46,7 +46,7 @@ logger.info("This will be shown") # (2)!
 | `cacheToDisk` | `bool` | `True` | Enable disk-based caching for file uploads |
 | `cacheTimeout` | `float` | `1` | Cache operation timeout in seconds |
 | `cacheLocation` | `Path` | `~/.cache/rapidata/upload_cache` | Directory for cache storage (immutable) |
-| `cacheShards` | `int` | `128` | Number of cache shards for parallel access (immutable) |
+| `cacheShards` | `int` | `32` | Number of disk-cache shards for concurrent access (immutable). Each shard holds open file handles — see [Too many open files](#too-many-open-files) |
 | `batchSize` | `int` | `1000` | Number of URLs per batch (100–5000) |
 | `batchPollInterval` | `float` | `0.5` | Batch polling interval in seconds |
 | `compression` | `CompressionConfig \| None` | `None` | Per-upload image-compression settings; see [Compression override](#compression-override) below. |
@@ -66,6 +66,24 @@ rapidata_config.upload.compression = CompressionConfig(
 ```
 
 Any field left as `None` falls back to the server-side default. Currently applies to single-asset uploads (`/asset/file` and `/asset/url`); batched URL uploads will pick the override up in a follow-up after the OpenAPI client regenerates.
+
+#### Too many open files
+
+Uploading local files opens file descriptors — for the on-disk upload cache (one set of handles per `cacheShards`), the worker pool (`maxWorkers`), and the HTTP connections. On systems with a low `ulimit -n` (1024 is common), a large or highly concurrent upload can exhaust the limit and fail with `OSError: [Errno 24] Too many open files`.
+
+Two ways to resolve it:
+
+- **Raise the OS limit** (per shell): `ulimit -n 8192`.
+- **Lower the SDK's footprint** — reduce the cache shards and/or the worker pool:
+
+    ```bash
+    export RAPIDATA_cacheShards=16   # fewer cache shards = fewer open handles
+    export RAPIDATA_maxWorkers=10    # fewer concurrent uploads
+    ```
+
+    `cacheShards` is immutable at runtime, so set it via the environment variable (or a `.env` file); `maxWorkers` can also be set in code (`rapidata_config.upload.maxWorkers = 10`).
+
+The default `cacheShards` of 32 keeps a single upload well under a 1024 limit; lower it further only if you run many upload processes concurrently against the same limit.
 
 ## Environment Variables
 
@@ -107,7 +125,7 @@ RAPIDATA_maxRetries=3
 RAPIDATA_cacheToDisk=true
 RAPIDATA_cacheTimeout=1
 RAPIDATA_cacheLocation=~/.cache/rapidata/upload_cache
-RAPIDATA_cacheShards=128
+RAPIDATA_cacheShards=32
 RAPIDATA_batchSize=1000
 RAPIDATA_batchPollInterval=0.5
 

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -174,3 +174,9 @@ except FailedUploadException as e:
 ```
 
 Note that this only re-uploads the datapoints; it does not create the job definition. Prefer `exception.retry()` unless you specifically need the lower-level control.
+
+## Too many open files
+
+If uploads fail with `OSError: [Errno 24] Too many open files`, the process has hit its file-descriptor limit — the upload cache, worker pool, and HTTP connections all consume descriptors. When the SDK detects this it appends a hint to the `FailedUploadException` message pointing at the relevant knobs.
+
+Raise the OS limit (`ulimit -n 8192`) or lower the SDK's footprint with `RAPIDATA_cacheShards` / `RAPIDATA_maxWorkers`. See [Too many open files](config.md#too-many-open-files) in the configuration guide for details.

--- a/src/rapidata/rapidata_client/config/upload_config.py
+++ b/src/rapidata/rapidata_client/config/upload_config.py
@@ -91,9 +91,12 @@ class UploadConfig(BaseModel):
         cacheTimeout (float): Cache operation timeout in seconds. Defaults to 0.1.
         cacheLocation (Path): Directory for cache storage. Defaults to ~/.cache/rapidata/upload_cache.
             This is immutable. Only used for file uploads when cacheToDisk=True.
-        cacheShards (int): Number of cache shards for parallel access. Defaults to 128.
-            Higher values improve concurrency but increase file handles. Must be positive.
-            This is immutable. Only used for file uploads when cacheToDisk=True.
+        cacheShards (int): Number of disk-cache shards for concurrent file-cache access. Defaults to 32.
+            Each shard is a separate on-disk store that holds open file handles, so a higher value
+            raises the process's file-descriptor count — which can exceed a low ``ulimit -n`` and
+            surface as "Too many open files". 32 comfortably covers the default ``maxWorkers`` of 25.
+            Must be positive. Immutable at runtime — set it via the ``RAPIDATA_cacheShards`` environment
+            variable. Only used for file uploads when cacheToDisk=True.
         enableBatchUpload (bool): Enable batch URL uploading (two-step process). Defaults to True.
         batchSize (int): Number of URLs per batch (100-5000). Defaults to 1000.
         batchPollInterval (float): Polling interval in seconds. Defaults to 0.5.
@@ -134,8 +137,9 @@ class UploadConfig(BaseModel):
         frozen=True,
     )
     cacheShards: int = Field(
-        default=128,
+        default=32,
         frozen=True,
+        description="Disk-cache shards. Each opens file handles; keep low enough for ulimit -n.",
     )
     batchSize: int = Field(
         default=1000,

--- a/src/rapidata/rapidata_client/exceptions/failed_upload_exception.py
+++ b/src/rapidata/rapidata_client/exceptions/failed_upload_exception.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import errno
 from rapidata.rapidata_client.datapoints._datapoint import Datapoint
 from .failed_upload import FailedUpload
 from typing import TYPE_CHECKING, Optional
@@ -95,6 +96,20 @@ class FailedUploadException(Exception):
             grouped[failed_upload.error_message].append(failed_upload.item)
         return dict(grouped)
 
+    def _has_fd_exhaustion_failure(self) -> bool:
+        """Whether any failure looks like the OS running out of file descriptors.
+
+        Checks the errno first (EMFILE), falling back to the message text for
+        cases where the OSError was wrapped or stringified before it reached us.
+        """
+        for fu in self._failed_uploads:
+            exc = fu.exception
+            if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
+                return True
+            if "too many open files" in fu.error_message.lower():
+                return True
+        return False
+
     def __str__(self) -> str:
         total = len(self._failed_uploads)
         if total == 0:
@@ -119,6 +134,16 @@ class FailedUploadException(Exception):
             lines.append("  ]")
 
         failed_upload_message = "\n".join(lines)
+        if self._has_fd_exhaustion_failure():
+            failed_upload_message += (
+                "\n\nThese failures look like file-descriptor exhaustion ('Too many open "
+                "files'). The upload cache and worker pool each hold open file handles, so a "
+                "large or concurrent upload can exceed a low 'ulimit -n'. To fix, either raise "
+                "the OS limit (e.g. 'ulimit -n 8192') or lower the SDK's footprint via the "
+                "'RAPIDATA_cacheShards' (default 32) and 'RAPIDATA_maxWorkers' (default 25) "
+                "environment variables. See "
+                "https://docs.rapidata.ai/3.x/config/#upload-configuration-options"
+            )
         if self.machine is not None:
             failed_upload_message += (
                 "\n\nNo job definition was created because the upload stayed outside the "

--- a/tests/rapidata_client/exceptions/test_failed_upload_exception.py
+++ b/tests/rapidata_client/exceptions/test_failed_upload_exception.py
@@ -1,0 +1,51 @@
+"""Tests for FailedUploadException message rendering.
+
+Focused on the file-descriptor-exhaustion hint: when an upload fails because the
+process ran out of file descriptors, the exception message must point the user
+at the knobs (cacheShards / maxWorkers / ulimit) rather than only listing the
+raw OSError.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from rapidata.rapidata_client.exceptions.failed_upload import FailedUpload
+from rapidata.rapidata_client.exceptions.failed_upload_exception import (
+    FailedUploadException,
+)
+
+
+def _exception(failed_uploads: list[FailedUpload]) -> FailedUploadException:
+    return FailedUploadException(dataset=MagicMock(), failed_uploads=failed_uploads)
+
+
+def test_hint_added_when_errno_is_emfile() -> None:
+    exc = OSError(24, "Too many open files")
+    failure = FailedUpload.from_exception("img.jpg", exc)
+
+    message = str(_exception([failure]))
+
+    assert "file-descriptor exhaustion" in message
+    assert "RAPIDATA_cacheShards" in message
+    assert "RAPIDATA_maxWorkers" in message
+    assert "ulimit -n" in message
+
+
+def test_hint_added_when_only_message_matches() -> None:
+    # Some layers stringify the OSError before it reaches us, losing the errno.
+    failure = FailedUpload(
+        item="img.jpg",
+        error_message="[Errno 24] Too many open files: 'img.jpg'",
+        error_type="OSError",
+    )
+
+    assert "file-descriptor exhaustion" in str(_exception([failure]))
+
+
+def test_no_hint_for_unrelated_failures() -> None:
+    failure = FailedUpload(
+        item="img.jpg", error_message="404 not found", error_type="RapidataError"
+    )
+
+    assert "file-descriptor exhaustion" not in str(_exception([failure]))


### PR DESCRIPTION
## Problem

Submitting local-file jobs on a common `ulimit -n 1024` can crash with `OSError: [Errno 24] Too many open files`. Reported from integration (SDK 3.16.5, Python 3.12, Linux, Compare task); the workaround was `ulimit -n 8192` + sequential submission.

## Root cause (measured)

The upload worker pool is **already bounded** (`maxWorkers=25`). The dominant descriptor consumer is the on-disk upload cache — `diskcache.FanoutCache(shards=128)`:

| cacheShards | FDs at init | FDs under 25-worker load |
|---|---|---|
| **128 (old default)** | 384 | **639** |
| **32 (new default)** | 96 | 317 |
| 16 | 48 | ~260 |

A single default-config process already holds ~640 descriptors for the cache alone, before open files + HTTP connections — right at the edge of a 1024 limit.

## Change

- **`cacheShards` default 128 → 32.** Shards only reduce SQLite write-lock contention, and cache writes are tiny `key → filename` strings written *after* the network upload. At 25 workers, 32 shards (≥ worker count) costs nothing measurable while cutting cache descriptors ~640 → ~317 — enough headroom for several concurrent processes under 1024. Benchmarked: fewer shards was not slower.
- **Kept `cacheShards` decoupled from `maxWorkers`.** Deriving shards from the worker count would change the `key → shard` mapping and silently invalidate the persistent cross-run upload cache every time workers changed (verified: 32→16 shards = ~57% cache miss). A stable static default reshuffles the on-disk cache exactly once (on upgrade).
- **Made the failure discoverable.** `FailedUploadException` now detects descriptor-exhaustion failures (EMFILE errno, with a message-text fallback) and appends a hint pointing at `RAPIDATA_cacheShards` / `RAPIDATA_maxWorkers` / `ulimit -n` and the config docs. New "Too many open files" sections in `docs/config.md` and `docs/error_handling.md`.
- **No self-bumping of the OS limit** (deliberate — a library shouldn't mutate process rlimits) and **no new per-call `max_upload_workers` param** (the global `rapidata_config.upload.maxWorkers` covers all upload paths uniformly). Both were discussed and decided with the requester.

## Compatibility with #687

Lands cleanly on top of the sibling's merged #687 (atomic job creation). #687's only `upload_config.py` edit was additive (`failureTolerance`) — no conflict. All changes here sit *below* the `JobDefinitionCreationMachine`, inside its `UPLOAD_DATAPOINTS` step, so the concurrency bound already respects the atomic upload-then-persist ordering; **no control flow was forked or reverted.** #687 also gave the error hint a natural home — `FailedUploadException` is now the single chokepoint where mass-EMFILE failures surface.

## One-time impact

Changing the shard count reshuffles the on-disk cache layout, so anyone with an existing warm cache re-uploads previously-cached assets **once**, then re-caches under the new layout. Not a correctness issue.

## Testing

- New `tests/rapidata_client/exceptions/test_failed_upload_exception.py` (3 tests) covering the EMFILE hint (errno + message-fallback + negative case).
- `pyright src/rapidata/rapidata_client` — 0 errors (the CI gate).
- `pytest tests/rapidata_client/job tests/rapidata_client/exceptions` — 13 passed.
- `mkdocs build` — succeeds.

> Note: skipped repo-wide `black` — the currently-pinned `black>=25.11.0` reformats ~19 unrelated files vs. how the repo was last formatted, which would bury this change in churn. Added lines follow the surrounding style; CI enforces pyright only.

🔗 Session: https://node-b899e465.poseidon.rapidata.internal/