### PR TITLE
ci: auto-merge OpenAPI client PR when pyright passes

### DIFF
--- a/.github/workflows/automerge-openapi-client.yml
+++ b/.github/workflows/automerge-openapi-client.yml
@@ -1,0 +1,47 @@
+name: Auto-merge OpenAPI Client PR
+
+# The OpenAPI client PR is bot-generated (openapi-generation-main -> main) and
+# only touches generated code, so once pyright is green there is nothing left
+# for a human to review. This watches the pyright run and squash-merges the PR
+# when it succeeds.
+on:
+  workflow_run:
+    workflows: ["Python Type Checking with Pyright"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    # Gate on: pyright succeeded, for a PR (not a branch push), on the generated
+    # branch, from this repo (not a fork). Only a write-access actor can push
+    # openapi-generation-main, so the branch name is a sufficient trust anchor.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'openapi-generation-main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ vars.RAPIDATA_OPENAPI_GENERATOR_APP_ID }}
+          private-key: ${{ secrets.RAPIDATA_OPENAPI_GENERATOR_PRIVATE_KEY }}
+
+      - name: Merge the OpenAPI client PR
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          pr=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --head openapi-generation-main --base main \
+            --state open --json number --jq '.[0].number')
+          if [ -z "$pr" ]; then
+            echo "No open OpenAPI client PR (openapi-generation-main -> main); nothing to merge."
+            exit 0
+          fi
+          echo "pyright passed for openapi-generation-main; merging PR #$pr"
+          gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --squash --delete-branch


### PR DESCRIPTION
## What

Adds `.github/workflows/automerge-openapi-client.yml`, a `workflow_run` workflow that squash-merges the bot-generated OpenAPI client PR into `main` once the pyright check passes.

## How it works

1. `update-openapi-client.yml` regenerates the client and opens a PR from `openapi-generation-main` → `main` (authored via the GitHub App token, so it *does* trigger other workflows — including pyright).
2. `pyright-type-checking.yml` ("Python Type Checking with Pyright") runs on that PR.
3. **This new workflow** listens for that pyright run completing and merges the PR when **all** of these hold:
   - the pyright run `conclusion == success`,
   - it ran for a `pull_request` (not a branch push),
   - `head_branch == openapi-generation-main`,
   - the head repo is this repo (not a fork).

   It then finds the open `openapi-generation-main → main` PR and runs `gh pr merge --squash --delete-branch`, using the same OpenAPI-generator App token already used to create the PR.

Scoped to `main` only, per the request (the generator can also target `2.x`; those PRs are left untouched).

## ⚠️ Prerequisite for it to actually merge

If `main` has branch protection that **requires an approving review**, the App must be on the branch-protection **bypass list** (or the review requirement relaxed for these bot PRs) — otherwise the merge step will fail with "at least N approving review is required". Making **pyright a required status check** on `main` is also recommended so a red pyright run additionally blocks any manual merge. These are repo settings I can't change from here; flag me if you'd like guidance on the exact settings.

🔗 Session: https://poseidon.rapidata.internal/chat/session-d45f6cbe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RapidataAI/codesmith/rapidata-python-sdk/pr/719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787746343&installation_model_id=5161&pr_number=719&repository=RapidataAI%2Frapidata-python-sdk&return_to=https%3A%2F%2Fgithub.com%2FRapidataAI%2Frapidata-python-sdk%2Fpull%2F719&signature=5c383a8ea0f417761b8287419ecd3ee48dacde4fbab8fd25e29acaf7b873a9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->