### PR TITLE
fix(ranking): honor comparison budget for rankings of 10 or fewer items

### DIFF
--- a/docs/examples/ranking_job.md
+++ b/docs/examples/ranking_job.md
@@ -45,7 +45,7 @@ print(results)
 
 1. The global audience (id `global`) already has labelers ready to work, so the job starts collecting responses immediately. You can assign a ranking job to any audience — browse them in the [Rapidata Dashboard](https://app.rapidata.ai/audiences).
 2. The outer list defines independent rankings; each inner list is the set of datapoints ranked against each other. Here, this is a single ranking over all rabbits.
-3. The number of matchups collected per ranking. More comparisons make the resulting order more reliable.
+3. The number of matchups collected per ranking. More comparisons make the resulting order more reliable. For rankings of 10 or fewer datapoints, the budget is spread evenly over every unique pair (rounded down to a multiple of the number of pairs).
 4. Half the comparisons are random; the rest are close matchups between similarly-rated datapoints.
 
 !!! note

--- a/docs/job_definition_parameters.md
+++ b/docs/job_definition_parameters.md
@@ -438,7 +438,9 @@ job_definition = client.job.create_free_text_job_definition(
 |-----------|------|-------------|
 | `comparison_budget_per_ranking` | `int` | Number of pairwise matchups collected per ranking (per inner list of `datapoints`) |
 | `responses_per_comparison` | `int` | Number of responses collected per matchup (default `1`) — replaces `responses_per_datapoint` |
-| `random_comparisons_ratio` | `float` | Ratio of random matchups to total matchups (default `0.5`); the rest are close matchups between similarly-rated datapoints |
+| `random_comparisons_ratio` | `float` | Ratio of random matchups to total matchups (default `0.5`); the rest are close matchups between similarly-rated datapoints. Only applies to rankings with more than 10 datapoints |
+
+Rankings with more than 10 datapoints pick matchups adaptively (Elo-style) within the comparison budget. Rankings with 10 or fewer datapoints compare every unique pair instead, spreading the budget evenly across the pairs — the total is rounded down to a multiple of the number of pairs, and every pair is compared at least once even if the budget is smaller than the number of pairs.
 
 ```python
 job_definition = client.job.create_ranking_job_definition(

--- a/src/rapidata/rapidata_client/job/rapidata_job_manager.py
+++ b/src/rapidata/rapidata_client/job/rapidata_job_manager.py
@@ -337,11 +337,15 @@ class RapidataJobManager:
             name (str): The name of the job.
             instruction (str): The instruction for the ranking. Will be shown with each matchup.
             datapoints (list[list[str]]): The outer list is determines the independent rankings, the inner list is the datapoints for each ranking.
-            comparison_budget_per_ranking (int): The number of comparisons that will be collected per ranking (outer list of datapoints).
+            comparison_budget_per_ranking (int): The number of comparisons that will be collected per ranking (outer list of datapoints).\n
+                Rankings with more than 10 datapoints are matched adaptively (Elo-style) within this budget.
+                Rankings with 10 or fewer datapoints compare every unique pair, spreading the budget evenly across the pairs —
+                the total is rounded down to a multiple of the number of pairs, and is at least one comparison per pair.
             responses_per_comparison (int, optional): The number of responses that will be collected per comparison. Defaults to 1.
             data_type (str, optional): The data type of the datapoints. Defaults to "media" (any form of image, video or audio). \n
                 Other option: "text".
-            random_comparisons_ratio (float, optional): The ratio of random comparisons to the total number of comparisons. Defaults to 0.5.
+            random_comparisons_ratio (float, optional): The ratio of random comparisons to the total number of comparisons. Defaults to 0.5.\n
+                Only applies to rankings with more than 10 datapoints; smaller rankings compare every unique pair.
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
@@ -390,16 +394,19 @@ class RapidataJobManager:
                         )
                     )
 
+            workflow = MultiRankingWorkflow(
+                instruction=instruction,
+                comparison_budget_per_ranking=comparison_budget_per_ranking,
+                random_comparisons_ratio=random_comparisons_ratio,
+                max_group_size=max(len(group) for group in datapoints),
+                responses_per_comparison=responses_per_comparison,
+            )
+
             return self._create_general_job_definition(
                 name=name,
-                workflow=MultiRankingWorkflow(
-                    instruction=instruction,
-                    comparison_budget_per_ranking=comparison_budget_per_ranking,
-                    random_comparisons_ratio=random_comparisons_ratio,
-                    max_group_size=max(len(group) for group in datapoints),
-                ),
+                workflow=workflow,
                 datapoints=datapoints_instances,
-                responses_per_datapoint=responses_per_comparison,
+                responses_per_datapoint=workflow.responses_per_datapoint,
                 settings=settings,
                 failure_tolerance=failure_tolerance,
             )

--- a/src/rapidata/rapidata_client/order/rapidata_order_manager.py
+++ b/src/rapidata/rapidata_client/order/rapidata_order_manager.py
@@ -431,11 +431,15 @@ class RapidataOrderManager:
             name (str): The name of the order.
             instruction (str): The instruction for the ranking. Will be shown with each matchup.
             datapoints (list[list[str]]): The outer list is determines the independent rankings, the inner list is the datapoints for each ranking.
-            comparison_budget_per_ranking (int): The number of comparisons that will be collected per ranking (outer list of datapoints).
+            comparison_budget_per_ranking (int): The number of comparisons that will be collected per ranking (outer list of datapoints).\n
+                Rankings with more than 10 datapoints are matched adaptively (Elo-style) within this budget.
+                Rankings with 10 or fewer datapoints compare every unique pair, spreading the budget evenly across the pairs —
+                the total is rounded down to a multiple of the number of pairs, and is at least one comparison per pair.
             responses_per_comparison (int, optional): The number of responses that will be collected per comparison. Defaults to 1.
             data_type (str, optional): The data type of the datapoints. Defaults to "media" (any form of image, video or audio). \n
                 Other option: "text".
-            random_comparisons_ratio (float, optional): The ratio of random comparisons to the total number of comparisons. Defaults to 0.5.
+            random_comparisons_ratio (float, optional): The ratio of random comparisons to the total number of comparisons. Defaults to 0.5.\n
+                Only applies to rankings with more than 10 datapoints; smaller rankings compare every unique pair.
             contexts (list[str], optional): The list of contexts for the ranking. Defaults to None.\n
                 If provided has to be the same length as the outer list of datapoints and will be shown in addition to the instruction. (Therefore will be different for each ranking)
                 Will be matched up with the datapoints using the list index.
@@ -506,16 +510,19 @@ class RapidataOrderManager:
                         )
                     )
 
+            workflow = MultiRankingWorkflow(
+                instruction=instruction,
+                comparison_budget_per_ranking=comparison_budget_per_ranking,
+                random_comparisons_ratio=random_comparisons_ratio,
+                max_group_size=max(len(group) for group in datapoints),
+                responses_per_comparison=responses_per_comparison,
+            )
+
             return self._create_general_order(
                 name=name,
-                workflow=MultiRankingWorkflow(
-                    instruction=instruction,
-                    comparison_budget_per_ranking=comparison_budget_per_ranking,
-                    random_comparisons_ratio=random_comparisons_ratio,
-                    max_group_size=max(len(group) for group in datapoints),
-                ),
+                workflow=workflow,
                 datapoints=datapoints_instances,
-                responses_per_datapoint=responses_per_comparison,
+                responses_per_datapoint=workflow.responses_per_datapoint,
                 validation_set_id=validation_set_id,
                 filters=filters,
                 selections=selections,

--- a/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
+++ b/src/rapidata/rapidata_client/workflow/_multi_ranking_workflow.py
@@ -9,6 +9,7 @@ from rapidata.rapidata_client.workflow._base_workflow import Workflow
 from rapidata.api_client.models.i_rapid_payload_compare_payload import (
     IRapidPayloadComparePayload,
 )
+from rapidata.rapidata_client.config import logger
 from rapidata.rapidata_client.datapoints._datapoint import Datapoint
 from rapidata.api_client.models.rapid_modality import RapidModality
 
@@ -26,6 +27,7 @@ class MultiRankingWorkflow(Workflow):
         comparison_budget_per_ranking: int,
         random_comparisons_ratio: float,
         max_group_size: int,
+        responses_per_comparison: int,
     ):
         from rapidata.api_client.models.i_pair_maker_config import (
             IPairMakerConfig,
@@ -50,12 +52,31 @@ class MultiRankingWorkflow(Workflow):
         self.comparison_budget_per_ranking = comparison_budget_per_ranking
         self.random_comparisons_ratio = random_comparisons_ratio
         self.max_group_size = max_group_size
+        self.responses_per_comparison = responses_per_comparison
 
         if max_group_size <= FULL_PERMUTATION_GROUP_SIZE_THRESHOLD:
             self.pair_maker_config = IPairMakerConfig(
                 actual_instance=IPairMakerConfigFullPermutationPairMakerConfig(
                     _t="FullPermutationPairMaker",
                 ),
+            )
+            # The full-permutation pair maker takes no budget: it emits each
+            # unique pair exactly once. Spread the budget over the pairs via
+            # the per-rapid response requirement so the total still honors it.
+            pairs = max_group_size * (max_group_size - 1) // 2
+            comparisons_per_pair = comparison_budget_per_ranking // pairs
+            if comparisons_per_pair < 1:
+                logger.warning(
+                    "comparison_budget_per_ranking=%d is below the %d unique pairs "
+                    "of a %d-item ranking; every pair is compared at least once, "
+                    "so the budget will be exceeded.",
+                    comparison_budget_per_ranking,
+                    pairs,
+                    max_group_size,
+                )
+                comparisons_per_pair = 1
+            self.responses_per_datapoint = (
+                comparisons_per_pair * responses_per_comparison
             )
         else:
             self.pair_maker_config = IPairMakerConfig(
@@ -65,6 +86,7 @@ class MultiRankingWorkflow(Workflow):
                     randomMatchesRatio=random_comparisons_ratio,
                 ),
             )
+            self.responses_per_datapoint = responses_per_comparison
 
         self.ranking_config = IRankingConfig(
             actual_instance=IRankingConfigBradleyTerryRankingConfig(
@@ -98,4 +120,4 @@ class MultiRankingWorkflow(Workflow):
         return f"MultiRankingWorkflow(instruction='{self.instruction}')"
 
     def __repr__(self) -> str:
-        return f"MultiRankingWorkflow(instruction={self.instruction!r}, comparison_budget_per_ranking={self.comparison_budget_per_ranking!r}, random_comparisons_ratio={self.random_comparisons_ratio!r}, max_group_size={self.max_group_size!r})"
+        return f"MultiRankingWorkflow(instruction={self.instruction!r}, comparison_budget_per_ranking={self.comparison_budget_per_ranking!r}, random_comparisons_ratio={self.random_comparisons_ratio!r}, max_group_size={self.max_group_size!r}, responses_per_comparison={self.responses_per_comparison!r})"

--- a/tests/rapidata_client/job/test_multi_ranking_workflow.py
+++ b/tests/rapidata_client/job/test_multi_ranking_workflow.py
@@ -1,0 +1,64 @@
+"""Tests for the ranking pair-maker selection and budget handling.
+
+Small rankings (<= 10 items) use the full-permutation pair maker, which takes
+no budget of its own — the comparison budget must be honored by scaling the
+per-pair response requirement instead of being silently dropped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rapidata.rapidata_client.workflow._multi_ranking_workflow import (
+    FULL_PERMUTATION_GROUP_SIZE_THRESHOLD,
+    MultiRankingWorkflow,
+)
+
+
+def _make(max_group_size: int, budget: int, responses_per_comparison: int = 1):
+    return MultiRankingWorkflow(
+        instruction="Which one is better?",
+        comparison_budget_per_ranking=budget,
+        random_comparisons_ratio=0.5,
+        max_group_size=max_group_size,
+        responses_per_comparison=responses_per_comparison,
+    )
+
+
+def test_small_ranking_spreads_budget_over_all_pairs():
+    # 7 items -> 21 unique pairs; a budget of 5000 must not collapse to 21.
+    workflow = _make(max_group_size=7, budget=5000)
+
+    assert (
+        workflow.pair_maker_config.actual_instance.t == "FullPermutationPairMaker"
+    )
+    assert workflow.responses_per_datapoint == 5000 // 21  # 238 -> 4998 total
+
+
+def test_small_ranking_budget_multiplies_responses_per_comparison():
+    workflow = _make(max_group_size=7, budget=100, responses_per_comparison=3)
+
+    assert workflow.responses_per_datapoint == (100 // 21) * 3
+
+
+def test_budget_below_pair_count_keeps_full_coverage_and_warns(caplog):
+    # 10 items -> 45 pairs; every pair still needs at least one comparison.
+    with caplog.at_level("WARNING", logger="rapidata"):
+        workflow = _make(max_group_size=10, budget=20, responses_per_comparison=2)
+
+    assert workflow.responses_per_datapoint == 2
+    assert any("budget" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_large_ranking_uses_online_pair_maker_with_budget():
+    workflow = _make(
+        max_group_size=FULL_PERMUTATION_GROUP_SIZE_THRESHOLD + 1,
+        budget=5000,
+        responses_per_comparison=2,
+    )
+
+    online = workflow.pair_maker_config.actual_instance
+    assert online.t == "OnlinePairMaker"
+    assert online.total_comparison_budget == 5000
+    assert online.random_matches_ratio == pytest.approx(0.5)
+    assert workflow.responses_per_datapoint == 2


### PR DESCRIPTION
## Problem

`create_ranking_job_definition` (and the deprecated `create_ranking_order`) silently ignores `comparison_budget_per_ranking` and `random_comparisons_ratio` when the largest ranking group has **10 or fewer datapoints**: `MultiRankingWorkflow` switches to the `FullPermutationPairMaker`, which emits each unique pair exactly once with `responses_per_comparison` responses.

Real-world impact: a 7-logo ranking launched with `comparison_budget_per_ranking=5000` (job `job_1S0zegXPmIhA6E`, workflow `rwf_1S0zfTbMe700Bu`) collected only C(7,2) = **21 responses** instead of ~5000, with no warning of any kind.

## Fix

The `FullPermutationPairMakerConfig` contract has no budget field, so the budget is honored through the referee instead:

- In full-permutation mode, each pair now requires `comparison_budget_per_ranking // n_pairs` comparisons (times `responses_per_comparison`), i.e. the budget is spread evenly over all unique pairs. Rounding is downward so the budget is never exceeded — the 7-logo example now yields 21 × 238 = 4998 responses.
- If the budget is smaller than the number of pairs, every pair is still compared once (the minimum for full coverage) and a **warning is logged** that the budget will be exceeded.
- The online (>10 items) path is unchanged.
- For jobs with multiple rankings of different sizes, the spread is computed from the largest group (consistent with how the pair-maker threshold is already chosen); smaller groups collect proportionally fewer comparisons.

Docstrings and the ranking docs now spell out both behaviors, and `MultiRankingWorkflow` has unit tests covering the budget spread, the `responses_per_comparison` multiplier, the below-coverage warning, and the online path.

## Verification

- `uv run pytest tests/rapidata_client/job` — 18 passed (4 pre-existing failures in `tests/rapidata_client/audience` also fail on `main`, unrelated)
- `uv run pyright src/rapidata/rapidata_client` — 0 errors
- `uv run black --check` on touched files — clean

🔗 Session: [session-cdc00927](https://poseidon.rapidata.internal/chat/session-cdc00927)

🤖 Generated with [Claude Code](https://claude.com/claude-code)