### PR TITLE
feat(upload): surface backend upload warnings (e.g. video length)

### DIFF
--- a/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_upload_orchestrator.py
@@ -12,6 +12,7 @@ from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.datapoints._batch_asset_uploader import (
     BatchAssetUploader,
 )
+from rapidata.rapidata_client.exceptions.asset_warning import AssetWarning
 from rapidata.rapidata_client.exceptions.failed_upload import FailedUpload
 from rapidata.rapidata_client.datapoints._single_flight_cache import SingleFlightCache
 
@@ -113,6 +114,7 @@ class AssetUploadOrchestrator:
 
         # 4. Report results
         self._log_upload_results(failed_uploads)
+        self._log_upload_warnings(self._collect_warnings())
         return failed_uploads
 
     # Keep the URL scheme check case-insensitive to match AssetUploader.
@@ -255,6 +257,36 @@ class AssetUploadOrchestrator:
             logger.warning(f"Step 1/2: {len(failed_uploads)} asset(s) failed to upload")
         else:
             logger.info("Step 1/2: All assets uploaded successfully")
+
+    def _collect_warnings(self) -> list[AssetWarning[str]]:
+        """Drain and de-duplicate backend warnings from both upload paths.
+
+        Caching means a warning is captured only on the first upload of a given
+        asset, so this is already roughly per-unique-asset — but de-duplicate on
+        (item, message) so an asset referenced by several datapoints is reported
+        once, not once per reference.
+        """
+        drained = (
+            self.asset_uploader.drain_warnings() + self.batch_uploader.drain_warnings()
+        )
+
+        seen: set[AssetWarning[str]] = set()
+        unique: list[AssetWarning[str]] = []
+        for warning in drained:
+            if warning not in seen:
+                seen.add(warning)
+                unique.append(warning)
+        return unique
+
+    def _log_upload_warnings(self, warnings: list[AssetWarning[str]]) -> None:
+        """Surface non-fatal upload warnings via the SDK logger.
+
+        The assets uploaded successfully — these are backend advisories about
+        them (e.g. a video longer than annotators can solve), reported once at
+        the end so they are not lost among the per-asset upload logs.
+        """
+        for warning in warnings:
+            logger.warning("Upload warning for '%s': %s", warning.item, warning.message)
 
     def _filter_uncached(self, assets: set[str], cache: SingleFlightCache) -> set[str]:
         """Filter out assets that are already cached."""

--- a/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_asset_uploader.py
@@ -11,6 +11,7 @@ from rapidata.rapidata_client.config import logger, rapidata_config, tracer
 from rapidata.rapidata_client.config.upload_config import CompressionConfig
 from rapidata.rapidata_client.datapoints._asset_mapper import AssetMapper
 from rapidata.rapidata_client.datapoints._single_flight_cache import SingleFlightCache
+from rapidata.rapidata_client.exceptions.asset_warning import AssetWarning
 from diskcache import FanoutCache
 
 
@@ -65,6 +66,32 @@ class AssetUploader:
 
     def __init__(self, openapi_service: OpenAPIService) -> None:
         self.openapi_service = openapi_service
+        # Non-fatal warnings the backend attaches to successful uploads. Only
+        # captured on a cache miss (i.e. the first upload of a given asset),
+        # so this holds one entry per uniquely-uploaded asset per run; the
+        # orchestrator drains and de-duplicates it when reporting.
+        self._warnings: list[AssetWarning[str]] = []
+        self._warnings_lock = threading.Lock()
+
+    def _record_warnings(self, item: str, warnings: Any) -> None:
+        """Buffer any backend warnings for ``item``.
+
+        Read defensively: ``warnings`` is only a list once the backend that
+        produced the upload response exposes the field — until then (or for a
+        mocked response) it is None/absent and there is nothing to record.
+        """
+        if not isinstance(warnings, list):
+            return
+        with self._warnings_lock:
+            for message in warnings:
+                self._warnings.append(AssetWarning(item=item, message=message))
+
+    def drain_warnings(self) -> list[AssetWarning[str]]:
+        """Return the buffered warnings and clear the buffer."""
+        with self._warnings_lock:
+            collected = self._warnings
+            self._warnings = []
+            return collected
 
     # NOTE: the public ``get_*_cache_key`` helpers read
     # ``rapidata_config.upload.compression`` at call time rather than taking a
@@ -150,6 +177,7 @@ class AssetUploader:
             response = self.openapi_service.asset.asset_api.asset_url_post(
                 url=url, **kwargs
             )
+            self._record_warnings(url, getattr(response, "warnings", None))
             logger.info(
                 "Asset uploaded from URL: %s, file name: %s", url, response.file_name
             )
@@ -173,6 +201,7 @@ class AssetUploader:
             response = self.openapi_service.asset.asset_api.asset_file_post(
                 file=file_path, **kwargs
             )
+            self._record_warnings(file_path, getattr(response, "warnings", None))
             logger.info(
                 "Asset uploaded from file: %s, file name: %s",
                 file_path,
@@ -189,9 +218,7 @@ class AssetUploader:
     def upload_asset(self, asset: str) -> str:
         logger.debug("Uploading asset: %s", asset)
         if not isinstance(asset, str):
-            raise TypeError(
-                f"Asset must be a string, got {type(asset).__name__}"
-            )
+            raise TypeError(f"Asset must be a string, got {type(asset).__name__}")
 
         if self._URL_SCHEME_RE.match(asset):
             return self._upload_url_asset(asset)

--- a/src/rapidata/rapidata_client/datapoints/_batch_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_batch_asset_uploader.py
@@ -39,6 +39,10 @@ class BatchAssetUploader:
         self._interrupted = False
         self._processed_batches: set[str] = set()
 
+    def drain_warnings(self):
+        """Return backend warnings gathered from batch items and clear them."""
+        return self.asset_uploader.drain_warnings()
+
     def batch_upload_urls(
         self,
         urls: list[str],
@@ -66,6 +70,7 @@ class BatchAssetUploader:
         # Reset state from previous runs
         self._interrupted = False
         self._processed_batches = set()
+        self.asset_uploader.drain_warnings()
 
         # Generate a correlation ID for this upload session so we can poll
         # by correlation ID instead of passing all batch IDs as query params
@@ -298,6 +303,14 @@ class BatchAssetUploader:
 
             # Process each URL in the batch result
             for item in result.items:
+                # Per-item warnings (e.g. "video longer than 25 seconds") ride
+                # alongside an otherwise-successful upload. Read defensively:
+                # the field is only present once the asset service exposing it
+                # is deployed. See _record_warnings.
+                self.asset_uploader._record_warnings(
+                    item.url, getattr(item, "warnings", None)
+                )
+
                 if item.status == BatchUploadUrlStatus.COMPLETED:
                     # Cache successful upload using proper API
                     if item.file_name is not None:

--- a/src/rapidata/rapidata_client/exceptions/__init__.py
+++ b/src/rapidata/rapidata_client/exceptions/__init__.py
@@ -1,6 +1,13 @@
 from .asset_upload_exception import AssetUploadException
+from .asset_warning import AssetWarning
 from .failed_upload import FailedUpload
 from .failed_upload_exception import FailedUploadException
 from .rapidata_error import RapidataError
 
-__all__ = ["AssetUploadException", "FailedUpload", "FailedUploadException", "RapidataError"]
+__all__ = [
+    "AssetUploadException",
+    "AssetWarning",
+    "FailedUpload",
+    "FailedUploadException",
+    "RapidataError",
+]

--- a/src/rapidata/rapidata_client/exceptions/asset_warning.py
+++ b/src/rapidata/rapidata_client/exceptions/asset_warning.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class AssetWarning(Generic[T]):
+    """A non-fatal advisory the backend attached to an otherwise-successful upload.
+
+    Mirrors :class:`FailedUpload` for the success path: the upload went
+    through, but the backend flagged something the caller should know about
+    (e.g. a video longer than the annotator-solvable limit). Frozen so it can
+    be de-duplicated in a set before reporting.
+
+    Attributes:
+        item: The asset (file path or URL) the warning is about.
+        message: The backend-provided advisory text, surfaced verbatim.
+    """
+
+    item: T
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.item}: {self.message}"

--- a/tests/rapidata_client/datapoints/test_upload_warnings.py
+++ b/tests/rapidata_client/datapoints/test_upload_warnings.py
@@ -1,0 +1,128 @@
+"""Tests for surfacing non-fatal backend upload warnings.
+
+The backend attaches advisory warnings (e.g. "video longer than 25 seconds")
+to otherwise-successful uploads. They arrive two ways — on the sync file/URL
+upload response, and per-item on a batch-upload result — and both must be
+gathered and reported once via the SDK logger without failing the upload.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from rapidata.api_client.models.batch_upload_url_status import BatchUploadUrlStatus
+from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
+from rapidata.rapidata_client.datapoints._asset_upload_orchestrator import (
+    AssetUploadOrchestrator,
+)
+from rapidata.rapidata_client.datapoints._batch_asset_uploader import BatchAssetUploader
+from rapidata.rapidata_client.datapoints._single_flight_cache import SingleFlightCache
+from rapidata.rapidata_client.exceptions.asset_warning import AssetWarning
+
+VIDEO_WARNING = (
+    "Annotators can't solve tasks with videos longer than 25 seconds. If this is "
+    "your use case, please reach out to info@rapidata.ai for a custom setup."
+)
+
+
+def _service() -> MagicMock:
+    openapi_service = MagicMock()
+    openapi_service.environment = "rapidata.ai"
+    return openapi_service
+
+
+def test_file_upload_records_response_warnings():
+    openapi_service = _service()
+    response = MagicMock()
+    response.file_name = "uploaded.mp4"
+    response.warnings = [VIDEO_WARNING]
+    openapi_service.asset.asset_api.asset_file_post.return_value = response
+
+    uploader = AssetUploader(openapi_service)
+    fresh_cache = SingleFlightCache("test file cache", storage={})
+    with (
+        patch.object(AssetUploader, "_build_file_cache_key", return_value="key"),
+        patch.object(uploader, "_get_file_cache", return_value=fresh_cache),
+    ):
+        uploader._upload_file_asset("/tmp/clip.mp4")
+
+    drained = uploader.drain_warnings()
+    assert drained == [AssetWarning(item="/tmp/clip.mp4", message=VIDEO_WARNING)]
+    # Draining clears the buffer.
+    assert uploader.drain_warnings() == []
+
+
+def test_url_upload_without_warnings_records_nothing():
+    openapi_service = _service()
+    response = MagicMock()
+    response.file_name = "uploaded.jpg"
+    response.warnings = None
+    openapi_service.asset.asset_api.asset_url_post.return_value = response
+
+    uploader = AssetUploader(openapi_service)
+    with patch.object(
+        uploader, "_url_cache", SingleFlightCache("test url cache", storage={})
+    ):
+        uploader._upload_url_asset("https://host/a.jpg")
+
+    assert uploader.drain_warnings() == []
+
+
+def test_batch_item_warnings_are_recorded():
+    openapi_service = _service()
+
+    completed_item = MagicMock()
+    completed_item.url = "https://host/clip.mp4"
+    completed_item.status = BatchUploadUrlStatus.COMPLETED
+    completed_item.file_name = "uploaded.mp4"
+    completed_item.warnings = [VIDEO_WARNING]
+
+    result = MagicMock()
+    result.items = [completed_item]
+    openapi_service.asset.batch_upload_api.asset_batch_upload_batch_upload_id_get.return_value = (
+        result
+    )
+
+    uploader = BatchAssetUploader(openapi_service)
+    successful, failures = uploader._process_single_batch("batch-1", {})
+
+    assert successful == ["https://host/clip.mp4"]
+    assert failures == []
+    assert uploader.drain_warnings() == [
+        AssetWarning(item="https://host/clip.mp4", message=VIDEO_WARNING)
+    ]
+
+
+def test_orchestrator_surfaces_warnings_via_logger():
+    orchestrator = AssetUploadOrchestrator(_service())
+    orchestrator.asset_uploader.drain_warnings = MagicMock(  # type: ignore[method-assign]
+        return_value=[AssetWarning(item="/tmp/clip.mp4", message=VIDEO_WARNING)]
+    )
+    orchestrator.batch_uploader.drain_warnings = MagicMock(  # type: ignore[method-assign]
+        return_value=[AssetWarning(item="https://host/clip.mp4", message=VIDEO_WARNING)]
+    )
+
+    module = "rapidata.rapidata_client.datapoints._asset_upload_orchestrator"
+    with patch(f"{module}.logger") as logger:
+        orchestrator._log_upload_warnings(orchestrator._collect_warnings())
+
+    assert logger.warning.call_count == 2
+    logged = " ".join(str(c) for c in logger.warning.call_args_list)
+    assert "/tmp/clip.mp4" in logged
+    assert "https://host/clip.mp4" in logged
+    assert VIDEO_WARNING in logged
+
+
+def test_orchestrator_deduplicates_warnings_per_asset():
+    orchestrator = AssetUploadOrchestrator(_service())
+    duplicate = AssetWarning(item="/tmp/clip.mp4", message=VIDEO_WARNING)
+    orchestrator.asset_uploader.drain_warnings = MagicMock(  # type: ignore[method-assign]
+        return_value=[duplicate, duplicate]
+    )
+    orchestrator.batch_uploader.drain_warnings = MagicMock(  # type: ignore[method-assign]
+        return_value=[]
+    )
+
+    collected = orchestrator._collect_warnings()
+
+    assert collected == [duplicate]


### PR DESCRIPTION
## What

Surfaces the backend's new non-fatal upload **warnings** (e.g. *"Annotators can't solve tasks with videos longer than 25 seconds…"*) to SDK users, aggregated across **both** upload paths and reported once at the end of Step 1/2, mirroring how `FailedUpload`s are already collected and reported.

This is the **second of two sequenced PRs**. The backend that emits these warnings — RapidataAI/rapidata-backend#4836 — is already **merged**.

## OpenAPI regeneration (Step 1)

Ran `./openapi/generate-schema.sh --environment prod` against the live prod spec. **It produced a zero-line diff** — the automated regen in `chore: update OpenAPI client to 2026.07.23.0652 (#709)` already pulled in the new fields:

- `UploadFileEndpointOutput.warnings` / `UploadFileFromUrlEndpointOutput.warnings` (file/URL sync path) — already existed.
- `GetBatchUploadResultEndpointUrlOutput.warnings` (**new** per-item field on the batch result) — confirmed present in the generated client and live prod spec.

So there is no separate client-regeneration commit here (it would be empty). The batch per-item `warnings` is nonetheless read **defensively** (`getattr(item, "warnings", None)` + `isinstance` guard) so it also works against any older/undeployed backend.

## How (Step 2)

- **`exceptions/asset_warning.py`** — new frozen `AssetWarning(item, message)` dataclass, the success-path parallel of `FailedUpload`; frozen so it de-duplicates in a set.
- **`_asset_uploader.py`** — `AssetUploader` buffers warnings from the `asset_file_post` / `asset_url_post` responses (captured on cache miss) with a thread-safe `_record_warnings` / `drain_warnings`.
- **`_batch_asset_uploader.py`** — `_process_single_batch` records the per-item `warnings`; exposed via `drain_warnings`.
- **`_asset_upload_orchestrator.py`** — `upload_all_assets` drains both uploaders, de-duplicates per unique asset, and reports via `logger.warning(...)` (the same advisory channel as `_warn_if_cost_exceeds_balance`) — not `print`/`warnings.warn`.

### Caching / dedup
Uploads are memoized via `SingleFlightCache`, so a warning is captured only on the **first** upload of a given asset (warn-once-per-unique-asset, as intended). Warnings are additionally de-duplicated on `(item, message)` so an asset referenced by multiple datapoints is reported once.

## Testing
- `tests/rapidata_client/datapoints/test_upload_warnings.py` — new: file-response warnings recorded, no-warning case records nothing, batch per-item warnings recorded, orchestrator surfaces both via the logger, and dedup.
- `pyright src/rapidata/rapidata_client` → 0 errors; `black` clean; full suite green except 4 **pre-existing** audience failures unrelated to this change (fail on a clean checkout too).

🔗 Session: https://poseidon.rapidata.internal/chat/node-94d89c28