### PR TITLE
docs: link the rapidata-vs-prolific quality benchmark

### DIFF
--- a/docs/understanding_the_results.md
+++ b/docs/understanding_the_results.md
@@ -187,6 +187,8 @@ Qualification tasks are examples with known correct answers that labelers must p
 - **Quality Control**: It helps in identifying and filtering for the most reliable responses.
 - **Insight into Labeler Performance**: Provides transparency into who is contributing to your data and how reliably.
 
+We measured how well this works in practice by asking Rapidata's crowd and Prolific's panel the same 300 questions with known answers: [Rapidata vs. Prolific - Cost and Quality on the Same 300 Tasks](https://www.rapidata.ai/blog/rapidata-vs-prolific).
+
 ## Utilizing the Results
 
 - **Clear Winners**: Use `winner` / `winnerIndex` (the raw-majority winner) or `weightedWinner` / `weightedWinnerIndex` (the reliability-weighted winner) to identify which option was preferred — and be explicit about which notion of "won" you mean, since the two can differ on close votes. Both are `null` when there is no clear winner. The older `winner_index` is a deprecated alias of `winnerIndex`; prefer `winnerIndex`.


### PR DESCRIPTION
Adds a backlink from the userScore / quality section of *Understanding the Results* to the new [Rapidata vs. Prolific blog post](https://www.rapidata.ai/blog/rapidata-vs-prolific), which benchmarks the scoring mechanism head-to-head on 300 ground-truth tasks.

**Merge after** RapidataAI/Website#545 is live — the blog URL 404s until the post is published.

🔗 Session: [session-2a6d1f63](https://poseidon.rapidata.internal/chat/session-2a6d1f63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)