### PR TITLE
refactor(capabilities)!: collapse customer capabilities into single list

### DIFF
--- a/openapi/schemas/identity.openapi.json
+++ b/openapi/schemas/identity.openapi.json
@@ -93,7 +93,7 @@
           "Capabilities"
         ],
         "summary": "Lists the capabilities a customer holds.",
-        "description": "explicitCapabilities are grants held directly or through organization membership;\n effectiveCapabilities also folds in platform-admin access.",
+        "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.",
         "parameters": [
           {
             "name": "customerId",
@@ -2595,12 +2595,11 @@
       },
       "GetCustomerCapabilitiesEndpoint_Output": {
         "required": [
-          "explicitCapabilities",
-          "effectiveCapabilities"
+          "capabilities"
         ],
         "type": "object",
         "properties": {
-          "explicitCapabilities": {
+          "capabilities": {
             "allOf": [
               {
                 "type": "array",
@@ -2609,18 +2608,7 @@
                 }
               }
             ],
-            "description": "Capability granted to the customer directly or through organization membership."
-          },
-          "effectiveCapabilities": {
-            "allOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Capability"
-                }
-              }
-            ],
-            "description": "Capability the customer effectively holds, including platform-admin fold-in."
+            "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access."
           }
         }
       },

--- a/openapi/schemas/identity.openapi.json
+++ b/openapi/schemas/identity.openapi.json
@@ -93,7 +93,7 @@
           "Capabilities"
         ],
         "summary": "Lists the capabilities a customer holds.",
-        "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.",
+        "description": "capabilities are grants held through organization membership.",
         "parameters": [
           {
             "name": "customerId",
@@ -2608,7 +2608,7 @@
                 }
               }
             ],
-            "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access."
+            "description": "Capabilities granted to the customer through organization membership."
           }
         }
       },

--- a/openapi/schemas/rapidata.filtered.openapi.json
+++ b/openapi/schemas/rapidata.filtered.openapi.json
@@ -3496,7 +3496,7 @@
           "Campaign"
         ],
         "summary": "Sets the fast bid multiplier for a single external booster campaign to an arbitrary value.",
-        "description": "Bypasses the level→multiplier mapping. Intended for live testing and one-off\n operational tweaks. Value must be in [0, 50]; 0 effectively pauses delivery on the\n campaign without changing its status. The response reports the multiplier the\n downstream system confirms is applied.",
+        "description": "Bypasses the level\u2192multiplier mapping. Intended for live testing and one-off\n operational tweaks. Value must be in [0, 50]; 0 effectively pauses delivery on the\n campaign without changing its status. The response reports the multiplier the\n downstream system confirms is applied.",
         "parameters": [
           {
             "name": "externalCampaignId",
@@ -4182,7 +4182,7 @@
           "Campaign"
         ],
         "summary": "Replaces the campaign's stream program.",
-        "description": "The program is validated before it is persisted; a malformed graph is rejected.\n The program's version is bumped and republished — running sessions pick up the new\n program on their next response.",
+        "description": "The program is validated before it is persisted; a malformed graph is rejected.\n The program's version is bumped and republished \u2014 running sessions pick up the new\n program on their next response.",
         "parameters": [
           {
             "name": "campaignId",
@@ -6889,7 +6889,7 @@
           "Capabilities"
         ],
         "summary": "Lists the capabilities a customer holds.",
-        "description": "explicitCapabilities are grants held directly or through organization membership;\n effectiveCapabilities also folds in platform-admin access.",
+        "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.",
         "parameters": [
           {
             "name": "customerId",
@@ -22645,7 +22645,7 @@
           "Job"
         ],
         "summary": "Restarts the given rapids of a job.",
-        "description": "The old rapids are rejected (their billed responses refunded) and soft-deleted, then cloned\n into a new target group. Results regenerate automatically once the replacements finish\n collecting; the job dips below 100% progress during re-collection and climbs back. Idempotent\n per original rapid — a repeated call reuses the existing replacement.",
+        "description": "The old rapids are rejected (their billed responses refunded) and soft-deleted, then cloned\n into a new target group. Results regenerate automatically once the replacements finish\n collecting; the job dips below 100% progress during re-collection and climbs back. Idempotent\n per original rapid \u2014 a repeated call reuses the existing replacement.",
         "parameters": [
           {
             "name": "jobId",
@@ -26508,7 +26508,7 @@
           "BillingAccount"
         ],
         "summary": "Grants a voucher to a customer.",
-        "description": "Provide exactly one of validity (a duration from now) or expiresAt (an\n explicit instant) — not both, not neither. The grant immediately raises the customer's\n serve allowance.",
+        "description": "Provide exactly one of validity (a duration from now) or expiresAt (an\n explicit instant) \u2014 not both, not neither. The grant immediately raises the customer's\n serve allowance.",
         "requestBody": {
           "description": "The customer, voucher amount, and expiry.",
           "content": {
@@ -30621,7 +30621,7 @@
           "Signal"
         ],
         "summary": "Deletes a signal by its id.",
-        "description": "Soft-deleted signals (and every run they spawned) are hidden from all view / list\n endpoints — including admin endpoints — per the cascade policy.",
+        "description": "Soft-deleted signals (and every run they spawned) are hidden from all view / list\n endpoints \u2014 including admin endpoints \u2014 per the cascade policy.",
         "parameters": [
           {
             "name": "signalId",
@@ -30843,7 +30843,7 @@
           "Signal"
         ],
         "summary": "Pauses a signal.",
-        "description": "Manual triggers still fire on a paused signal — pause only affects the scheduler.",
+        "description": "Manual triggers still fire on a paused signal \u2014 pause only affects the scheduler.",
         "parameters": [
           {
             "name": "signalId",
@@ -31830,7 +31830,7 @@
           "ValidationSet"
         ],
         "summary": "Gets all validation sets available to the user that a rapid with the provided parameters can be added to.",
-        "description": "Matching is strict: a validation set is only returned when its asset type, modality, and prompt type\n equal the provided parameters exactly — the same constraint enforced when actually adding a rapid.\n This differs from /validation-set/recommended, which uses loose overlap matching and may return\n sets that then reject the rapid. Returns an empty array when no compatible set exists.",
+        "description": "Matching is strict: a validation set is only returned when its asset type, modality, and prompt type\n equal the provided parameters exactly \u2014 the same constraint enforced when actually adding a rapid.\n This differs from /validation-set/recommended, which uses loose overlap matching and may return\n sets that then reject the rapid. Returns an empty array when no compatible set exists.",
         "parameters": [
           {
             "name": "assetType",
@@ -34715,7 +34715,7 @@
           },
           "minResponsesToGraduate": {
             "type": "integer",
-            "description": "Minimum responses required before a user can graduate into the audience.\n Even if the user's score is at or above the graduation threshold, they will\n remain in distilling until they have answered at least this many responses.\n Must be strictly less than MaxDistillingResponses when both are set.\n Defaults to null (no minimum — users graduate as soon as the score is reached).",
+            "description": "Minimum responses required before a user can graduate into the audience.\n Even if the user's score is at or above the graduation threshold, they will\n remain in distilling until they have answered at least this many responses.\n Must be strictly less than MaxDistillingResponses when both are set.\n Defaults to null (no minimum \u2014 users graduate as soon as the score is reached).",
             "format": "uint32",
             "nullable": true
           },
@@ -38957,7 +38957,7 @@
                 "$ref": "#/components/schemas/BoostingControlMode"
               }
             ],
-            "description": "How the campaign's boost is controlled — Manual (user-editable) or Automatic\n (managed by an owning service; boost edits are rejected by the API)."
+            "description": "How the campaign's boost is controlled \u2014 Manual (user-editable) or Automatic\n (managed by an owning service; boost edits are rejected by the API)."
           },
           "ownerMail": {
             "type": "string",
@@ -39201,7 +39201,7 @@
                 "$ref": "#/components/schemas/BoostingProfile"
               }
             ],
-            "description": "The boosting profile configuration. Takes precedence over BoostLevel and\n RequiresBooster when set. Prefer BoostLevel — it lets the server derive\n the right profile (including filtered-audience creation) from the campaign's filters."
+            "description": "The boosting profile configuration. Takes precedence over BoostLevel and\n RequiresBooster when set. Prefer BoostLevel \u2014 it lets the server derive\n the right profile (including filtered-audience creation) from the campaign's filters."
           },
           "stickyConfig": {
             "allOf": [
@@ -41210,12 +41210,11 @@
       },
       "GetCustomerCapabilitiesEndpoint_Output": {
         "required": [
-          "explicitCapabilities",
-          "effectiveCapabilities"
+          "capabilities"
         ],
         "type": "object",
         "properties": {
-          "explicitCapabilities": {
+          "capabilities": {
             "allOf": [
               {
                 "type": "array",
@@ -41224,18 +41223,7 @@
                 }
               }
             ],
-            "description": "Capability granted to the customer directly or through organization membership."
-          },
-          "effectiveCapabilities": {
-            "allOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Capability"
-                }
-              }
-            ],
-            "description": "Capability the customer effectively holds, including platform-admin fold-in."
+            "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access."
           }
         }
       },
@@ -42045,7 +42033,7 @@
           },
           "initialBoostLevel": {
             "type": "integer",
-            "description": "Initial boost level applied to the campaign of every run created from this benchmark.\n Leave unset to fall back to DefaultInitialBoostLevel. Admins\n may set any value the validator allows (0-10); non-admins are restricted to\n 0..BenchmarkEntity.DefaultInitialBoostLevel — anything outside that range returns\n 403 Forbidden via IsAllowedToSetInitialBoostLevel.",
+            "description": "Initial boost level applied to the campaign of every run created from this benchmark.\n Leave unset to fall back to DefaultInitialBoostLevel. Admins\n may set any value the validator allows (0-10); non-admins are restricted to\n 0..BenchmarkEntity.DefaultInitialBoostLevel \u2014 anything outside that range returns\n 403 Forbidden via IsAllowedToSetInitialBoostLevel.",
             "format": "int32",
             "nullable": true
           },
@@ -44006,7 +43994,7 @@
           },
           "additionalInputs": {
             "type": "object",
-            "description": "Extra model inputs keyed by parameter name (e.g. \"aspect_ratio\"). The system-managed keys\n (prompt, num_outputs) must not appear here — they are supplied automatically. Values are\n validated against the model's live input schema when the faucet is set."
+            "description": "Extra model inputs keyed by parameter name (e.g. \"aspect_ratio\"). The system-managed keys\n (prompt, num_outputs) must not appear here \u2014 they are supplied automatically. Values are\n validated against the model's live input schema when the faucet is set."
           }
         },
         "description": "Configures a faucet that generates samples via the Replicate API."
@@ -46472,7 +46460,7 @@
                 "$ref": "#/components/schemas/CreateJobEndpoint_CostWarning"
               }
             ],
-            "description": "Present only when the job's estimated cost exceeds the owner's remaining balance.\n Advisory — the job is created and runs regardless; it may pause for funds mid-run."
+            "description": "Present only when the job's estimated cost exceeds the owner's remaining balance.\n Advisory \u2014 the job is created and runs regardless; it may pause for funds mid-run."
           }
         },
         "description": "The result when a job has been created."
@@ -49103,7 +49091,7 @@
           },
           "progress": {
             "type": "number",
-            "description": "Labeling completion as a ratio in the range 0–1, or null when no progress has\n been reported yet (completion sets it to 1). Sortable via ?sort=progress.",
+            "description": "Labeling completion as a ratio in the range 0\u20131, or null when no progress has\n been reported yet (completion sets it to 1). Sortable via ?sort=progress.",
             "format": "double",
             "nullable": true
           }

--- a/openapi/schemas/rapidata.filtered.openapi.json
+++ b/openapi/schemas/rapidata.filtered.openapi.json
@@ -6889,7 +6889,7 @@
           "Capabilities"
         ],
         "summary": "Lists the capabilities a customer holds.",
-        "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.",
+        "description": "capabilities are grants held through organization membership.",
         "parameters": [
           {
             "name": "customerId",
@@ -41223,7 +41223,7 @@
                 }
               }
             ],
-            "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access."
+            "description": "Capabilities granted to the customer through organization membership."
           }
         }
       },

--- a/openapi/schemas/rapidata.openapi.json
+++ b/openapi/schemas/rapidata.openapi.json
@@ -6939,7 +6939,7 @@
           "Capabilities"
         ],
         "summary": "Lists the capabilities a customer holds.",
-        "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.",
+        "description": "capabilities are grants held through organization membership.",
         "parameters": [
           {
             "name": "customerId",
@@ -43058,7 +43058,7 @@
                 }
               }
             ],
-            "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access."
+            "description": "Capabilities granted to the customer through organization membership."
           }
         }
       },

--- a/openapi/schemas/rapidata.openapi.json
+++ b/openapi/schemas/rapidata.openapi.json
@@ -3546,7 +3546,7 @@
           "Campaign"
         ],
         "summary": "Sets the fast bid multiplier for a single external booster campaign to an arbitrary value.",
-        "description": "Bypasses the level→multiplier mapping. Intended for live testing and one-off\n operational tweaks. Value must be in [0, 50]; 0 effectively pauses delivery on the\n campaign without changing its status. The response reports the multiplier the\n downstream system confirms is applied.",
+        "description": "Bypasses the level\u2192multiplier mapping. Intended for live testing and one-off\n operational tweaks. Value must be in [0, 50]; 0 effectively pauses delivery on the\n campaign without changing its status. The response reports the multiplier the\n downstream system confirms is applied.",
         "parameters": [
           {
             "name": "externalCampaignId",
@@ -4232,7 +4232,7 @@
           "Campaign"
         ],
         "summary": "Replaces the campaign's stream program.",
-        "description": "The program is validated before it is persisted; a malformed graph is rejected.\n The program's version is bumped and republished — running sessions pick up the new\n program on their next response.",
+        "description": "The program is validated before it is persisted; a malformed graph is rejected.\n The program's version is bumped and republished \u2014 running sessions pick up the new\n program on their next response.",
         "parameters": [
           {
             "name": "campaignId",
@@ -6939,7 +6939,7 @@
           "Capabilities"
         ],
         "summary": "Lists the capabilities a customer holds.",
-        "description": "explicitCapabilities are grants held directly or through organization membership;\n effectiveCapabilities also folds in platform-admin access.",
+        "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.",
         "parameters": [
           {
             "name": "customerId",
@@ -24353,7 +24353,7 @@
           "Job"
         ],
         "summary": "Restarts the given rapids of a job.",
-        "description": "The old rapids are rejected (their billed responses refunded) and soft-deleted, then cloned\n into a new target group. Results regenerate automatically once the replacements finish\n collecting; the job dips below 100% progress during re-collection and climbs back. Idempotent\n per original rapid — a repeated call reuses the existing replacement.",
+        "description": "The old rapids are rejected (their billed responses refunded) and soft-deleted, then cloned\n into a new target group. Results regenerate automatically once the replacements finish\n collecting; the job dips below 100% progress during re-collection and climbs back. Idempotent\n per original rapid \u2014 a repeated call reuses the existing replacement.",
         "parameters": [
           {
             "name": "jobId",
@@ -28216,7 +28216,7 @@
           "BillingAccount"
         ],
         "summary": "Grants a voucher to a customer.",
-        "description": "Provide exactly one of validity (a duration from now) or expiresAt (an\n explicit instant) — not both, not neither. The grant immediately raises the customer's\n serve allowance.",
+        "description": "Provide exactly one of validity (a duration from now) or expiresAt (an\n explicit instant) \u2014 not both, not neither. The grant immediately raises the customer's\n serve allowance.",
         "requestBody": {
           "description": "The customer, voucher amount, and expiry.",
           "content": {
@@ -32329,7 +32329,7 @@
           "Signal"
         ],
         "summary": "Deletes a signal by its id.",
-        "description": "Soft-deleted signals (and every run they spawned) are hidden from all view / list\n endpoints — including admin endpoints — per the cascade policy.",
+        "description": "Soft-deleted signals (and every run they spawned) are hidden from all view / list\n endpoints \u2014 including admin endpoints \u2014 per the cascade policy.",
         "parameters": [
           {
             "name": "signalId",
@@ -32551,7 +32551,7 @@
           "Signal"
         ],
         "summary": "Pauses a signal.",
-        "description": "Manual triggers still fire on a paused signal — pause only affects the scheduler.",
+        "description": "Manual triggers still fire on a paused signal \u2014 pause only affects the scheduler.",
         "parameters": [
           {
             "name": "signalId",
@@ -33538,7 +33538,7 @@
           "ValidationSet"
         ],
         "summary": "Gets all validation sets available to the user that a rapid with the provided parameters can be added to.",
-        "description": "Matching is strict: a validation set is only returned when its asset type, modality, and prompt type\n equal the provided parameters exactly — the same constraint enforced when actually adding a rapid.\n This differs from /validation-set/recommended, which uses loose overlap matching and may return\n sets that then reject the rapid. Returns an empty array when no compatible set exists.",
+        "description": "Matching is strict: a validation set is only returned when its asset type, modality, and prompt type\n equal the provided parameters exactly \u2014 the same constraint enforced when actually adding a rapid.\n This differs from /validation-set/recommended, which uses loose overlap matching and may return\n sets that then reject the rapid. Returns an empty array when no compatible set exists.",
         "parameters": [
           {
             "name": "assetType",
@@ -36423,7 +36423,7 @@
           },
           "minResponsesToGraduate": {
             "type": "integer",
-            "description": "Minimum responses required before a user can graduate into the audience.\n Even if the user's score is at or above the graduation threshold, they will\n remain in distilling until they have answered at least this many responses.\n Must be strictly less than MaxDistillingResponses when both are set.\n Defaults to null (no minimum — users graduate as soon as the score is reached).",
+            "description": "Minimum responses required before a user can graduate into the audience.\n Even if the user's score is at or above the graduation threshold, they will\n remain in distilling until they have answered at least this many responses.\n Must be strictly less than MaxDistillingResponses when both are set.\n Defaults to null (no minimum \u2014 users graduate as soon as the score is reached).",
             "format": "uint32",
             "nullable": true
           },
@@ -40722,7 +40722,7 @@
                 "$ref": "#/components/schemas/BoostingControlMode"
               }
             ],
-            "description": "How the campaign's boost is controlled — Manual (user-editable) or Automatic\n (managed by an owning service; boost edits are rejected by the API)."
+            "description": "How the campaign's boost is controlled \u2014 Manual (user-editable) or Automatic\n (managed by an owning service; boost edits are rejected by the API)."
           },
           "requiresBooster": {
             "type": "boolean",
@@ -40976,7 +40976,7 @@
                 "$ref": "#/components/schemas/BoostingProfile"
               }
             ],
-            "description": "The boosting profile configuration. Takes precedence over BoostLevel and\n RequiresBooster when set. Prefer BoostLevel — it lets the server derive\n the right profile (including filtered-audience creation) from the campaign's filters."
+            "description": "The boosting profile configuration. Takes precedence over BoostLevel and\n RequiresBooster when set. Prefer BoostLevel \u2014 it lets the server derive\n the right profile (including filtered-audience creation) from the campaign's filters."
           },
           "stickyConfig": {
             "allOf": [
@@ -43045,12 +43045,11 @@
       },
       "GetCustomerCapabilitiesEndpoint_Output": {
         "required": [
-          "explicitCapabilities",
-          "effectiveCapabilities"
+          "capabilities"
         ],
         "type": "object",
         "properties": {
-          "explicitCapabilities": {
+          "capabilities": {
             "allOf": [
               {
                 "type": "array",
@@ -43059,18 +43058,7 @@
                 }
               }
             ],
-            "description": "Capability granted to the customer directly or through organization membership."
-          },
-          "effectiveCapabilities": {
-            "allOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Capability"
-                }
-              }
-            ],
-            "description": "Capability the customer effectively holds, including platform-admin fold-in."
+            "description": "The capabilities the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access."
           }
         }
       },
@@ -43880,7 +43868,7 @@
           },
           "initialBoostLevel": {
             "type": "integer",
-            "description": "Initial boost level applied to the campaign of every run created from this benchmark.\n Leave unset to fall back to DefaultInitialBoostLevel. Admins\n may set any value the validator allows (0-10); non-admins are restricted to\n 0..BenchmarkEntity.DefaultInitialBoostLevel — anything outside that range returns\n 403 Forbidden via IsAllowedToSetInitialBoostLevel.",
+            "description": "Initial boost level applied to the campaign of every run created from this benchmark.\n Leave unset to fall back to DefaultInitialBoostLevel. Admins\n may set any value the validator allows (0-10); non-admins are restricted to\n 0..BenchmarkEntity.DefaultInitialBoostLevel \u2014 anything outside that range returns\n 403 Forbidden via IsAllowedToSetInitialBoostLevel.",
             "format": "int32",
             "nullable": true
           },
@@ -45889,7 +45877,7 @@
           },
           "additionalInputs": {
             "type": "object",
-            "description": "Extra model inputs keyed by parameter name (e.g. \"aspect_ratio\"). The system-managed keys\n (prompt, num_outputs) must not appear here — they are supplied automatically. Values are\n validated against the model's live input schema when the faucet is set."
+            "description": "Extra model inputs keyed by parameter name (e.g. \"aspect_ratio\"). The system-managed keys\n (prompt, num_outputs) must not appear here \u2014 they are supplied automatically. Values are\n validated against the model's live input schema when the faucet is set."
           }
         },
         "description": "Configures a faucet that generates samples via the Replicate API."
@@ -48368,7 +48356,7 @@
                 "$ref": "#/components/schemas/CreateJobEndpoint_CostWarning"
               }
             ],
-            "description": "Present only when the job's estimated cost exceeds the owner's remaining balance.\n Advisory — the job is created and runs regardless; it may pause for funds mid-run."
+            "description": "Present only when the job's estimated cost exceeds the owner's remaining balance.\n Advisory \u2014 the job is created and runs regardless; it may pause for funds mid-run."
           }
         },
         "description": "The result when a job has been created."
@@ -51065,7 +51053,7 @@
           },
           "progress": {
             "type": "number",
-            "description": "Labeling completion as a ratio in the range 0–1, or null when no progress has\n been reported yet (completion sets it to 1). Sortable via ?sort=progress.",
+            "description": "Labeling completion as a ratio in the range 0\u20131, or null when no progress has\n been reported yet (completion sets it to 1). Sortable via ?sort=progress.",
             "format": "double",
             "nullable": true
           }

--- a/src/rapidata/api_client/api/capabilities_api.py
+++ b/src/rapidata/api_client/api/capabilities_api.py
@@ -365,7 +365,7 @@ class CapabilitiesApi:
     ) -> GetCustomerCapabilitiesEndpointOutput:
         """Lists the capabilities a customer holds.
 
-        explicitCapabilities are grants held directly or through organization membership;  effectiveCapabilities also folds in platform-admin access.
+        capabilities are the ones the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.
 
         :param customer_id: The customer to inspect. (required)
         :type customer_id: UUID
@@ -435,7 +435,7 @@ class CapabilitiesApi:
     ) -> ApiResponse[GetCustomerCapabilitiesEndpointOutput]:
         """Lists the capabilities a customer holds.
 
-        explicitCapabilities are grants held directly or through organization membership;  effectiveCapabilities also folds in platform-admin access.
+        capabilities are the ones the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.
 
         :param customer_id: The customer to inspect. (required)
         :type customer_id: UUID
@@ -505,7 +505,7 @@ class CapabilitiesApi:
     ) -> RESTResponseType:
         """Lists the capabilities a customer holds.
 
-        explicitCapabilities are grants held directly or through organization membership;  effectiveCapabilities also folds in platform-admin access.
+        capabilities are the ones the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.
 
         :param customer_id: The customer to inspect. (required)
         :type customer_id: UUID

--- a/src/rapidata/api_client/api/capabilities_api.py
+++ b/src/rapidata/api_client/api/capabilities_api.py
@@ -365,7 +365,7 @@ class CapabilitiesApi:
     ) -> GetCustomerCapabilitiesEndpointOutput:
         """Lists the capabilities a customer holds.
 
-        capabilities are the ones the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.
+        capabilities are grants held through organization membership.
 
         :param customer_id: The customer to inspect. (required)
         :type customer_id: UUID
@@ -435,7 +435,7 @@ class CapabilitiesApi:
     ) -> ApiResponse[GetCustomerCapabilitiesEndpointOutput]:
         """Lists the capabilities a customer holds.
 
-        capabilities are the ones the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.
+        capabilities are grants held through organization membership.
 
         :param customer_id: The customer to inspect. (required)
         :type customer_id: UUID
@@ -505,7 +505,7 @@ class CapabilitiesApi:
     ) -> RESTResponseType:
         """Lists the capabilities a customer holds.
 
-        capabilities are the ones the customer effectively holds: granted directly, through organization membership, or folded in from platform-admin access.
+        capabilities are grants held through organization membership.
 
         :param customer_id: The customer to inspect. (required)
         :type customer_id: UUID

--- a/src/rapidata/api_client/models/get_customer_capabilities_endpoint_output.py
+++ b/src/rapidata/api_client/models/get_customer_capabilities_endpoint_output.py
@@ -16,7 +16,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List
 from rapidata.api_client.models.capability import Capability
 from pydantic import ValidationError
@@ -28,9 +28,8 @@ class GetCustomerCapabilitiesEndpointOutput(LazyValidatedModel):
     """
     GetCustomerCapabilitiesEndpointOutput
     """ # noqa: E501
-    explicit_capabilities: List[Capability] = Field(alias="explicitCapabilities")
-    effective_capabilities: List[Capability] = Field(alias="effectiveCapabilities")
-    __properties: ClassVar[List[str]] = ["explicitCapabilities", "effectiveCapabilities"]
+    capabilities: List[Capability]
+    __properties: ClassVar[List[str]] = ["capabilities"]
 
     # model_config is inherited from LazyValidatedModel
 
@@ -79,8 +78,7 @@ class GetCustomerCapabilitiesEndpointOutput(LazyValidatedModel):
             return cls.model_validate(obj)
 
         _data = {
-            "explicitCapabilities": obj.get("explicitCapabilities"),
-            "effectiveCapabilities": obj.get("effectiveCapabilities")
+            "capabilities": obj.get("capabilities")
         }
         try:
             _obj = cls.model_validate(_data)


### PR DESCRIPTION
## What

The backend `GET /customers/{id}/capabilities` endpoint is changing its response from `{ explicitCapabilities, effectiveCapabilities }` to a single `{ capabilities }` list — mirroring the existing organization capabilities endpoint. This updates the generated Python client to match.

## Changes

- **`models/get_customer_capabilities_endpoint_output.py`** — replaces the `explicit_capabilities` / `effective_capabilities` fields with a single `capabilities: List[Capability]` field (regenerated output, mirroring `GetOrganizationCapabilitiesEndpointOutput`).
- **`api/capabilities_api.py`** — updates the endpoint docstring that described the explicit/effective split.
- **`openapi/schemas/*.openapi.json`** — updates the committed specs (`identity`, joined `rapidata`, and `rapidata.filtered`) to the collapsed shape so a post-deploy regeneration is a no-op diff.

## ⚠️ Breaking change

`GetCustomerCapabilitiesEndpointOutput` no longer exposes `explicit_capabilities` / `effective_capabilities`; consumers must read `capabilities` instead. Version bump is handled by the `Release and Publish` workflow.

## Dependency / ordering

Depends on the sibling **rapidata-backend** PR that ships the new OpenAPI. Prod (`api.rabbitdata.ch`) still serves the old shape, so this was regenerated against the intended post-deploy contract rather than a live spec — **land after the backend is deployed**, then a regeneration will produce no diff.

## Validation

- `python3 -c "from rapidata import RapidataClient; print('OK')"` → OK
- Model round-trips `{"capabilities": [...]}` correctly; old attributes gone.
- `pyright src/rapidata/rapidata_client` → 0 errors.

🔗 Session: https://node-1a21365c.poseidon.rapidata.internal/