### PR TITLE
docs(ai-agents): document skill auto-update for claude code

### DIFF
--- a/docs/ai_agents.md
+++ b/docs/ai_agents.md
@@ -62,15 +62,41 @@ Other agents follow their own conventions — Cursor rules, Copilot instructions
 
 ## Keeping the skill up to date
 
-The Rapidata SDK evolves constantly — new task types, new audience features, better defaults. Pull the latest version so your agent stays in sync.
+The Rapidata SDK evolves constantly — new task types, new audience features, better defaults. A skill that lags behind the SDK will describe methods that have changed, so either let Claude Code update it for you or pull it yourself.
 
-**Claude Code**:
+### Automatic — Claude Code
+
+Claude Code refreshes marketplaces and updates their installed plugins in the background shortly after a session starts. This is off by default for marketplaces outside Anthropic's own, so switch it on once:
+
+`/plugin` → **Marketplaces** → `rapidata-sdk-marketplace` → **Enable auto-update**
+
+To set it for everyone on a project, commit it to `.claude/settings.json` — the same block works in your personal `~/.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "rapidata-sdk-marketplace": {
+      "source": { "source": "github", "repo": "RapidataAI/skills" },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "rapidata-sdk-plugin@rapidata-sdk-marketplace": true
+  }
+}
+```
+
+When an update lands mid-session, Claude Code asks you to run `/reload-plugins`. Otherwise it takes effect on your next launch.
+
+### Manual
+
+Claude Code:
 
 ```bash
 claude plugin marketplace update
 ```
 
-**Everything else**:
+Everything else — the `skills` CLI updates only when you ask it to:
 
 ```bash
 npx skills update rapidata


### PR DESCRIPTION
## What

Rewrites the "Keeping the skill up to date" section of `docs/ai_agents.md` to lead with the automatic option instead of only manual commands.

Claude Code refreshes marketplaces and updates their installed plugins in the background shortly after a session starts, but this defaults to **off** for every marketplace outside Anthropic's own — so nobody who installed our skill was getting it. The page now documents both ways to opt in:

- the one-time `/plugin` → Marketplaces → **Enable auto-update** toggle
- an `extraKnownMarketplaces` block with `"autoUpdate": true` for `.claude/settings.json`, so a team can commit it once

The manual commands stay, moved under their own heading. The `skills` CLI (Cursor / Copilot / Codex / Windsurf) has no auto-update mechanism, so `npx skills update` remains the only option there and the text now says so rather than implying parity.

## Context

The skill drifting from the SDK is a real failure mode, not a hypothetical: the version pinned in the published skill is currently three minor versions behind PyPI, because the sync workflow in `RapidataAI/skills` has failed on every release since v3.16.7. **This PR does not fix that** — it only makes sure users receive updates once they are published again. The pipeline repair is tracked separately.

## Verification

`uv run --group docs mkdocs build` passes; the new section renders on the AI Agents page. Remaining build warnings are pre-existing and unrelated.

🔗 Session: https://poseidon.rapidata.internal/chat/session-39aad07d