### PR TITLE
ci(release): dispatch cross-repo rebuilds with a GitHub App token

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -172,24 +172,37 @@ jobs:
           dist/*.whl
           dist/*.tar.gz
 
+    # A repository_dispatch needs Contents:write on the *target* repo, so a single
+    # token has to cover every repo the release notifies. The GitHub App grants that
+    # per run; a repo-scoped PAT silently covers only the repos it was cut for.
+    - name: Create cross-repo dispatch token
+      id: dispatch_token
+      if: steps.release_type.outputs.type == 'stable'
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ vars.RAPIDATA_OPENAPI_GENERATOR_APP_ID }}
+        private-key: ${{ secrets.RAPIDATA_OPENAPI_GENERATOR_PRIVATE_KEY }}
+        owner: RapidataAI
+        repositories: "skills,rapidata-mcp"
+        permission-contents: write
+
     - name: Trigger skills plugin version sync
       if: steps.release_type.outputs.type == 'stable'
       uses: peter-evans/repository-dispatch@v3
       with:
-        token: ${{ secrets.SKILLS_REPO_PAT }}
-        repository: rapidataAI/skills
+        token: ${{ steps.dispatch_token.outputs.token }}
+        repository: RapidataAI/skills
         event-type: sdk-release
         client-payload: '{"version": "${{ steps.update_version.outputs.new_version }}"}'
 
     # The hosted MCP server wraps this SDK but resolves it at image build time, so
     # without a rebuild it keeps serving whatever version was current when that repo
-    # last changed — it had drifted to 3.15.3 while 3.19.2 was released. Hand it the
-    # version just published so it pins exactly this release.
+    # last changed. Hand it the version just published so it pins exactly this release.
     - name: Trigger rapidata-mcp image rebuild
       if: steps.release_type.outputs.type == 'stable'
       uses: peter-evans/repository-dispatch@v3
       with:
-        token: ${{ secrets.SKILLS_REPO_PAT }}
+        token: ${{ steps.dispatch_token.outputs.token }}
         repository: RapidataAI/rapidata-mcp
         event-type: sdk-released
         client-payload: '{"sdk_version": "${{ steps.update_version.outputs.new_version }}"}'


### PR DESCRIPTION
## What was failing

`Release and Publish` has gone red on every stable release since the `rapidata-mcp` rebuild step was added ([#747](https://github.com/RapidataAI/rapidata-python-sdk/pull/747)) — the last two runs, and the two before that never fired it at all:

```
Trigger rapidata-mcp image rebuild
##[error]Resource not accessible by personal access token
```

Both cross-repo dispatch steps authenticate with `SKILLS_REPO_PAT`, a fine-grained PAT cut for `rapidataAI/skills` only. `POST /repos/{owner}/{repo}/dispatches` needs **Contents: write on the target repo**, so the `skills` step passes and the `rapidata-mcp` step 403s.

The failure lands *after* build, publish, tag and GitHub Release, so it never blocked a release — 3.19.4 is on PyPI. What it did break is the thing that step exists for: `rapidata-mcp` has not rebuilt since 2026-07-31, so the hosted MCP server has been resolving an SDK ~9 releases stale.

## Fix

Mint a short-lived installation token from the `RAPIDATA_OPENAPI_GENERATOR` GitHub App, scoped to exactly the two target repos with `permission-contents: write`, and use it for both dispatches. The app is installed org-wide, so notifying one more repo later is a one-word change here instead of re-issuing a PAT. `SKILLS_REPO_PAT` is now unused by this repo.

Also normalised `rapidataAI/skills` → `RapidataAI/skills` and dropped a stale incident detail from the step comment.

## Verification

Probed on a throwaway branch (workflow since deleted, nothing left on this branch):

| token | mint for `rapidata-mcp` | dispatch |
|---|---|---|
| `ARGOCD_APP_*` | ❌ app not installed on the repo | — |
| `RAPIDATA_OPENAPI_GENERATOR_*` | ✅ | ✅ 204 to **both** `rapidata-mcp` and `skills` |
| `SKILLS_REPO_PAT` | n/a | ❌ 403 on `rapidata-mcp` |

The dispatch probes used event type `poseidon-token-probe`, which no workflow listens for — confirmed no runs were triggered in either repo, so no image was built and nothing deployed.

## Follow-up (not in this PR)

`rapidata-mcp` prod is still pinned to the pre-drift image. The next stable SDK release will fix it automatically, or it can be rebuilt now via `workflow_dispatch` on [`build-image.yml`](https://github.com/RapidataAI/rapidata-mcp/actions/workflows/build-image.yml) with `rapidata_version` blank (= latest on PyPI). Say the word and I'll do it.

🔗 Session: [session-b776995e](https://poseidon.rapidata.internal/chat/session-b776995e)