### PR TITLE
fix(benchmark): make prompt cache instantiation atomic

### DIFF
--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -69,11 +69,11 @@ class RapidataBenchmark:
         )
 
         with tracer.start_as_current_span("RapidataBenchmark.__instantiate_prompts"):
-            self.__prompts = []
-            self.__english_prompts = []
-            self.__identifiers = []
-            self.__prompt_assets = []
-            self.__tags = []
+            prompts: list[str | None] = []
+            english_prompts: list[str | None] = []
+            identifiers: list[str] = []
+            prompt_assets: list[str | None] = []
+            tags: list[list[str]] = []
 
             current_page = 1
             total_pages = None
@@ -93,11 +93,11 @@ class RapidataBenchmark:
                 total_pages = prompts_result.total_pages
 
                 for prompt in prompts_result.items:
-                    self.__prompts.append(prompt.original_prompt)
-                    self.__english_prompts.append(prompt.english_prompt)
-                    self.__identifiers.append(prompt.identifier)
+                    prompts.append(prompt.original_prompt)
+                    english_prompts.append(prompt.english_prompt)
+                    identifiers.append(prompt.identifier)
                     if prompt.prompt_asset is None:
-                        self.__prompt_assets.append(None)
+                        prompt_assets.append(None)
                     else:
                         file_asset = prompt.prompt_asset.actual_instance
                         assert isinstance(file_asset, IAssetModelFileAssetModel)
@@ -108,21 +108,30 @@ class RapidataBenchmark:
                             assert isinstance(
                                 instance, IMetadataModelSourceUrlMetadataModel
                             )
-                            self.__prompt_assets.append(instance.url)
+                            prompt_assets.append(instance.url)
                         elif original_filename is not None:
                             instance = original_filename.actual_instance
                             assert isinstance(
                                 instance, IMetadataModelOriginalFilenameMetadataModel
                             )
-                            self.__prompt_assets.append(instance.original_filename)
+                            prompt_assets.append(instance.original_filename)
                         else:
-                            self.__prompt_assets.append(None)
+                            prompt_assets.append(None)
 
-                    self.__tags.append([tag.value for tag in prompt.tags])
+                    tags.append([tag.value for tag in prompt.tags])
                 if current_page >= total_pages:
                     break
 
                 current_page += 1
+
+            # Commit the caches only once every page fetched and parsed cleanly.
+            # A mid-pagination failure would otherwise leave them partially filled,
+            # and the property getters treat any non-empty cache as complete.
+            self.__prompts = prompts
+            self.__english_prompts = english_prompts
+            self.__identifiers = identifiers
+            self.__prompt_assets = prompt_assets
+            self.__tags = tags
 
     # http / https in any case — same detection the asset uploader uses to tell
     # a remote URL from a local path.


### PR DESCRIPTION
## Context

Investigating a report that `benchmark.prompts` / `.identifiers` / `.tags` broke in SDK **3.17.2** with:

```
TypeError: Field 'tags' on GetPromptsByBenchmarkEndpointOutput has an unexpected type from the backend: Input should be a valid string
```

**Primary root cause (already fixed on `main`, not this PR):** backend PR RapidataAI/rapidata-backend#4879 `feat(leaderboard): prompt tags and origin` (merged 2026-07-27) deliberately changed `GET /benchmark/{id}/prompts` to return `tags` as `{value, category}` objects (plus a new `origin` field). The OpenAPI regen (#725) already updated the model to `List[Tag]` and `__instantiate_prompts` already extracts `tag.value`. That fix just needs a **PyPI release** — the latest published version (v3.17.2, 2026-07-22) predates the backend change. This PR does **not** address the release; it fixes an independent latent bug the report surfaced along the way.

## What this PR fixes (report's "Secondary issue 1")

`__instantiate_prompts` reset the five prompt caches and appended to them **in place** while paginating. Any failure partway through — a 503 on a later page (the report saw intermittent 503s), or a parse error on a single item — left the caches **partially populated**. Because every cache getter (`prompts`, `identifiers`, `tags`, …) treats a non-empty list as a complete, authoritative set, the next access returned silently-truncated data instead of re-fetching or raising.

Observed in the report: `.prompts` raised, then `.identifiers` returned **1 entry** rather than re-instantiating — which downstream surfaced as a misleading `"All identifiers/prompts must be in the registered ... list"` instead of the real fetch failure.

**Fix:** accumulate into local lists and assign to `self` only after every page has been fetched and parsed cleanly — the caches are now all-or-nothing.

## Not in this PR (deliberately)

- **Release of the tags fix** — needs a maintainer to dispatch `Release and Publish` (patch → 3.17.3). Publishing to PyPI is outside an agent's remit.
- **Report's open question — `add_model(prompts=...)` validates against the wrong list.** Confirmed a real latent bug: when `prompts=` is passed, it is validated against `self.identifiers` (line ~619) and used as the upload identifier, but `identifier` and `original_prompt` are distinct fields (identifiers default to prompt text only when `add_prompts` was called without explicit `identifiers`). For a benchmark with distinct identifiers, valid `prompts=` input is spuriously rejected, and the *complete* fix must also translate prompt→identifier before upload (samples are matched server-side by identifier). That's a behavioral change with edge cases (duplicate/None prompt text) best decided by the owner, so it's left out of this focused PR — happy to follow up.

## Testing

`uv run black` clean; `uv run pyright src/rapidata/rapidata_client` → 0 errors.

🔗 Session: https://poseidon.rapidata.internal/chat/session-f1ef50bc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RapidataAI/codesmith/rapidata-python-sdk/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787823527&installation_model_id=5161&pr_number=729&repository=RapidataAI%2Frapidata-python-sdk&return_to=https%3A%2F%2Fgithub.com%2FRapidataAI%2Frapidata-python-sdk%2Fpull%2F729&signature=b9b5b2978d2eb3192461b44b5637fe39d64daf072974f676edc8e495d3bbcc43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->