### PR TITLE
feat(audience): surface target_accuracy and min_tasks on audience creation

### DIFF
--- a/docs/audiences.md
+++ b/docs/audiences.md
@@ -32,6 +32,28 @@ audience = client.audience.create_audience(name="Custom Prompt Alignment Audienc
 
 1. Creates a new, empty audience. Labelers join by passing the qualification examples you add next.
 
+#### Tuning the admission bar
+
+By default a labeler is admitted once they answer enough qualification tasks
+well enough — the server default is **75% accuracy over 10 tasks**. Set the bar
+explicitly as "solve N tasks at X accuracy" with two arguments:
+
+```py
+audience = client.audience.create_audience(
+    name="Custom Prompt Alignment Audience",
+    target_accuracy=0.9, # (1)!
+    min_tasks=20,        # (2)!
+)
+```
+
+1. `X` — the fraction of qualification tasks (0..1) a labeler must get right to
+   be admitted. Omit to use the server default of `0.75`.
+2. `N` — how many qualification tasks a labeler must complete before the
+   accuracy verdict is trusted. Omit to use the server default of `10`.
+
+Supplying just one of the two is fine — the other keeps its default. A higher
+bar yields fewer but more reliable labelers.
+
 ### Step 2: Add Qualification Examples
 
 Qualification examples are questions with known correct answers. Labelers must answer these correctly to join your audience.

--- a/src/rapidata/rapidata_client/audience/rapidata_audience_manager.py
+++ b/src/rapidata/rapidata_client/audience/rapidata_audience_manager.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from rapidata.rapidata_client.audience.rapidata_audience import RapidataAudience
     from rapidata.service.openapi_service import OpenAPIService
     from rapidata.rapidata_client.filter import RapidataFilter
+    from rapidata.api_client.models.i_graduation_rule import IGraduationRule
 
 
 class RapidataAudienceManager:
@@ -16,21 +17,94 @@ class RapidataAudienceManager:
     Audiences are groups of annotators that can be recruited based on example tasks and assigned jobs.
     """
 
+    # Defaults the backend applies when no graduation rule is sent. Mirrored
+    # here because the TaskAccuracy wire variant requires both fields, so
+    # supplying only one of target_accuracy / min_tasks means we still have to
+    # send the other.
+    _DEFAULT_TARGET_ACCURACY = 0.75
+    _DEFAULT_MIN_TASKS = 10
+
     def __init__(self, openapi_service: OpenAPIService):
         self._openapi_service = openapi_service
+
+    def _build_task_accuracy_rule(
+        self,
+        target_accuracy: float | None,
+        min_tasks: int | None,
+        max_tasks: int | None,
+    ) -> IGraduationRule | None:
+        """Build a TaskAccuracy graduation rule, or None to let the server default.
+
+        Returns None only when the caller opted out entirely (no knob set), so the
+        backend applies its own default rule.
+        """
+        if target_accuracy is None and min_tasks is None and max_tasks is None:
+            return None
+
+        effective_accuracy = (
+            target_accuracy
+            if target_accuracy is not None
+            else self._DEFAULT_TARGET_ACCURACY
+        )
+        effective_min_tasks = (
+            min_tasks if min_tasks is not None else self._DEFAULT_MIN_TASKS
+        )
+
+        if not 0.0 <= effective_accuracy <= 1.0:
+            raise ValueError(
+                f"target_accuracy must be between 0.0 and 1.0, got {effective_accuracy}."
+            )
+        if effective_min_tasks < 1:
+            raise ValueError(
+                f"min_tasks must be at least 1, got {effective_min_tasks}."
+            )
+        if max_tasks is not None and max_tasks < effective_min_tasks:
+            raise ValueError(
+                f"max_tasks ({max_tasks}) must be greater than or equal to "
+                f"min_tasks ({effective_min_tasks})."
+            )
+
+        from rapidata.api_client.models.i_graduation_rule import IGraduationRule
+        from rapidata.api_client.models.i_graduation_rule_task_accuracy_rule import (
+            IGraduationRuleTaskAccuracyRule,
+        )
+
+        return IGraduationRule(
+            actual_instance=IGraduationRuleTaskAccuracyRule(
+                _t="TaskAccuracy",
+                targetAccuracy=effective_accuracy,
+                minTasks=effective_min_tasks,
+                maxTasks=max_tasks,
+            )
+        )
 
     def create_audience(
         self,
         name: str,
         filters: list[RapidataFilter] | None = None,
+        target_accuracy: float | None = None,
+        min_tasks: int | None = None,
+        max_tasks: int | None = None,
     ) -> RapidataAudience:
         """Create a new audience.
 
         Creates a new audience with the specified name and optional filters.
 
+        Annotators join an audience by passing a short admission trial: they must
+        answer validation tasks well enough to be trusted. The two intuitive knobs
+        below describe that bar as "solve N tasks at X accuracy":
+
         Args:
             name (str): The name of the audience.
             filters (list[RapidataFilter], optional): The list of filters to apply to the audience. Defaults to None (no filters).
+            target_accuracy (float, optional): X — the fraction of validation tasks
+                (0..1) an annotator must get right to be admitted. Defaults to None,
+                in which case the server default of 0.75 applies.
+            min_tasks (int, optional): N — the number of validation tasks an annotator
+                must complete before the accuracy verdict is trusted. Defaults to None,
+                in which case the server default of 10 applies.
+            max_tasks (int, optional): Upper bound on admission-trial tasks before a
+                verdict is forced. Defaults to None (no cap).
 
         Returns:
             RapidataAudience: The created audience instance.
@@ -46,10 +120,17 @@ class RapidataAudienceManager:
             logger.debug(f"Creating audience: {name}")
             if filters is None:
                 filters = []
+
+            graduation_rule = self._build_task_accuracy_rule(
+                target_accuracy=target_accuracy,
+                min_tasks=min_tasks,
+                max_tasks=max_tasks,
+            )
             response = self._openapi_service.audience.audience_api.audience_post(
                 create_audience_endpoint_input=CreateAudienceEndpointInput(
                     name=name,
                     filters=[filter._to_audience_model() for filter in filters],
+                    graduationRule=graduation_rule,
                 ),
             )
             audience = RapidataAudience(


### PR DESCRIPTION
## What

Surfaces the two **intuitive admission knobs** on `RapidataAudienceManager.create_audience`:

- **`target_accuracy`** (X) — the fraction of qualification tasks (0..1) an annotator must get right to be admitted.
- **`min_tasks`** (N) — how many qualification tasks the annotator must complete before the accuracy verdict is trusted.
- **`max_tasks`** (optional) — upper bound on trial tasks before a verdict is forced.

Together they read as *"solve N tasks at X accuracy"*.

## Why

Today `create_audience` exposes **no score fields at all**. The only way to tune the admission bar was to create the audience and then blindly `PATCH` `graduation_score=0.9` — the exact "Odyssey" path. This replaces that with two intuitive numbers; the raw `graduation_score` is deliberately **not** surfaced on the high-level API.

When the caller supplies neither knob, `graduationRule` is omitted and the backend applies its default (TaskAccuracy, 0.75 over 10). Supplying just one fills the other with the matching server default (0.75 / 10), since the `TaskAccuracy` wire variant requires both fields.

## Wire contract (verified against the merged backend spec)

`graduationRule` is a discriminated union on `_t` — modeled by the generated client exactly like the audience `filters` union (`IGraduationRule` with `ScoreThreshold` / `TaskAccuracy` subtypes):

```jsonc
{ "_t": "ScoreThreshold", "graduationScore": <number>, "demotionScore": <number|null>, "minResponsesToGraduate": <int|null> }
{ "_t": "TaskAccuracy",    "targetAccuracy": <0..1>,   "minTasks": <int>, "maxTasks": <int|null> }
```

- **CreateAudience / UpdateAudience input:** `graduationRule` optional.
- **GetAudienceById / QueryAudiences output:** `graduationRule` required.
- The old flat `graduationScore` / `minResponsesToGraduate` fields were removed from the endpoints in backend review.

## Changes

- `RapidataAudienceManager.create_audience`: new `target_accuracy` / `min_tasks` / `max_tasks` params; constructs the discriminated `TaskAccuracy` `graduationRule` for the caller. Out-of-range thresholds are rejected client-side with a clear `ValueError` (`target_accuracy` in [0,1], `min_tasks >= 1`, `max_tasks >= min_tasks`), resolving defaults first so the bounds reflect the values actually sent.
- Docs: added an "admission bar" subsection to `docs/audiences.md`.

The generated `IGraduationRule` union + `IGraduationRuleTaskAccuracyRule` / `IGraduationRuleScoreThresholdRule` models and the `graduation_rule` field on the audience inputs/outputs are **not** bundled in this PR — they already landed on `main` via the autogenerated OpenAPI client refresh (#704, `2026.07.22.0910`). This branch is rebased onto that commit and relies on those autogenerated specs, so the diff is just the two hand-written files above.


## Scope

- **Creation** (the Odyssey path) is done. **Update** (`RapidataAudience`) was left out of scope this pass — the generated `UpdateAudienceEndpointInput` already carries `graduation_rule`, but no high-level setter is added yet.

## Validation

- `python -c "from rapidata import RapidataClient"` → OK
- `pyright src/rapidata/rapidata_client` → 0 errors
- `uv run black --check` → clean
- `mkdocs build` → succeeds
- Guard rails verified: `target_accuracy=1.5`, `min_tasks=0`, and `max_tasks < min_tasks` each raise `ValueError`.
- Serialization verified: `create_audience(name, target_accuracy=0.9)` → `{"_t":"TaskAccuracy","targetAccuracy":0.9,"minTasks":10,"maxTasks":null}`
- (Note: 4 pre-existing `assign_job` test failures exist on `main` unchanged — unrelated to this PR.)

## Related

Backend (merged to main): RapidataAI/rapidata-backend#4768, RapidataAI/rapidata-backend#4757

🔗 Session: https://poseidon.rapidata.internal/chat/node-8815f7c3

