### PR TITLE
feat(config): opt in to explicit-content check on job assignment

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,7 @@ logger.info("This will be shown") # (2)!
 | `batchSize` | `int` | `1000` | Number of URLs per batch (100–5000) |
 | `batchPollInterval` | `float` | `0.5` | Batch polling interval in seconds |
 | `compression` | `CompressionConfig \| None` | `None` | Per-upload image-compression settings; see [Compression override](#compression-override) below. |
+| `checkForExplicitContent` | `bool \| None` | `None` | Opt in/out of the server-side explicit-content check on job assignment. `None` uses the account default; `True` forces it on; `False` requests skipping it (honored only if the account is permitted, otherwise the check still runs and a warning is logged). |
 
 #### Compression override
 

--- a/src/rapidata/rapidata_client/audience/_audience_base.py
+++ b/src/rapidata/rapidata_client/audience/_audience_base.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from rapidata.rapidata_client.config import logger, managed_print, tracer
+from rapidata.rapidata_client.config import (
+    logger,
+    managed_print,
+    rapidata_config,
+    tracer,
+)
 
 if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
@@ -78,6 +83,7 @@ class RapidataAudienceBase:
                 create_job_endpoint_input=CreateJobEndpointInput(
                     audienceId=self.id,
                     jobDefinitionId=job_definition.id,
+                    checkForExplicitContent=rapidata_config.upload.checkForExplicitContent,
                 ),
             )
             job = RapidataJob(
@@ -93,6 +99,9 @@ class RapidataAudienceBase:
                 f"Job '{job.name}' is now viewable under: {job.job_details_page}"
             )
             self._warn_if_cost_exceeds_balance(job, response.cost_warning)
+            self._warn_if_content_check_skip_denied(
+                job, response.content_check_skip_denied
+            )
             self._warn_if_no_graduated_annotators(job)
             return job
 
@@ -126,6 +135,26 @@ class RapidataAudienceBase:
             cost_warning.estimated_cost,
             cost_warning.available_balance,
             cost_warning.shortfall,
+        )
+
+    @staticmethod
+    def _warn_if_content_check_skip_denied(
+        job: RapidataJob, skip_denied: bool | None
+    ) -> None:
+        """Warn when a requested explicit-content-check skip was not permitted.
+
+        Set on the response when the caller asked to skip the check
+        (``rapidata_config.upload.checkForExplicitContent = False``) but the account
+        may not skip it — the check ran regardless. Advisory, not an error.
+        """
+        if not skip_denied:
+            return
+        logger.warning(
+            "Job '%s' requested skipping the explicit-content check, but this account is "
+            "not permitted to skip it — the check ran anyway. Unset "
+            "rapidata_config.upload.checkForExplicitContent (or set it to None/True), or "
+            "contact Rapidata if you need the skip capability.",
+            job.name,
         )
 
     def find_jobs(

--- a/src/rapidata/rapidata_client/config/upload_config.py
+++ b/src/rapidata/rapidata_client/config/upload_config.py
@@ -114,6 +114,11 @@ class UploadConfig(BaseModel):
             uploads successfully (a definition over an empty dataset is never created).
             Overridable per call via the ``failure_tolerance`` argument on
             ``create_*_job_definition``. Defaults to 0.0.
+        checkForExplicitContent (bool | None): Opt in or out of Rapidata's server-side
+            explicit-content check, applied when a job is assigned to an audience.
+            ``None`` (default) uses the account's default. ``True`` forces the check on.
+            ``False`` requests skipping it — honored only when the account is permitted to
+            skip; otherwise the check still runs and a warning is logged. Defaults to None.
     """
 
     model_config = ConfigDict(validate_assignment=True)
@@ -160,6 +165,10 @@ class UploadConfig(BaseModel):
     failureTolerance: float = Field(
         default=0.0,
         description="Fraction of a job's datapoints allowed to fail while still creating the definition (0.0-1.0).",
+    )
+    checkForExplicitContent: bool | None = Field(
+        default=None,
+        description="Opt in/out of the server-side explicit-content check on job assignment. None uses the account default; True forces it on; False requests skip (honored only if permitted).",
     )
 
     @field_validator("maxWorkers")


### PR DESCRIPTION
## What

Adds `rapidata_config.upload.checkForExplicitContent` (`bool | None`) so a client can control Rapidata's **server-side explicit-content check** applied when a job is assigned to an audience.

The flag is read in `RapidataAudienceBase.assign_job` and passed through the newly-regenerated `CreateJobEndpointInput.checkForExplicitContent`:

| Value | Behaviour |
|---|---|
| `None` (default) | Use the account's default — fully backward-compatible. |
| `True` | Force the check on, even for exempt callers. |
| `False` | Request skipping it — honored **only** if the account is permitted to skip; otherwise the check still runs. |

When a skip is requested but not permitted, the create response's `contentCheckSkipDenied` is surfaced via `logger.warning` (mirroring the existing `_warn_if_cost_exceeds_balance` advisory). The job is created and runs either way.

## Why

Second (SDK) half of the two-repo opt-in feature. The backend half ([rapidata-backend#4805](https://github.com/RapidataAI/rapidata-backend/pull/4805)) and the OpenAPI client regeneration (#699) are already merged to `main`.

## Notes
- `pyright src/rapidata/rapidata_client` → 0 errors; `black` clean.
- The flag also works via the standard `RAPIDATA_checkForExplicitContent` env override.
- Docs updated (`docs/config.md` Upload Configuration table).

🔗 Session: https://node-3494df9f.poseidon.rapidata.internal/