### PR TITLE
ci(release): rebuild the MCP image on stable SDK releases

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -180,3 +180,16 @@ jobs:
         repository: rapidataAI/skills
         event-type: sdk-release
         client-payload: '{"version": "${{ steps.update_version.outputs.new_version }}"}'
+
+    # The hosted MCP server wraps this SDK but resolves it at image build time, so
+    # without a rebuild it keeps serving whatever version was current when that repo
+    # last changed — it had drifted to 3.15.3 while 3.19.2 was released. Hand it the
+    # version just published so it pins exactly this release.
+    - name: Trigger rapidata-mcp image rebuild
+      if: steps.release_type.outputs.type == 'stable'
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.SKILLS_REPO_PAT }}
+        repository: RapidataAI/rapidata-mcp
+        event-type: sdk-released
+        client-payload: '{"sdk_version": "${{ steps.update_version.outputs.new_version }}"}'


### PR DESCRIPTION
## Why

The hosted MCP server (`https://mcp.rapidata.ai`) wraps this SDK, but its image resolves `rapidata` from PyPI **at build time** and only rebuilds when its own repo changes. Nothing connected the two, so it silently drifted: prod has been serving **rapidata 3.15.3** since 2026-07-06 while **3.19.2** is current (verified by pulling the deployed image).

That drift is far enough to matter. Against the live API, 3.15.3 fails to validate `GetAudienceByIdEndpointOutput` — the backend now returns `graduationScore: null` where 3.15.3 types it as a required `float | int`:

```
ValidationError: graduationScore  Input should be a valid number [input_value=None]
```

That is the `audience.get_audience_by_id("global")` lookup the MCP's `start_job` tool is built on. Clean on 3.19.2.

## What this does

Adds one step to the release job: after a **stable** publish, `repository_dispatch` `sdk-released` to `RapidataAI/rapidata-mcp` with the version just released, so the rebuild pins exactly this release rather than re-resolving.

Mirrors the existing skills-plugin sync directly above it — same action, same `SKILLS_REPO_PAT`, same `stable`-only gate so pre-releases (`alpha`/`beta`/`rc`) never reach the hosted server. Placed last, after publish/tag/release, so a dispatch failure cannot affect the release itself.

## Depends on

[RapidataAI/rapidata-mcp#17](https://github.com/RapidataAI/rapidata-mcp/pull/17), which consumes the event. **Merge that one first** — `repository_dispatch` only triggers workflows present on the default branch, so until it lands this dispatch is a no-op. That PR also bounds `mcp` to `<2`, which turned out to be load-bearing: mcp 2.0.0 drops `mcp.server.fastmcp`, so an unbounded rebuild produced an image that could not import at all.

## Verification

- Both workflow files parse, and the two halves of the contract were cross-checked mechanically: the `event-type` the SDK sends is in the MCP's `repository_dispatch.types`, and every `client_payload` key the MCP reads (`sdk_version`) is one this step sends.
- YAML-only change; no SDK source touched, so `pyright`/`black` are unaffected.

## One thing to confirm

Per your call, this reuses `SKILLS_REPO_PAT`. That works if it's a classic PAT with `repo` scope; if it turns out to be fine-grained and scoped to `rapidataAI/skills` only, this step will fail with a 404 on the next stable release (loudly, and after the publish has already succeeded — so the release is never at risk). If that happens, either widen the token or swap in a credential with `contents: write` on `rapidata-mcp`.

🔗 Session: https://poseidon.rapidata.internal/chat/session-46d6d6d0