### PR TITLE
test(telemetry): disable OTLP export during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest configuration shared by the whole test suite.
+
+The SDK ships OTLP tracing on by default, and `rapidata_config` reads
+`RAPIDATA_DISABLE_OTLP` once at import time. Without this, every test run
+exports spans to the production collector: the suite drives the SDK with
+`MagicMock` arguments, so the resulting validation failures land in prod
+telemetry as real errors from `Rapidata.Python.SDK` and drown out genuine
+customer failures.
+
+Setting the env var before `rapidata` is imported is what actually disables
+tracing; the explicit config assignment below is a safety net in case something
+imported the package during collection first.
+"""
+
+import os
+
+os.environ["RAPIDATA_DISABLE_OTLP"] = "1"
+
+from rapidata.rapidata_client.config import rapidata_config  # noqa: E402
+
+rapidata_config.logging.enable_otlp = False


### PR DESCRIPTION
Found while sweeping the last 24h of failing traces in `otel.otel_traces`.

## The problem

**101 of the 310 `Rapidata.Python.SDK` error spans in the last 24h — a third of the service's entire error volume — are this repo's own test suite reporting to the production collector.**

They are unmistakable once you look at the `StatusMessage`:

```
ValidationError: 1 validation error for CreateAudienceEndpointInput
name  Input should be a valid string
  [type=string_type, input_value=<MagicMock id='139333307065664'>, input_type=MagicMock]
```

```
TypeError: Asset must be a string, got MagicMock
TypeError: '>=' not supported between instances of 'int' and 'MagicMock'
```

Spread across ~15 distinct span names (`RapidataAudience.assign_job`, `RapidataAudience.add_locate_example`, `ContextManager.shorten_contexts`, `BenchmarkParticipant._uploaded_identifier_counts`, …), arriving in bursts that match local `pytest` runs, from SDK versions `3.19.2`/`3.19.3` with developer-machine `system.os` attributes.

This is pure noise, and it is actively harmful: it sits in the same service as real customer errors (403s, upload `ReadError`s, `get_results` timeouts) and makes that signal much harder to read.

## Why it happens

`LoggingConfig.enable_otlp` defaults to on, and `rapidata_config = RapidataConfig()` resolves `RAPIDATA_DISABLE_OTLP` **once at module import time**. The repo has no `conftest.py`, so nothing ever turns it off for tests.

## The fix

A root `tests/conftest.py` that sets the existing `RAPIDATA_DISABLE_OTLP` env var before `rapidata` is imported. Pytest imports `conftest.py` ahead of test modules, so the flag is in place by the time the config singleton is built. The explicit `rapidata_config.logging.enable_otlp = False` afterwards is a safety net for the case where something imported the package during collection first.

No product code changes — this only affects test runs.

## Verification

```
enable_otlp: False
tracer._enabled: False
span type: NoOpSpan
otlp_initialized after span: False
```

The exporter is never even constructed, so there is no connection attempt and no export timeout to wait on.

Test outcomes are unchanged: **102 passed** both with and without this file. The 4 failures in `tests/rapidata_client/audience/` (`test_assign_job_warns_on_cost_warning` and friends) are **pre-existing** — they fail identically on a clean checkout — and are deliberately left untouched here.

## Follow-up worth considering

There is no `pytest` job in `.github/workflows/`, which is why these spans come from laptops rather than CI. Adding one (with this conftest in place) would be a separate PR.

🔗 Session: https://poseidon.rapidata.internal/chat/node-8a3e4f464c74

🤖 Generated with [Claude Code](https://claude.com/claude-code)