### PR TITLE
feat(leaderboard): expose prompt-tag filters on leaderboard creation

### DIFF
--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -197,6 +197,46 @@ print(leaderboard.level_of_detail)   # "custom"
 print(leaderboard.response_budget)   # 5000
 ```
 
+### Restricting which prompts a leaderboard uses
+
+A leaderboard normally builds matchups from every prompt in its benchmark. Pass
+`included_tags` and/or `excluded_tags` at creation to narrow that down to a slice
+of the [tagged](#tagging-system) prompts — useful for running a focused
+leaderboard (say, outdoor scenes only) against a broad benchmark.
+
+```python
+leaderboard = benchmark.create_leaderboard(
+    name="Realism (outdoor)",
+    instruction="Which image is more realistic?",
+    included_tags=["outdoor"],   # only prompts tagged "outdoor"
+    excluded_tags=["nsfw"],      # never these, even if also tagged "outdoor"
+)
+```
+
+A prompt is used when it carries at least one `included_tags` value **and** no
+`excluded_tags` value. `excluded_tags` always wins. An empty or omitted
+`included_tags` means no restriction; a non-empty one drops prompts that have no
+tags at all. Matching is on the tag value — a tag's category is irrelevant.
+
+The rules are applied when a run starts rather than snapshotted at creation, so
+re-tagging a prompt changes which future runs pick it up. They only affect what
+gets **collected**; votes already recorded stay in the standings.
+
+!!! note
+    This is a different thing from `get_standings(tags=...)`. These arguments decide
+    which prompts get matchups collected for them, while `get_standings(tags=...)`
+    filters the standings you read back out of what was already collected.
+
+Both are set at creation and read back as read-only properties:
+
+```python
+print(leaderboard.included_tags)  # ["outdoor"]
+print(leaderboard.excluded_tags)  # ["nsfw"]
+```
+
+They cannot be changed afterwards — a leaderboard whose history was collected
+under changing rules is hard to interpret. To re-scope, create a new leaderboard.
+
 ### Prompt and Asset Display
 
 Control what evaluators see during comparison.

--- a/src/rapidata/rapidata_client/benchmark/leaderboard/rapidata_leaderboard.py
+++ b/src/rapidata/rapidata_client/benchmark/leaderboard/rapidata_leaderboard.py
@@ -35,6 +35,8 @@ class RapidataLeaderboard:
         show_prompt: Whether to show the prompt to the users.
         id: The ID of the leaderboard.
         openapi_service: The OpenAPIService instance for API interaction.
+        included_tags: The prompt tag values the leaderboard restricts its matchups to.
+        excluded_tags: The prompt tag values the leaderboard skips when building matchups.
     """
 
     def __init__(
@@ -49,6 +51,8 @@ class RapidataLeaderboard:
         benchmark_id: str,
         id: str,
         openapi_service: OpenAPIService,
+        included_tags: list[str] | None = None,
+        excluded_tags: list[str] | None = None,
     ):
         self.__openapi_service = openapi_service
         self.__name = name
@@ -59,6 +63,8 @@ class RapidataLeaderboard:
         self.__response_budget = response_budget
         self.__min_responses_per_matchup = min_responses_per_matchup
         self.__benchmark_id = benchmark_id
+        self.__included_tags = list(included_tags) if included_tags else []
+        self.__excluded_tags = list(excluded_tags) if excluded_tags else []
         self.id = id
         self.__leaderboard_page = f"https://app.{self.__openapi_service.environment}/mri/benchmarks/{self.__benchmark_id}/leaderboard/{self.id}"
 
@@ -157,6 +163,31 @@ class RapidataLeaderboard:
         Returns the instruction of the leaderboard.
         """
         return self.__instruction
+
+    @property
+    def included_tags(self) -> list[str]:
+        """
+        The prompt tag values this leaderboard restricts its matchups to.
+
+        Only benchmark prompts carrying at least one of these tags are used to build
+        matchups; an empty list (the default) means no restriction. Fixed at creation —
+        to re-scope a leaderboard, create a new one.
+
+        Not to be confused with the ``tags`` argument of :meth:`get_standings`, which
+        filters the standings you read back rather than what gets collected.
+        """
+        return list(self.__included_tags)
+
+    @property
+    def excluded_tags(self) -> list[str]:
+        """
+        The prompt tag values this leaderboard skips when building matchups.
+
+        A prompt carrying any of these tags is never used, even if it also carries one
+        of :attr:`included_tags`. Fixed at creation — to re-scope a leaderboard, create
+        a new one.
+        """
+        return list(self.__excluded_tags)
 
     @property
     def name(self) -> str:

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -306,6 +306,8 @@ class RapidataBenchmark:
                                 self.id,
                                 leaderboard.id,
                                 self._openapi_service,
+                                leaderboard.included_tags,
+                                leaderboard.excluded_tags,
                             )
                             for leaderboard in leaderboards_result.items
                         ]
@@ -618,6 +620,8 @@ class RapidataBenchmark:
         min_responses_per_matchup: int | None = None,
         audience_id: str | RapidataAudienceBase | None = None,
         settings: Sequence["RapidataSetting"] | None = None,
+        included_tags: list[str] | None = None,
+        excluded_tags: list[str] | None = None,
     ) -> RapidataLeaderboard:
         """
         Creates a new leaderboard for the benchmark.
@@ -632,6 +636,20 @@ class RapidataBenchmark:
             min_responses_per_matchup: The minimum number of responses required to be considered for the leaderboard. (default: 3)
             audience_id: The audience that should answer the leaderboard. Pass either the audience id, a :class:`RapidataAudience` (dimension audience), or a :class:`RapidataFilteredAudience` (derived via :py:meth:`RapidataAudience.filter`). Defaults to the global audience when not specified.
             settings: The settings that should be applied to the leaderboard. Will determine the behavior of the tasks on the leaderboard. (default: [])
+            included_tags: Restricts **which of the benchmark's prompts this leaderboard collects matchups for**: only prompts carrying at least one of these tag values are used. When empty or not specified (the default) every prompt is eligible. Note that a non-empty list drops untagged prompts. (default: None)
+            excluded_tags: Prompt tag values to skip when collecting matchups. Always wins over ``included_tags`` — a prompt carrying both an included and an excluded tag is skipped. (default: None)
+
+        Do not confuse either tag argument with the ``tags`` argument of
+        :meth:`RapidataLeaderboard.get_standings`: that filters the standings you read
+        back out, whereas these decide which prompts get matchups collected in the first
+        place.
+
+        Both match on the tag **value**; a tag's category is irrelevant. They are
+        resolved when a run starts rather than snapshotted at creation, so re-tagging a
+        prompt changes which future runs pick it up. They are read back via the
+        read-only :attr:`RapidataLeaderboard.included_tags` /
+        :attr:`RapidataLeaderboard.excluded_tags` and cannot be changed afterwards — to
+        re-scope, create a new leaderboard.
         """
         from rapidata.api_client.models.create_leaderboard_endpoint_input import (
             CreateLeaderboardEndpointInput,
@@ -666,7 +684,7 @@ class RapidataBenchmark:
             )
 
             logger.info(
-                "Creating leaderboard %s with instruction %s, show_prompt %s, show_prompt_asset %s, inverse_ranking %s, level_of_detail %s, min_responses_per_matchup %s, audience_id %s, settings %s",
+                "Creating leaderboard %s with instruction %s, show_prompt %s, show_prompt_asset %s, inverse_ranking %s, level_of_detail %s, min_responses_per_matchup %s, audience_id %s, settings %s, included_tags %s, excluded_tags %s",
                 name,
                 instruction,
                 show_prompt,
@@ -676,6 +694,8 @@ class RapidataBenchmark:
                 min_responses_per_matchup,
                 resolved_audience_id,
                 settings,
+                included_tags,
+                excluded_tags,
             )
 
             leaderboard_result = (
@@ -690,6 +710,8 @@ class RapidataBenchmark:
                         minResponses=min_responses_per_matchup,
                         responseBudget=response_budget,
                         audienceId=resolved_audience_id,
+                        includedTags=included_tags,
+                        excludedTags=excluded_tags,
                         featureFlags=(
                             [setting._to_feature_flag() for setting in settings]
                             if settings
@@ -716,6 +738,8 @@ class RapidataBenchmark:
                 self.id,
                 leaderboard_result.id,
                 self._openapi_service,
+                included_tags,
+                excluded_tags,
             )
 
     def evaluate_model(

--- a/tests/rapidata_client/benchmark/test_leaderboard_prompt_tag_filters.py
+++ b/tests/rapidata_client/benchmark/test_leaderboard_prompt_tag_filters.py
@@ -1,0 +1,108 @@
+"""Tests for the leaderboard prompt-tag filters.
+
+``included_tags`` / ``excluded_tags`` restrict which of a benchmark's prompts a
+leaderboard collects matchups for. They are create-only by design: set on
+``create_leaderboard``, read back as properties, never mutated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rapidata.rapidata_client.benchmark.leaderboard.rapidata_leaderboard import (
+    RapidataLeaderboard,
+)
+from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
+
+
+def _make_benchmark() -> RapidataBenchmark:
+    svc = MagicMock()
+    svc.environment = "rapidata.ai"
+    create = svc.leaderboard.leaderboard_api.leaderboard_post
+    create.return_value.benchmark_id = "bm-1"
+    create.return_value.id = "lb-1"
+    create.return_value.response_budget = 2000
+    create.return_value.min_responses = 3
+    return RapidataBenchmark("bm", "bm-1", svc)
+
+
+def _sent_payload(benchmark: RapidataBenchmark):
+    create = benchmark._openapi_service.leaderboard.leaderboard_api.leaderboard_post
+    return create.call_args.kwargs["create_leaderboard_endpoint_input"]
+
+
+def _make_leaderboard(**kwargs) -> RapidataLeaderboard:
+    return RapidataLeaderboard(
+        "lb",
+        "Which is better?",
+        False,
+        False,
+        False,
+        2000,
+        3,
+        "bm-1",
+        "lb-1",
+        MagicMock(),
+        **kwargs,
+    )
+
+
+def test_create_leaderboard_threads_tags_to_the_wire() -> None:
+    benchmark = _make_benchmark()
+    leaderboard = benchmark.create_leaderboard(
+        name="lb",
+        instruction="Which is better?",
+        included_tags=["outdoor"],
+        excluded_tags=["nsfw"],
+    )
+
+    payload = _sent_payload(benchmark)
+    assert payload.included_tags == ["outdoor"]
+    assert payload.excluded_tags == ["nsfw"]
+    # The create response does not echo the tags, so the returned entity has to
+    # carry the values the caller passed.
+    assert leaderboard.included_tags == ["outdoor"]
+    assert leaderboard.excluded_tags == ["nsfw"]
+
+
+def test_create_leaderboard_omits_tags_by_default() -> None:
+    benchmark = _make_benchmark()
+    leaderboard = benchmark.create_leaderboard(
+        name="lb", instruction="Which is better?"
+    )
+
+    payload = _sent_payload(benchmark)
+    assert payload.included_tags is None
+    assert payload.excluded_tags is None
+    # Unrestricted reads back as empty, matching the wire contract's "empty means
+    # no restriction".
+    assert leaderboard.included_tags == []
+    assert leaderboard.excluded_tags == []
+
+
+def test_tags_default_to_empty_lists() -> None:
+    leaderboard = _make_leaderboard()
+    assert leaderboard.included_tags == []
+    assert leaderboard.excluded_tags == []
+
+
+def test_tag_properties_do_not_expose_internal_state() -> None:
+    """Mutating the returned list must not re-scope the leaderboard."""
+    included = ["outdoor"]
+    leaderboard = _make_leaderboard(included_tags=included)
+
+    leaderboard.included_tags.append("indoor")
+    included.append("city")
+
+    assert leaderboard.included_tags == ["outdoor"]
+
+
+@pytest.mark.parametrize("attribute", ["included_tags", "excluded_tags"])
+def test_tags_are_read_only(attribute: str) -> None:
+    """Create-only by design: a leaderboard is never re-scoped in place."""
+    leaderboard = _make_leaderboard(included_tags=["outdoor"], excluded_tags=["nsfw"])
+
+    with pytest.raises(AttributeError):
+        setattr(leaderboard, attribute, ["something-else"])


### PR DESCRIPTION
Exposes the leaderboard prompt-tag filters from RapidataAI/rapidata-backend#4911 in the SDK.

A leaderboard carries two lists of prompt **tag values** that restrict which of its benchmark's prompts it builds matchups from:

```
eligible(prompt) = (included_tags is empty OR prompt.tags ∩ included_tags ≠ ∅)
                   AND (prompt.tags ∩ excluded_tags = ∅)
```

```python
leaderboard = benchmark.create_leaderboard(
    name="Realism (outdoor)",
    instruction="Which image is more realistic?",
    included_tags=["outdoor"],   # only prompts tagged "outdoor"
    excluded_tags=["nsfw"],      # never these, even if also tagged "outdoor"
)

leaderboard.included_tags  # ["outdoor"]  — read-only
```

## Create-only by design

The API supports `PATCH`ing both fields (`UpdateLeaderboardEndpoint_Input` carries them), but **this PR deliberately does not expose editing**. They are set at creation and read-only afterwards: no setters, no mutation helpers, and `_update_config` is untouched. Rationale: a leaderboard whose history was collected under changing rules is hard to interpret — to re-scope, create a new leaderboard.

## Changes

**No generated code in this PR.** `includedTags` / `excludedTags` are already on `main`'s generated client, landed by the scheduled `chore: update OpenAPI client` automation (through #744) — so this PR is purely the hand-written wrapper on top of it, and `src/rapidata/api_client/` is untouched.

- `RapidataBenchmark.create_leaderboard()` gains `included_tags` / `excluded_tags`, threaded to `CreateLeaderboardEndpointInput(includedTags=..., excludedTags=...)`.
- `RapidataLeaderboard` gains read-only `included_tags` / `excluded_tags` properties, following the `show_prompt` / `instruction` / `inverse_ranking` pattern. Threaded through `__init__` and **both** construction sites — the `leaderboards` property (from the query output, which carries the fields) and `create_leaderboard`.
- Docs: a new "Restricting which prompts a leaderboard uses" section in `docs/mri_advanced.md`.
- Tests: `tests/rapidata_client/benchmark/test_leaderboard_prompt_tag_filters.py`, following the `test_prompt_tags.py` precedent for covering wrapper params.

### Note for reviewers

`create_leaderboard` passes the caller's values into the returned `RapidataLeaderboard` rather than reading them off the response, because `CreateLeaderboardEndpoint_Output` does **not** echo the two fields (only the `Get`/`Query` outputs do). This matches what the surrounding code already does for `name`, `instruction`, and `show_prompt`.

The docstrings explicitly distinguish these from `get_standings(tags=...)` — that filters the standings you read back out, whereas these decide which prompts get matchups collected in the first place. The two are easy to confuse.

## Verification

Run against `main`'s generated client (rebased onto bc0d3c36):

- `pyright src/rapidata/rapidata_client` → 0 errors, 0 warnings
- `pytest tests/rapidata_client/benchmark` → 22 passed
- `python3 -c "from rapidata import RapidataClient"` → OK
- `uv run --group docs mkdocs build` → builds; remaining warnings are pre-existing and unrelated
- `black --check` on the touched packages → clean

Pre-existing on `main`, **not** caused by this PR: 4 failures in `tests/rapidata_client/audience/` (`test_assign_job_*`). Verified by running them at a clean `main` checkout before making any change.

🔗 Session: https://poseidon.rapidata.internal/chat/node-b645b8dd
