### PR TITLE
docs: remove unused LanguageFilter imports from starting page

### DIFF
--- a/docs/starting_page.md
+++ b/docs/starting_page.md
@@ -60,7 +60,7 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
 
 === "Audio"
     ```python
-    from rapidata import RapidataClient, LanguageFilter
+    from rapidata import RapidataClient
 
     client = RapidataClient()
 
@@ -82,7 +82,7 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
 
 === "Text"
     ```python
-    from rapidata import RapidataClient, LanguageFilter
+    from rapidata import RapidataClient
 
     client = RapidataClient()
 


### PR DESCRIPTION
The Audio and Text tabs of the docs landing page import `LanguageFilter` but never use it — leftovers from when these examples used the deprecated order API, which took a `filters=` argument.

`create_compare_job_definition` has no `filters` parameter; in the Jobs model, annotator filtering lives on the audience (`audience.filter([LanguageFilter(["en"])])`, documented in `docs/audiences.md`). The dangling import points readers at a parameter that does not exist on the job path.

This came out of investigating why a customer on the latest SDK (3.19.2) reached for `create_compare_order` instead of a job definition: they needed an English-only audience, and `filters=` only exists on the deprecated order API. The unused import here is one of the trails leading there.

Docs-only, two lines. Verified with `uv run --group docs mkdocs build` — builds clean, remaining warnings are pre-existing and unrelated.

🔗 Session: [session-af1a7b32](https://poseidon.rapidata.internal/chat/session-af1a7b32)