### PR TITLE
feat(flow): relax flow item time-to-live minimum to 45s

### DIFF
--- a/src/rapidata/rapidata_client/flow/rapidata_flow.py
+++ b/src/rapidata/rapidata_client/flow/rapidata_flow.py
@@ -59,8 +59,8 @@ class RapidataFlow:
                 RapidataFlowItem,
             )
 
-            if time_to_live is not None and time_to_live < 60:
-                raise ValueError("Time to live must be at least 60 seconds.")
+            if time_to_live is not None and time_to_live < 45:
+                raise ValueError("Time to live must be at least 45 seconds.")
             if context_assets is not None and not 1 <= len(context_assets) <= 10:
                 raise ValueError("Context assets must contain between 1 and 10 assets.")
 


### PR DESCRIPTION
## What

Lower the client-side minimum `time_to_live` for flow items from **60s → 45s** in `RapidataFlow.create_new_flow_batch`.

## Why

Per discussion with the team: the 60s floor was just a conservative guess. With streaming rapids, sub-minute lifetimes are viable. This matches the relaxed backend floor ([companion PR](https://github.com/RapidataAI/rapidata-backend/pull/4897)).

## Changes

- `rapidata_flow.py`: the `< 60` guard → `< 45`, and the error message updated to "at least 45 seconds".

🔗 Session: https://poseidon.rapidata.internal/chat/t-92abe2146ebd89

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RapidataAI/codesmith/rapidata-python-sdk/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787752602&installation_model_id=5161&pr_number=721&repository=RapidataAI%2Frapidata-python-sdk&return_to=https%3A%2F%2Fgithub.com%2FRapidataAI%2Frapidata-python-sdk%2Fpull%2F721&signature=66dae8eb2f4f9bd1649763fa581d288df74aa0cd7f61c8894f8117bab32e0e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->