### PR TITLE
ci(openapi): run client auto-merge daily instead of per PR

### DIFF
--- a/.github/workflows/automerge-openapi-client.yml
+++ b/.github/workflows/automerge-openapi-client.yml
@@ -2,35 +2,36 @@ name: Auto-merge OpenAPI Client PR
 
 # The OpenAPI client PR is bot-generated (openapi-generation-main -> main) and
 # is *supposed* to touch only generated code, so once pyright is green there is
-# nothing left for a human to review. This watches the pyright run and
-# squash-merges the PR when it succeeds.
+# nothing left for a human to review.
+#
+# This runs on a daily schedule rather than on every pyright completion: the
+# backend dispatches a regeneration many times a day, and merging each one
+# immediately produced a dozen+ commits a day on main. Letting the PR accumulate
+# and merging once a day collapses that into a single commit without changing
+# what lands.
 #
 # The branch name alone is NOT a sufficient trust anchor: anyone with write
 # access (a human, a Poseidon vessel) can push to openapi-generation-main, and a
 # hand-written edit there can turn pyright green and slip past a name-only gate,
 # reaching main with no review. So before merging we re-verify the PR is
-# genuinely generator-only (see the guard step below).
+# genuinely generator-only (see the guard steps below).
 on:
-  workflow_run:
-    workflows: ["Python Type Checking with Pyright"]
-    types:
-      - completed
+  schedule:
+    # 06:00 UTC — the accumulated specs land before the working day starts.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: automerge-openapi-client
+  cancel-in-progress: false
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    # Gate on: pyright succeeded, for a PR (not a branch push), on the generated
-    # branch, from this repo (not a fork). The generator-only content check runs
-    # in the merge step, since it needs API calls the `if:` can't make.
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'openapi-generation-main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
     steps:
       - uses: actions/create-github-app-token@v1
         id: generate-token
@@ -45,6 +46,9 @@ jobs:
           # in update-openapi-client.yml. Every commit on an auto-mergeable PR
           # must match this.
           GENERATOR_COMMIT_EMAIL: login@rapidata.ai
+          # The type-check that used to trigger this workflow; now we look up its
+          # conclusion for the PR head ourselves.
+          PYRIGHT_WORKFLOW: pyright-type-checking.yml
         run: |
           set -euo pipefail
 
@@ -68,6 +72,31 @@ jobs:
           This PR is no longer generator-only, so it needs a human to review and merge it (the pyright check passing is not enough on its own)."
             exit 0
           }
+
+          pr_json=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid,headRepository,headRepositoryOwner,isDraft)
+          head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
+          head_repo=$(jq -r '.headRepositoryOwner.login + "/" + .headRepository.name' <<<"$pr_json")
+          is_draft=$(jq -r '.isDraft' <<<"$pr_json")
+
+          if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
+            block "its head branch lives in a fork ($head_repo)"
+          fi
+          if [ "$is_draft" = "true" ]; then
+            echo "PR #$pr is a draft; leaving it alone."
+            exit 0
+          fi
+
+          # Guard 0: pyright is green for exactly this head commit. A run that is
+          # still queued/in-progress just means the PR is not ready yet — the next
+          # scheduled run will pick it up.
+          conclusion=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/$PYRIGHT_WORKFLOW/runs?head_sha=$head_sha&event=pull_request&per_page=1" \
+            --jq '.workflow_runs[0].conclusion // "missing"')
+          if [ "$conclusion" != "success" ]; then
+            echo "Pyright for $head_sha is '$conclusion', not success; not merging PR #$pr."
+            exit 0
+          fi
 
           # Guard 1: every commit is authored by the generator identity. A push
           # from a human or a Poseidon vessel shows up here as a foreign author,

--- a/.github/workflows/automerge-openapi-client.yml
+++ b/.github/workflows/automerge-openapi-client.yml
@@ -73,11 +73,12 @@ jobs:
             exit 0
           }
 
-          pr_json=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" \
-            --json headRefOid,headRepository,headRepositoryOwner,isDraft)
-          head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
-          head_repo=$(jq -r '.headRepositoryOwner.login + "/" + .headRepository.name' <<<"$pr_json")
-          is_draft=$(jq -r '.isDraft' <<<"$pr_json")
+          # REST rather than `gh pr view --json`: reading the head repo over
+          # GraphQL needs read:org, which the app token does not carry.
+          pr_json=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr")
+          head_sha=$(jq -r '.head.sha' <<<"$pr_json")
+          head_repo=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+          is_draft=$(jq -r '.draft' <<<"$pr_json")
 
           if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
             block "its head branch lives in a fork ($head_repo)"


### PR DESCRIPTION
## Why

The backend dispatches an OpenAPI regeneration many times a day. Each dispatch recreates the `openapi-generation-main` PR, and the auto-merge fired the moment pyright went green — so every regeneration became its own commit on `main`. Recent history:

| Date | `chore: update OpenAPI client` commits on main |
|---|---|
| 2026-08-07 | 13 |
| 2026-08-06 | 10 |
| 2026-08-05 | 11 |
| 2026-08-03 | 14 |

86 of the last 100 commits on `main` are generator merges.

## What changed

Auto-merge moves from `workflow_run` (every pyright completion) to a daily `schedule` at 06:00 UTC, plus `workflow_dispatch` for a manual run.

Generation is untouched — the PR still updates on every dispatch, so the latest specs are always visible in the open PR. It just lands on `main` once a day instead of a dozen times, collapsing the day's regenerations into a single squash commit.

Because the workflow no longer receives the pyright result as its trigger payload, it now looks the conclusion up itself: the newest `pyright-type-checking.yml` run for the PR's head SHA must be `success`. Queued/in-progress/failed is a no-op — the next scheduled run picks it up.

## Safety

All existing guards are kept, and two are added:

- **new** — head branch must not be a fork; draft PRs are skipped
- **new** — pyright must be `success` for the exact head SHA
- every commit authored by the generator identity (`login@rapidata.ai`)
- only generated paths changed (`openapi/schemas/`, `src/rapidata/api_client/`, `api_client_README.md`)

A blocked PR still gets the explanatory comment and falls back to a human.

## Verification

- YAML parses; embedded shell passes `bash -n`
- Both `gh` lookups verified against real PR #804: the workflow-run query returns `conclusion: success` for its head SHA, and the PR JSON fields resolve

## Trade-off

Specs merged during the day now wait until the next 06:00 UTC window. Anyone who needs one sooner can trigger the workflow manually or merge the PR by hand. Say the word if you'd rather have a different hour or a twice-daily cadence.

🔗 Session: [session-8f35d91c](https://poseidon.rapidata.internal/chat/session-8f35d91c)