### PR TITLE
feat(mri): custom response budget + clarified win/loss matrix docs

### DIFF
--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -100,9 +100,22 @@ leaderboard = benchmark.create_leaderboard(
 )
 ```
 
-### Level of Detail
+### Level of Detail (response budget)
 
-Controls the number of comparisons performed, affecting accuracy vs. speed.
+`level_of_detail` sets the leaderboard's **response budget** — the total number of
+comparison responses collected per model evaluation. A larger budget buys more
+matchups, which makes the standings more precise but makes each evaluation slower
+and more expensive. The named levels map to concrete budgets:
+
+| `level_of_detail` | Responses per model evaluation |
+|---|---|
+| `"debug"` | 20 |
+| `"low"` | 2,000 |
+| `"medium"` | 4,000 |
+| `"high"` | 8,000 |
+| `"very high"` | 16,000 |
+
+Omitting `level_of_detail` lets the server pick a default.
 
 ```python
 # Different detail levels
@@ -117,6 +130,15 @@ leaderboard_precise = benchmark.create_leaderboard(
     instruction="Which image do you prefer?", 
     level_of_detail="very high"  # More comparisons, higher accuracy
 )
+```
+
+You can also read or change the budget on an existing leaderboard through the
+`level_of_detail` property. Changes apply to future evaluations; standings that
+have already been computed are not recomputed.
+
+```python
+print(leaderboard.level_of_detail)   # e.g. "low"
+leaderboard.level_of_detail = "high" # collect more responses from now on
 ```
 
 ### Prompt and Asset Display
@@ -199,6 +221,43 @@ You can remove a participant — and its uploaded media — from the benchmark. 
 ```python
 participant = benchmark.participants[0]
 participant.delete()
+```
+
+## Win/Loss Matrix
+
+`get_standings` collapses every matchup into one Elo score per model. When you want
+the head-to-head breakdown instead, use `get_win_loss_matrix`. It returns a square
+pandas DataFrame with participant names on both axes, where cell `[i, j]` is how
+often the row model `i` beat the column model `j`. Reading a single row tells you
+how one model fared against each opponent; the diagonal is always 0.
+
+```python
+# Per-leaderboard: matchups within one leaderboard
+matrix = leaderboard.get_win_loss_matrix()
+
+# Benchmark-wide: aggregated across all leaderboards
+matrix = benchmark.get_win_loss_matrix()
+
+print(matrix)
+#            ModelA  ModelB  ModelC
+#   ModelA        0      12       9
+#   ModelB        4       0       7
+#   ModelC        6       8       0
+```
+
+Both methods accept `tags` to restrict the count to matchups with specific prompt
+tags. The benchmark-level method additionally accepts `participant_ids` and
+`leaderboard_ids` to narrow the participants and leaderboards included.
+
+By default the cells are raw win counts. Pass `use_weighted_scoring=True` to weight
+each matchup by the responding annotators' reliability (`userScore`) instead — the
+cells then hold weighted sums (floats) rather than integer counts.
+
+```python
+matrix = leaderboard.get_win_loss_matrix(
+    tags=["landscape"],
+    use_weighted_scoring=True,
+)
 ```
 
 ## Accessing the Underlying Jobs

--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -117,6 +117,17 @@ and more expensive. The named levels map to concrete budgets:
 
 Omitting `level_of_detail` lets the server pick a default.
 
+Need a budget between (or beyond) the named levels? Pass a positive integer
+instead of a name to set a **custom** response budget directly:
+
+```python
+leaderboard = benchmark.create_leaderboard(
+    name="Custom Budget",
+    instruction="Which image do you prefer?",
+    level_of_detail=5000,   # exactly 5,000 responses per model evaluation
+)
+```
+
 ```python
 # Different detail levels
 leaderboard_fast = benchmark.create_leaderboard(
@@ -133,12 +144,23 @@ leaderboard_precise = benchmark.create_leaderboard(
 ```
 
 You can also read or change the budget on an existing leaderboard through the
-`level_of_detail` property. Changes apply to future evaluations; standings that
-have already been computed are not recomputed.
+`level_of_detail` property, which likewise accepts a named level or a custom
+integer. Changes apply to future evaluations; standings that have already been
+computed are not recomputed.
 
 ```python
 print(leaderboard.level_of_detail)   # e.g. "low"
-leaderboard.level_of_detail = "high" # collect more responses from now on
+leaderboard.level_of_detail = "high" # named level
+leaderboard.level_of_detail = 5000   # custom budget
+```
+
+A custom budget reads back as `"custom"`; use the `response_budget` property to
+get the exact number.
+
+```python
+leaderboard.level_of_detail = 5000
+print(leaderboard.level_of_detail)   # "custom"
+print(leaderboard.response_budget)   # 5000
 ```
 
 ### Prompt and Asset Display

--- a/src/rapidata/rapidata_client/benchmark/_detail_mapper.py
+++ b/src/rapidata/rapidata_client/benchmark/_detail_mapper.py
@@ -2,34 +2,54 @@ from typing import Literal
 
 LevelOfDetail = Literal["debug", "low", "medium", "high", "very high"]
 
+# What `level_of_detail` reports back: a named level, or "custom" for any budget
+# that doesn't line up with one of the named levels (e.g. a raw int budget).
+ResolvedLevelOfDetail = Literal["debug", "low", "medium", "high", "very high", "custom"]
+
+_LEVEL_BUDGETS: dict[str, int] = {
+    "debug": 20,
+    "low": 2_000,
+    "medium": 4_000,
+    "high": 8_000,
+    "very high": 16_000,
+}
+
 
 class DetailMapper:
     @staticmethod
     def get_budget(level_of_detail: LevelOfDetail) -> int:
-        if level_of_detail == "debug":
-            return 20
-        elif level_of_detail == "low":
-            return 2_000
-        elif level_of_detail == "medium":
-            return 4_000
-        elif level_of_detail == "high":
-            return 8_000
-        elif level_of_detail == "very high":
-            return 16_000
-        else:
+        try:
+            return _LEVEL_BUDGETS[level_of_detail]
+        except KeyError:
             raise ValueError(
                 "Invalid level of detail. Must be one of: "
                 + ", ".join(LevelOfDetail.__args__)
+                + " (or pass an integer response budget for a custom level)"
             )
 
     @staticmethod
-    def get_level_of_detail(response_budget: int) -> LevelOfDetail:
-        if response_budget <= 20:
-            return "debug"
-        elif response_budget < 4_000:
-            return "low"
-        elif response_budget < 8_000:
-            return "medium"
-        elif response_budget < 16_000:
-            return "high"
-        return "very high"
+    def resolve_budget(level_of_detail: "LevelOfDetail | int") -> int:
+        """Turns a named level or a raw response budget into a concrete budget."""
+        # bool is an int subclass — reject it so `True` isn't read as a budget of 1.
+        if isinstance(level_of_detail, bool) or not isinstance(
+            level_of_detail, (int, str)
+        ):
+            raise ValueError(
+                "Level of detail must be one of "
+                + ", ".join(LevelOfDetail.__args__)
+                + " or a positive integer response budget"
+            )
+
+        if isinstance(level_of_detail, int):
+            if level_of_detail < 1:
+                raise ValueError("Response budget must be a positive integer")
+            return level_of_detail
+
+        return DetailMapper.get_budget(level_of_detail)
+
+    @staticmethod
+    def get_level_of_detail(response_budget: int) -> ResolvedLevelOfDetail:
+        for level, budget in _LEVEL_BUDGETS.items():
+            if budget == response_budget:
+                return level  # type: ignore[return-value]
+        return "custom"

--- a/src/rapidata/rapidata_client/benchmark/leaderboard/rapidata_leaderboard.py
+++ b/src/rapidata/rapidata_client/benchmark/leaderboard/rapidata_leaderboard.py
@@ -8,6 +8,7 @@ from rapidata.rapidata_client.config import logger, managed_print, tracer
 from rapidata.rapidata_client.benchmark._detail_mapper import (
     DetailMapper,
     LevelOfDetail,
+    ResolvedLevelOfDetail,
 )
 from rapidata.api_client.models.audience_audience_id_jobs_get_job_id_parameter import (
     AudienceAudienceIdJobsGetJobIdParameter,
@@ -62,31 +63,44 @@ class RapidataLeaderboard:
         self.__leaderboard_page = f"https://app.{self.__openapi_service.environment}/mri/benchmarks/{self.__benchmark_id}/leaderboard/{self.id}"
 
     @property
-    def level_of_detail(self) -> LevelOfDetail:
+    def response_budget(self) -> int:
+        """
+        The leaderboard's response budget — the total number of comparison responses
+        collected per model evaluation.
+
+        This is the raw number behind :attr:`level_of_detail`; read it when you need
+        the exact budget rather than the named level (which is ``"custom"`` for
+        budgets that don't match a named level).
+        """
+        return self.__response_budget
+
+    @property
+    def level_of_detail(self) -> ResolvedLevelOfDetail:
         """
         The level of detail of the leaderboard.
 
-        This is a friendly name for the leaderboard's *response budget* — the total
-        number of comparison responses collected per model evaluation. A larger
+        This is a friendly name for the leaderboard's :attr:`response_budget` — the
+        total number of comparison responses collected per model evaluation. A larger
         budget buys more matchups and therefore more precise standings, at the cost
-        of a slower and more expensive evaluation. The names map to these budgets:
-        ``'debug'`` (20), ``'low'`` (2,000), ``'medium'`` (4,000), ``'high'`` (8,000),
-        ``'very high'`` (16,000). Reading this rounds the stored budget down to the
-        nearest level.
+        of a slower and more expensive evaluation. The named levels map to these
+        budgets: ``'debug'`` (20), ``'low'`` (2,000), ``'medium'`` (4,000),
+        ``'high'`` (8,000), ``'very high'`` (16,000). Any other budget reads back as
+        ``'custom'`` — use :attr:`response_budget` to get the exact number.
         """
         return DetailMapper.get_level_of_detail(self.__response_budget)
 
     @level_of_detail.setter
-    def level_of_detail(self, level_of_detail: LevelOfDetail):
+    def level_of_detail(self, level_of_detail: LevelOfDetail | int):
         """
         Sets the level of detail (response budget) of the leaderboard.
 
-        Takes effect for future evaluations; already-computed standings are not
-        recomputed.
+        Accepts one of the named levels or a positive integer for a custom response
+        budget. Takes effect for future evaluations; already-computed standings are
+        not recomputed.
         """
         with tracer.start_as_current_span("RapidataLeaderboard.level_of_detail.setter"):
             logger.debug(f"Setting level of detail to {level_of_detail}")
-            self.__response_budget = DetailMapper.get_budget(level_of_detail)
+            self.__response_budget = DetailMapper.resolve_budget(level_of_detail)
             self._update_config()
 
     @property

--- a/src/rapidata/rapidata_client/benchmark/leaderboard/rapidata_leaderboard.py
+++ b/src/rapidata/rapidata_client/benchmark/leaderboard/rapidata_leaderboard.py
@@ -64,14 +64,25 @@ class RapidataLeaderboard:
     @property
     def level_of_detail(self) -> LevelOfDetail:
         """
-        Returns the level of detail of the leaderboard.
+        The level of detail of the leaderboard.
+
+        This is a friendly name for the leaderboard's *response budget* — the total
+        number of comparison responses collected per model evaluation. A larger
+        budget buys more matchups and therefore more precise standings, at the cost
+        of a slower and more expensive evaluation. The names map to these budgets:
+        ``'debug'`` (20), ``'low'`` (2,000), ``'medium'`` (4,000), ``'high'`` (8,000),
+        ``'very high'`` (16,000). Reading this rounds the stored budget down to the
+        nearest level.
         """
         return DetailMapper.get_level_of_detail(self.__response_budget)
 
     @level_of_detail.setter
     def level_of_detail(self, level_of_detail: LevelOfDetail):
         """
-        Sets the level of detail of the leaderboard.
+        Sets the level of detail (response budget) of the leaderboard.
+
+        Takes effect for future evaluations; already-computed standings are not
+        recomputed.
         """
         with tracer.start_as_current_span("RapidataLeaderboard.level_of_detail.setter"):
             logger.debug(f"Setting level of detail to {level_of_detail}")
@@ -243,18 +254,28 @@ class RapidataLeaderboard:
         use_weighted_scoring: Optional[bool] = None,
     ) -> pd.DataFrame:
         """
-        Returns the win/loss matrix for all participants in this leaderboard.
+        Returns the pairwise win/loss matrix for the participants in this leaderboard.
 
-        The matrix shows pairwise comparison results where each cell [i, j] represents
-        the number of wins participant i has against participant j.
+        The returned DataFrame is square, with participant names on both the index
+        (rows) and columns. Cell ``[i, j]`` is how often participant ``i`` (row) beat
+        participant ``j`` (column) in their direct matchups. Read a row to see how a
+        model did against every opponent; the diagonal (a model against itself) is
+        always 0. This is the head-to-head breakdown behind :meth:`get_standings`,
+        which collapses the same matchups into a single Elo score per model.
 
         Args:
-            tags: Filter matchups by these tags. If None, all matchups are considered.
-            use_weighted_scoring: Whether to use weighted scoring for the matrix calculation.
+            tags: Only count matchups carrying one of these prompt tags. If None,
+                every matchup on the leaderboard is included; if an empty list, none are.
+            use_weighted_scoring: If True, each matchup is weighted by the responding
+                annotators' reliability (``userScore``) instead of being counted as a
+                plain win, so cells hold weighted sums (floats) rather than raw counts.
+                If False, cells are raw win counts. When None (default), the server
+                applies the leaderboard's configured default.
 
         Returns:
-            A pandas DataFrame with participants as both index and columns,
-            containing the pairwise win counts.
+            A pandas DataFrame indexed by participant name on both axes, where cell
+            ``[i, j]`` holds the (optionally weighted) number of wins of the row
+            participant over the column participant.
         """
         with tracer.start_as_current_span("RapidataLeaderboard.get_win_loss_matrix"):
             tags_filter = AudienceAudienceIdJobsGetJobIdParameter()

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -429,7 +429,7 @@ class RapidataBenchmark:
         show_prompt: bool = False,
         show_prompt_asset: bool = False,
         inverse_ranking: bool = False,
-        level_of_detail: LevelOfDetail | None = None,
+        level_of_detail: LevelOfDetail | int | None = None,
         min_responses_per_matchup: int | None = None,
         audience_id: str | RapidataAudienceBase | None = None,
         settings: Sequence["RapidataSetting"] | None = None,
@@ -443,7 +443,7 @@ class RapidataBenchmark:
             show_prompt: Whether to show the prompt to the users. (default: False)
             show_prompt_asset: Whether to show the prompt asset to the users. (only works if the prompt asset is a URL) (default: False)
             inverse_ranking: Whether to inverse the ranking of the leaderboard. (if the question is inversed, e.g. "Which video is worse?")
-            level_of_detail: Sets the leaderboard's response budget — the total number of comparison responses collected per model evaluation. A larger budget buys more matchups and therefore more precise standings, at the cost of a slower, more expensive evaluation. One of 'debug' (20 responses), 'low' (2,000), 'medium' (4,000), 'high' (8,000), 'very high' (16,000). (default: None, server decides)
+            level_of_detail: Sets the leaderboard's response budget — the total number of comparison responses collected per model evaluation. A larger budget buys more matchups and therefore more precise standings, at the cost of a slower, more expensive evaluation. Either one of the named levels — 'debug' (20 responses), 'low' (2,000), 'medium' (4,000), 'high' (8,000), 'very high' (16,000) — or a positive integer for a custom budget. (default: None, server decides)
             min_responses_per_matchup: The minimum number of responses required to be considered for the leaderboard. (default: 3)
             audience_id: The audience that should answer the leaderboard. Pass either the audience id, a :class:`RapidataAudience` (dimension audience), or a :class:`RapidataFilteredAudience` (derived via :py:meth:`RapidataAudience.filter`). Defaults to the global audience when not specified.
             settings: The settings that should be applied to the leaderboard. Will determine the behavior of the tasks on the leaderboard. (default: [])
@@ -460,14 +460,11 @@ class RapidataBenchmark:
         )
 
         with tracer.start_as_current_span("RapidataBenchmark.create_leaderboard"):
-            if level_of_detail is not None and (
-                not isinstance(level_of_detail, str)
-                or level_of_detail not in LevelOfDetail.__args__
-            ):
-                raise ValueError(
-                    "Level of detail must be a string and one of: "
-                    + ", ".join(LevelOfDetail.__args__)
-                )
+            response_budget = (
+                DetailMapper.resolve_budget(level_of_detail)
+                if level_of_detail is not None
+                else None
+            )
 
             if min_responses_per_matchup is not None and (
                 not isinstance(min_responses_per_matchup, int)
@@ -506,11 +503,7 @@ class RapidataBenchmark:
                         showPromptAsset=show_prompt_asset,
                         isInversed=inverse_ranking,
                         minResponses=min_responses_per_matchup,
-                        responseBudget=(
-                            DetailMapper.get_budget(level_of_detail)
-                            if level_of_detail is not None
-                            else None
-                        ),
+                        responseBudget=response_budget,
                         audienceId=resolved_audience_id,
                         featureFlags=(
                             [setting._to_feature_flag() for setting in settings]

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -443,7 +443,7 @@ class RapidataBenchmark:
             show_prompt: Whether to show the prompt to the users. (default: False)
             show_prompt_asset: Whether to show the prompt asset to the users. (only works if the prompt asset is a URL) (default: False)
             inverse_ranking: Whether to inverse the ranking of the leaderboard. (if the question is inversed, e.g. "Which video is worse?")
-            level_of_detail: The level of detail of the leaderboard. This will effect how many comparisons are done per model evaluation. One of: 'debug', 'low', 'medium', 'high', 'very high'. (default: None, server decides)
+            level_of_detail: Sets the leaderboard's response budget — the total number of comparison responses collected per model evaluation. A larger budget buys more matchups and therefore more precise standings, at the cost of a slower, more expensive evaluation. One of 'debug' (20 responses), 'low' (2,000), 'medium' (4,000), 'high' (8,000), 'very high' (16,000). (default: None, server decides)
             min_responses_per_matchup: The minimum number of responses required to be considered for the leaderboard. (default: 3)
             audience_id: The audience that should answer the leaderboard. Pass either the audience id, a :class:`RapidataAudience` (dimension audience), or a :class:`RapidataFilteredAudience` (derived via :py:meth:`RapidataAudience.filter`). Defaults to the global audience when not specified.
             settings: The settings that should be applied to the leaderboard. Will determine the behavior of the tasks on the leaderboard. (default: [])
@@ -767,20 +767,33 @@ class RapidataBenchmark:
         use_weighted_scoring: Optional[bool] = None,
     ) -> pd.DataFrame:
         """
-        Returns the win/loss matrix for all participants across all leaderboards in the benchmark.
+        Returns the pairwise win/loss matrix aggregated across the benchmark's leaderboards.
 
-        The matrix shows pairwise comparison results where each cell [i, j] represents
-        the number of wins participant i has against participant j.
+        The returned DataFrame is square, with participant names on both the index
+        (rows) and columns. Cell ``[i, j]`` is how often participant ``i`` (row) beat
+        participant ``j`` (column) in their direct matchups, summed over every
+        leaderboard in scope. Read a row to see how a model did against every
+        opponent; the diagonal (a model against itself) is always 0. This is the
+        head-to-head breakdown behind :meth:`get_overall_standings`, which collapses
+        the same matchups into a single Elo score per model.
 
         Args:
-            tags: Filter matchups by these tags. If None, all matchups are considered.
-            participant_ids: Filter to only include these participants.
-            leaderboard_ids: Filter to only include matchups from these leaderboards.
-            use_weighted_scoring: Whether to use weighted scoring for the matrix calculation.
+            tags: Only count matchups carrying one of these prompt tags. If None,
+                every matchup is included; if an empty list, none are.
+            participant_ids: Restrict the matrix to these participants. If None, all
+                participants are included.
+            leaderboard_ids: Only aggregate matchups from these leaderboards. If None,
+                all leaderboards in the benchmark are included.
+            use_weighted_scoring: If True, each matchup is weighted by the responding
+                annotators' reliability (``userScore``) instead of being counted as a
+                plain win, so cells hold weighted sums (floats) rather than raw counts.
+                If False, cells are raw win counts. When None (default), the server
+                applies its configured default.
 
         Returns:
-            A pandas DataFrame with participants as both index and columns,
-            containing the pairwise win counts.
+            A pandas DataFrame indexed by participant name on both axes, where cell
+            ``[i, j]`` holds the (optionally weighted) number of wins of the row
+            participant over the column participant.
         """
         import pandas as pd
 

--- a/uv.lock
+++ b/uv.lock
@@ -2610,7 +2610,7 @@ wheels = [
 
 [[package]]
 name = "rapidata"
-version = "3.17.0"
+version = "3.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## What

Two related changes to the benchmark / MRI API.

### 1. Custom response budget (`level_of_detail`)
`level_of_detail` now accepts a **positive integer** wherever it previously took only a named level, setting the leaderboard's response budget directly instead of snapping to one of the five named buckets:

```python
benchmark.create_leaderboard(..., level_of_detail=5000)  # 5,000 responses per evaluation
leaderboard.level_of_detail = 5000                       # same on an existing leaderboard
```

- `DetailMapper.resolve_budget` normalises a name-or-int to a budget (rejecting bools and non-positive ints with a clear error).
- `DetailMapper.get_level_of_detail` now returns `"custom"` for any budget that doesn't match a named level (previously it snapped to the nearest name, which would mislabel a custom budget).
- New read-only `RapidataLeaderboard.response_budget` property exposes the exact integer, since `level_of_detail` reads back as `"custom"` for non-named budgets.

### 2. Clarified docs (original ask)
- `get_win_loss_matrix` (leaderboard + benchmark): documented the matrix layout (row beats column, zero diagonal), its relationship to the standings, the filter args, and the `use_weighted_scoring` flag (`userScore` weighting -> float cells vs. raw counts; `None` -> server default).
- Response budget behind `level_of_detail`: the `create_leaderboard` parameter and the `level_of_detail` property now spell out the level -> responses-per-evaluation mapping. Fixed "effect" -> "affect".
- `docs/mri_advanced.md` gains a **Win/Loss Matrix** section, a **response-budget table**, and custom-budget examples.

## Notes
- `pyright src/rapidata/rapidata_client/benchmark` -> 0 errors
- `black` -> unchanged
- `mkdocs build` -> succeeds (remaining warnings pre-existing and unrelated)

🔗 Session: https://poseidon.rapidata.internal/chat/session-7231d9d1