### PR TITLE
fix(api-client): bound HTTP timeouts and stop retry log spam

### DIFF
--- a/openapi/templates/rest.mustache
+++ b/openapi/templates/rest.mustache
@@ -6,12 +6,22 @@ import json
 import logging
 import random
 import re
+import threading
 import time
 from typing import Dict, Optional
 
 import httpx
 from authlib.integrations.httpx_client import OAuth2Client
-from httpx import Timeout, ConnectError, Limits, RemoteProtocolError, ConnectTimeout, ReadTimeout
+from httpx import (
+    USE_CLIENT_DEFAULT,
+    ConnectError,
+    Limits,
+    ReadError,
+    RemoteProtocolError,
+    Timeout,
+    TimeoutException,
+    WriteError,
+)
 
 from rapidata.api_client.exceptions import ApiException, ApiValueError
 
@@ -20,9 +30,29 @@ _TRANSIENT_RETRY_MAX_ATTEMPTS = 3
 _TRANSIENT_RETRY_BASE_DELAY = 0.5
 _TRANSIENT_RETRY_MAX_DELAY = 30.0
 # 429 = rate limit, 502/503/504 = transient upstream / gateway errors.
-# All five are safe to retry with exponential backoff.
+# All four are safe to retry with exponential backoff.
 _RETRYABLE_STATUS_CODES = {429, 502, 503, 504}
 _RETRY_AFTER_MAX_SECONDS = 60.0
+
+# httpx disables timeouts entirely when one is passed explicitly as `None`, so every
+# request must resolve to a real Timeout or to USE_CLIENT_DEFAULT. Without this a
+# stalled upload holds its worker thread open indefinitely instead of failing fast
+# enough for the retry below to reach a healthy connection.
+_DEFAULT_TIMEOUT = Timeout(connect=15.0, read=120.0, write=120.0, pool=60.0)
+
+# ReadError and WriteError are the NetworkError siblings of ConnectError: a local
+# firewall or TLS-inspecting proxy aborting a live request surfaces as one of those
+# rather than as a timeout. Retrying them carries the same caveat already accepted
+# for ReadTimeout — the server may have received the request.
+_RETRYABLE_TRANSPORT_ERRORS = (
+    ReadError,
+    WriteError,
+    RemoteProtocolError,
+    TimeoutException,
+)
+
+# One summary line per interval instead of one line per retried request.
+_RETRY_SUMMARY_INTERVAL = 30.0
 
 
 def _backoff_delay(attempt: int) -> float:
@@ -35,6 +65,60 @@ def _backoff_delay(attempt: int) -> float:
     ceiling = min(_TRANSIENT_RETRY_BASE_DELAY * (2 ** attempt), _TRANSIENT_RETRY_MAX_DELAY)
     half = ceiling / 2
     return half + random.uniform(0, half)
+
+
+class _RetryNoiseThrottle:
+    """Collapses per-attempt retry logs into a periodic summary.
+
+    A saturated or filtered uplink fails hundreds of concurrent requests at once.
+    Logging every attempt at WARNING buries the failures that never recovered
+    under thousands of lines about ones that did, so attempts are counted here
+    and reported at most once per interval.
+    """
+
+    def __init__(self, interval: float = _RETRY_SUMMARY_INTERVAL) -> None:
+        self._interval = interval
+        self._lock = threading.Lock()
+        self._counts: Dict[str, int] = {}
+        self._next_report = 0.0
+
+    def record(self, reason: str) -> None:
+        """Count one retried request, emitting a summary when the interval is up."""
+        with self._lock:
+            self._counts[reason] = self._counts.get(reason, 0) + 1
+            now = time.monotonic()
+            if now < self._next_report:
+                return
+
+            is_first = self._next_report == 0.0
+            self._next_report = now + self._interval
+            total = sum(self._counts.values())
+            breakdown = ", ".join(
+                f"{reason} x{count}"
+                for reason, count in sorted(
+                    self._counts.items(), key=lambda item: -item[1]
+                )
+            )
+            self._counts.clear()
+
+        if is_first:
+            _logger.warning(
+                "Transient network error (%s); retrying automatically. Further retries "
+                "are summarised every %.0fs — only unrecoverable failures are logged as "
+                "errors. Enable DEBUG logging to see each attempt.",
+                breakdown,
+                self._interval,
+            )
+        else:
+            _logger.warning(
+                "Retried %d request(s) after transient errors in the last %.0fs (%s).",
+                total,
+                self._interval,
+                breakdown,
+            )
+
+
+_retry_noise = _RetryNoiseThrottle()
 
 
 class RESTResponse(io.IOBase):
@@ -234,11 +318,12 @@ class RESTClientObject:
                 delay = self._retry_after_from_response(r)
                 if delay is None:
                     delay = _backoff_delay(attempt)
-                _logger.warning(
+                _logger.debug(
                     "Server error on %s %s (attempt %d/%d): %d. Retrying in %.1fs...",
                     method, url, attempt + 1, _TRANSIENT_RETRY_MAX_ATTEMPTS + 1,
                     r.status_code, delay,
                 )
+                _retry_noise.record(f"HTTP {r.status_code}")
                 time.sleep(delay)
                 continue
 
@@ -329,15 +414,19 @@ class RESTClientObject:
 
     @staticmethod
     def _build_timeout(_request_timeout):
-        """Build a Timeout object from the request timeout parameter."""
+        """Build a Timeout object from the request timeout parameter.
+
+        Falls back to USE_CLIENT_DEFAULT rather than None, because httpx reads an
+        explicit None as "wait forever" instead of "use the client's default".
+        """
         if not _request_timeout:
-            return None
+            return USE_CLIENT_DEFAULT
         if isinstance(_request_timeout, (int, float)):
             return Timeout(timeout=_request_timeout)
         if isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
             connect_timeout, read_timeout = _request_timeout
             return Timeout(timeout=connect_timeout, read=read_timeout)
-        return None
+        return USE_CLIENT_DEFAULT
 
     def _handle_http_error(self, error, method, url, attempt):
         """Handle HTTP errors, retrying transient failures with exponential backoff.
@@ -353,11 +442,12 @@ class RESTClientObject:
 
         if self._is_retryable_error(error) and attempt < _TRANSIENT_RETRY_MAX_ATTEMPTS:
             delay = _backoff_delay(attempt)
-            _logger.warning(
+            _logger.debug(
                 "Transient network error on %s %s (attempt %d/%d): %s. Retrying in %.1fs...",
                 method, url, attempt + 1, _TRANSIENT_RETRY_MAX_ATTEMPTS + 1,
                 type(error).__name__, delay,
             )
+            _retry_noise.record(type(error).__name__)
             time.sleep(delay)
             return
 
@@ -375,6 +465,7 @@ class RESTClientObject:
                 else self.configuration.verify_ssl
             ),
             "limits": limits,
+            "timeout": _DEFAULT_TIMEOUT,
         }
 
         if self.configuration.proxy:
@@ -401,7 +492,7 @@ class RESTClientObject:
             if RESTClientObject._is_certificate_validation_error(error):
                 return False
             return True
-        return isinstance(error, (RemoteProtocolError, ConnectTimeout, ReadTimeout))
+        return isinstance(error, _RETRYABLE_TRANSPORT_ERRORS)
 
     @staticmethod
     def _is_certificate_validation_error(error: ConnectError) -> bool:

--- a/src/rapidata/api_client/rest.py
+++ b/src/rapidata/api_client/rest.py
@@ -15,12 +15,22 @@ import json
 import logging
 import random
 import re
+import threading
 import time
 from typing import Dict, Optional
 
 import httpx
 from authlib.integrations.httpx_client import OAuth2Client
-from httpx import Timeout, ConnectError, Limits, RemoteProtocolError, ConnectTimeout, ReadTimeout
+from httpx import (
+    USE_CLIENT_DEFAULT,
+    ConnectError,
+    Limits,
+    ReadError,
+    RemoteProtocolError,
+    Timeout,
+    TimeoutException,
+    WriteError,
+)
 
 from rapidata.api_client.exceptions import ApiException, ApiValueError
 
@@ -29,9 +39,29 @@ _TRANSIENT_RETRY_MAX_ATTEMPTS = 3
 _TRANSIENT_RETRY_BASE_DELAY = 0.5
 _TRANSIENT_RETRY_MAX_DELAY = 30.0
 # 429 = rate limit, 502/503/504 = transient upstream / gateway errors.
-# All five are safe to retry with exponential backoff.
+# All four are safe to retry with exponential backoff.
 _RETRYABLE_STATUS_CODES = {429, 502, 503, 504}
 _RETRY_AFTER_MAX_SECONDS = 60.0
+
+# httpx disables timeouts entirely when one is passed explicitly as `None`, so every
+# request must resolve to a real Timeout or to USE_CLIENT_DEFAULT. Without this a
+# stalled upload holds its worker thread open indefinitely instead of failing fast
+# enough for the retry below to reach a healthy connection.
+_DEFAULT_TIMEOUT = Timeout(connect=15.0, read=120.0, write=120.0, pool=60.0)
+
+# ReadError and WriteError are the NetworkError siblings of ConnectError: a local
+# firewall or TLS-inspecting proxy aborting a live request surfaces as one of those
+# rather than as a timeout. Retrying them carries the same caveat already accepted
+# for ReadTimeout — the server may have received the request.
+_RETRYABLE_TRANSPORT_ERRORS = (
+    ReadError,
+    WriteError,
+    RemoteProtocolError,
+    TimeoutException,
+)
+
+# One summary line per interval instead of one line per retried request.
+_RETRY_SUMMARY_INTERVAL = 30.0
 
 
 def _backoff_delay(attempt: int) -> float:
@@ -44,6 +74,60 @@ def _backoff_delay(attempt: int) -> float:
     ceiling = min(_TRANSIENT_RETRY_BASE_DELAY * (2 ** attempt), _TRANSIENT_RETRY_MAX_DELAY)
     half = ceiling / 2
     return half + random.uniform(0, half)
+
+
+class _RetryNoiseThrottle:
+    """Collapses per-attempt retry logs into a periodic summary.
+
+    A saturated or filtered uplink fails hundreds of concurrent requests at once.
+    Logging every attempt at WARNING buries the failures that never recovered
+    under thousands of lines about ones that did, so attempts are counted here
+    and reported at most once per interval.
+    """
+
+    def __init__(self, interval: float = _RETRY_SUMMARY_INTERVAL) -> None:
+        self._interval = interval
+        self._lock = threading.Lock()
+        self._counts: Dict[str, int] = {}
+        self._next_report = 0.0
+
+    def record(self, reason: str) -> None:
+        """Count one retried request, emitting a summary when the interval is up."""
+        with self._lock:
+            self._counts[reason] = self._counts.get(reason, 0) + 1
+            now = time.monotonic()
+            if now < self._next_report:
+                return
+
+            is_first = self._next_report == 0.0
+            self._next_report = now + self._interval
+            total = sum(self._counts.values())
+            breakdown = ", ".join(
+                f"{reason} x{count}"
+                for reason, count in sorted(
+                    self._counts.items(), key=lambda item: -item[1]
+                )
+            )
+            self._counts.clear()
+
+        if is_first:
+            _logger.warning(
+                "Transient network error (%s); retrying automatically. Further retries "
+                "are summarised every %.0fs — only unrecoverable failures are logged as "
+                "errors. Enable DEBUG logging to see each attempt.",
+                breakdown,
+                self._interval,
+            )
+        else:
+            _logger.warning(
+                "Retried %d request(s) after transient errors in the last %.0fs (%s).",
+                total,
+                self._interval,
+                breakdown,
+            )
+
+
+_retry_noise = _RetryNoiseThrottle()
 
 
 class RESTResponse(io.IOBase):
@@ -243,11 +327,12 @@ class RESTClientObject:
                 delay = self._retry_after_from_response(r)
                 if delay is None:
                     delay = _backoff_delay(attempt)
-                _logger.warning(
+                _logger.debug(
                     "Server error on %s %s (attempt %d/%d): %d. Retrying in %.1fs...",
                     method, url, attempt + 1, _TRANSIENT_RETRY_MAX_ATTEMPTS + 1,
                     r.status_code, delay,
                 )
+                _retry_noise.record(f"HTTP {r.status_code}")
                 time.sleep(delay)
                 continue
 
@@ -338,15 +423,19 @@ class RESTClientObject:
 
     @staticmethod
     def _build_timeout(_request_timeout):
-        """Build a Timeout object from the request timeout parameter."""
+        """Build a Timeout object from the request timeout parameter.
+
+        Falls back to USE_CLIENT_DEFAULT rather than None, because httpx reads an
+        explicit None as "wait forever" instead of "use the client's default".
+        """
         if not _request_timeout:
-            return None
+            return USE_CLIENT_DEFAULT
         if isinstance(_request_timeout, (int, float)):
             return Timeout(timeout=_request_timeout)
         if isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
             connect_timeout, read_timeout = _request_timeout
             return Timeout(timeout=connect_timeout, read=read_timeout)
-        return None
+        return USE_CLIENT_DEFAULT
 
     def _handle_http_error(self, error, method, url, attempt):
         """Handle HTTP errors, retrying transient failures with exponential backoff.
@@ -362,11 +451,12 @@ class RESTClientObject:
 
         if self._is_retryable_error(error) and attempt < _TRANSIENT_RETRY_MAX_ATTEMPTS:
             delay = _backoff_delay(attempt)
-            _logger.warning(
+            _logger.debug(
                 "Transient network error on %s %s (attempt %d/%d): %s. Retrying in %.1fs...",
                 method, url, attempt + 1, _TRANSIENT_RETRY_MAX_ATTEMPTS + 1,
                 type(error).__name__, delay,
             )
+            _retry_noise.record(type(error).__name__)
             time.sleep(delay)
             return
 
@@ -384,6 +474,7 @@ class RESTClientObject:
                 else self.configuration.verify_ssl
             ),
             "limits": limits,
+            "timeout": _DEFAULT_TIMEOUT,
         }
 
         if self.configuration.proxy:
@@ -410,7 +501,7 @@ class RESTClientObject:
             if RESTClientObject._is_certificate_validation_error(error):
                 return False
             return True
-        return isinstance(error, (RemoteProtocolError, ConnectTimeout, ReadTimeout))
+        return isinstance(error, _RETRYABLE_TRANSPORT_ERRORS)
 
     @staticmethod
     def _is_certificate_validation_error(error: ConnectError) -> bool:

--- a/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
+++ b/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
@@ -101,9 +101,9 @@ class BenchmarkPromptUploader:
                 self.upload(prompt)
             except Exception as e:
                 failures[prompt.identifier] = e
-                logger.error(
-                    "Failed to upload prompt %s: %s", prompt.identifier, str(e)
-                )
+                # The post-batch summary below reports every failed identifier, so an
+                # error per prompt only duplicates it once a whole batch goes bad.
+                logger.info("Failed to upload prompt %s: %s", prompt.identifier, str(e))
             finally:
                 otel_context.detach(token)
 

--- a/src/rapidata/rapidata_client/benchmark/participant/participant.py
+++ b/src/rapidata/rapidata_client/benchmark/participant/participant.py
@@ -239,7 +239,9 @@ class BenchmarkParticipant:
                     )
                     time.sleep(retry_delay)
 
-        logger.error(f"Upload failed for {identifier}. Error: {str(last_exception)}")
+        # Not the last word on this sample: callers sweep with `retry_missing` and then
+        # report whatever is still short, so an error here double-counts recoveries.
+        logger.info("Upload failed for %s. Error: %s", identifier, last_exception)
         return FailedUpload.from_exception(
             SampleUpload(media=asset, identifier=identifier), last_exception
         )

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -39,6 +39,10 @@ if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
 
 
+# A batch-wide failure would otherwise print one full error block per sample.
+_MAX_REPORTED_FAILURES = 5
+
+
 class RapidataBenchmark:
     """
     An instance of a Rapidata benchmark.
@@ -892,8 +896,13 @@ class RapidataBenchmark:
                 )
 
                 if failed_uploads:
-                    for failure in failed_uploads:
+                    for failure in failed_uploads[:_MAX_REPORTED_FAILURES]:
                         logger.error(failure.format_error_details())
+                    if len(failed_uploads) > _MAX_REPORTED_FAILURES:
+                        logger.error(
+                            "... and %s more failed upload(s). Enable INFO logging to see each one.",
+                            len(failed_uploads) - _MAX_REPORTED_FAILURES,
+                        )
                     logger.warning(
                         "Some uploads failed. The model evaluation may be incomplete. "
                         "Call `participant.retry_missing(media, identifiers)` to try "

--- a/tests/api_client/test_rest_retry.py
+++ b/tests/api_client/test_rest_retry.py
@@ -1,0 +1,115 @@
+"""Tests for the REST client's timeout resolution and transient-error retries.
+
+Both behaviours here were the cause of long upload stalls that surfaced to users
+as unexplained connection errors: httpx treats an explicit ``timeout=None`` as
+"wait forever", and the retry predicate only covered part of the transport-error
+family, so an aborted upload was never retried.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from httpx import USE_CLIENT_DEFAULT
+
+from rapidata.api_client.rest import RESTClientObject, _RetryNoiseThrottle
+
+
+class _Configuration:
+    """The subset of ``Configuration`` that ``_get_session_defaults`` reads."""
+
+    ssl_ca_cert = None
+    verify_ssl = True
+    proxy = None
+    proxy_headers = None
+    retries = None
+
+
+def _rest_client() -> RESTClientObject:
+    client = RESTClientObject.__new__(RESTClientObject)
+    client.configuration = _Configuration()  # type: ignore[attr-defined]
+    return client
+
+
+class TestBuildTimeout:
+    def test_unset_timeout_defers_to_client_default(self):
+        """A bare None would disable timeouts entirely rather than inherit them."""
+        assert RESTClientObject._build_timeout(None) is USE_CLIENT_DEFAULT
+
+    def test_malformed_timeout_defers_to_client_default(self):
+        assert RESTClientObject._build_timeout(("only-one",)) is USE_CLIENT_DEFAULT
+
+    def test_single_number_applies_to_every_phase(self):
+        assert RESTClientObject._build_timeout(5) == httpx.Timeout(5)
+
+    def test_pair_splits_connect_and_read(self):
+        timeout = RESTClientObject._build_timeout((3, 30))
+        assert timeout.connect == 3
+        assert timeout.read == 30
+
+
+class TestSessionDefaults:
+    def test_client_is_given_a_bounded_timeout(self):
+        defaults = _rest_client()._get_session_defaults()
+        timeout = defaults["timeout"]
+        assert None not in (
+            timeout.connect,
+            timeout.read,
+            timeout.write,
+            timeout.pool,
+        ), "every phase needs a bound, or a stalled request hangs forever"
+
+
+class TestRetryableErrors:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            httpx.ReadError("aborted by local software"),
+            httpx.WriteError("aborted mid-upload"),
+            httpx.PoolTimeout("no free connection"),
+            httpx.ConnectTimeout("no response"),
+            httpx.ReadTimeout("no response"),
+            httpx.RemoteProtocolError("server disconnected"),
+            httpx.ConnectError("connection refused"),
+        ],
+    )
+    def test_transient_transport_errors_are_retried(self, error):
+        assert RESTClientObject._is_retryable_error(error) is True
+
+    def test_certificate_failure_is_not_retried(self):
+        error = httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] unable to verify")
+        assert RESTClientObject._is_retryable_error(error) is False
+
+    def test_unrelated_error_is_not_retried(self):
+        assert (
+            RESTClientObject._is_retryable_error(httpx.UnsupportedProtocol("nope"))
+            is False
+        )
+
+
+class TestRetryNoiseThrottle:
+    def test_first_retry_warns_once_then_stays_quiet(self, caplog):
+        """One line tells the user retries are happening; the rest would be spam."""
+        throttle = _RetryNoiseThrottle(interval=3600.0)
+
+        with caplog.at_level(logging.WARNING, logger="rapidata.api_client"):
+            for _ in range(500):
+                throttle.record("ReadError")
+
+        assert len(caplog.records) == 1
+        assert "ReadError" in caplog.records[0].message
+
+    def test_summary_covers_the_interval_that_elapsed(self, caplog):
+        throttle = _RetryNoiseThrottle(interval=0.0)
+
+        with caplog.at_level(logging.WARNING, logger="rapidata.api_client"):
+            throttle.record("ReadError")  # first occurrence
+            throttle.record("ReadError")
+            throttle.record("HTTP 429")
+
+        # The counters reset each time they are reported, so the totals across the
+        # summaries account for every recorded retry exactly once.
+        assert len(caplog.records) == 3
+        assert "HTTP 429" in caplog.records[-1].message


### PR DESCRIPTION
## Why

Recurring reports of "connection errors" during benchmark participant uploads, most recently adding **Grok Image Imagine 2.0 (Thinking)** to `bmk_1Pet6iHzbf6RQu` — on a healthy connection.

The server was not at fault. During that upload window `Rapidata.Asset.API` logged **zero** errors and every `POST /participant/{id}/sample` that arrived returned 200. All the failures were client-side transport errors (`ReadError [WinError 10053]`, `ConnectTimeout [WinError 10060]`), and two REST-client defects turned a brief local hiccup into a stalled run buried in warnings.

## What was wrong

**1. Timeouts were never applied.** `_build_timeout` returned `None` when no `_request_timeout` was passed — the default for every generated call — and httpx treats an explicit `None` as *no timeout*, not *use the client default*. Only omitting the argument inherits the default:

```
omit timeout kwarg       -> raised ReadTimeout after 2.0s
explicit timeout=None    -> still hanging when killed at 20s
```

Effect in traces: single upload requests hanging **87s, 290s and 314s**, each pinning one of the 25 upload worker threads.

**2. `ReadError` was never retried.** `_is_retryable_error` covered `ConnectError`, `RemoteProtocolError`, `ConnectTimeout` and `ReadTimeout`. But `ReadError`/`WriteError` are the `NetworkError` siblings of `ConnectError` — a local firewall or TLS-inspecting proxy aborting a live request surfaces as one of those, not as a timeout. `ReadError` was **98 of ~100** failures on one run and skipped the transport retry entirely.

**3. Retry logging was per-attempt at WARNING.** The default log level *is* WARNING, so every retried attempt printed a line — across thousands of concurrent requests, the failures that never recovered were buried under the ones that did.

## What changed

| | Before | After |
|---|---|---|
| Unset request timeout | `None` → wait forever | `USE_CLIENT_DEFAULT` → `connect=15s read=120s write=120s pool=60s` |
| `ReadError` / `WriteError` / `PoolTimeout` | not retried | retried |
| Per-attempt retry log | one WARNING each | DEBUG + one throttled WARNING per 30s with a per-reason breakdown |
| Per-sample upload failure | ERROR (even when the sweep recovered it) | INFO — the post-sweep summary stays authoritative |
| Batch failure report | one error block per failed sample | first 5 + `... and N more` |

Retrying `ReadError`/`WriteError` means the server may already have received the request — the same caveat `ReadTimeout` retries already accept, so this widens no risk class. The sample endpoint is idempotent in effect (the backend rejects a duplicate with 409, which the SDK treats as success).

`rest.py` is generated, so `openapi/templates/rest.mustache` carries the identical change (verified in sync).

## Verification

- 16 new tests in `tests/api_client/test_rest_retry.py` — timeout resolution, the retryable-error matrix, and the throttle's suppression behaviour.
- End-to-end against a socket that accepts and never replies: the real `_get_session_defaults()` + `_build_timeout(None)` composition now raises `ReadTimeout` and classifies it retryable, where it previously hung indefinitely.
- `pyright src/rapidata/rapidata_client` → 0 errors. `black` applied.
- Full suite: 102 passed. The 4 failures in `tests/rapidata_client/audience/` **pre-exist on the base branch** (verified by stashing) and are untouched by this change.

## Follow-up, not in this PR

`upload.maxWorkers` defaults to 25, which is what makes a filtering middlebox abort connections in the first place. Lowering the default is a behaviour change for every user, so it is worth deciding separately.

---
🔗 Session: [session-5ba57819](https://poseidon.rapidata.internal/chat/session-5ba57819)