### PR TITLE
fix(telemetry): stop reporting absorbed schema drift as errors

### DIFF
--- a/src/rapidata/api_client/lazy_model.py
+++ b/src/rapidata/api_client/lazy_model.py
@@ -101,7 +101,9 @@ class LazyValidatedModel(BaseModel):
             python_name = alias_to_field.get(key, key)
             construct_kwargs[python_name] = value
 
-        # --- observability: log error + fail the trace ---
+        # --- observability: log the drift, but leave the span status alone.
+        # The call still returns a usable model, so the failure (if any) happens
+        # at access time in __getattribute__ — that is where the span is failed.
         error_fields = list(field_errors.keys())
         logger.warning(
             "Validation failed for %s – mismatched fields: %s",
@@ -110,9 +112,7 @@ class LazyValidatedModel(BaseModel):
             exc_info=error,
         )
 
-        tracer.fail_current_span(
-            f"Validation failed for {cls.__name__}: {error_fields}"
-        )
+        tracer.record_schema_drift(cls.__name__, error_fields)
 
         # --- construct without validation ---
         instance = cls.model_construct(**construct_kwargs)

--- a/src/rapidata/rapidata_client/config/tracer.py
+++ b/src/rapidata/rapidata_client/config/tracer.py
@@ -13,6 +13,9 @@ from rapidata import __version__
 from .logging_config import LoggingConfig, register_config_handler
 from rapidata.rapidata_client.config import logger
 
+# Span event emitted when lazy validation absorbs a backend/SDK schema mismatch.
+SCHEMA_DRIFT_EVENT_NAME = "api.schema_drift"
+
 
 def get_system_attributes() -> dict[str, str | int | None]:
     """Gather system telemetry for traces."""
@@ -40,6 +43,7 @@ class TracerProtocol(Protocol):
     def set_session_id(self, session_id: str) -> None: ...
     def set_user_info(self, client_id: str, email: str) -> None: ...
     def fail_current_span(self, message: str | None = None) -> None: ...
+    def record_schema_drift(self, model_name: str, fields: list[str]) -> None: ...
 
 
 class NoOpSpan:
@@ -84,6 +88,9 @@ class NoOpTracer:
         pass
 
     def fail_current_span(self, message: str | None = None) -> None:
+        pass
+
+    def record_schema_drift(self, model_name: str, fields: list[str]) -> None:
         pass
 
     def __getattr__(self, name: str) -> Any:
@@ -233,6 +240,24 @@ class RapidataTracer:
         span = trace.get_current_span()
         if span.is_recording():
             span.set_status(Status(StatusCode.ERROR, message))
+
+    def record_schema_drift(self, model_name: str, fields: list[str]) -> None:
+        """Record that a backend response drifted from the model the SDK expects.
+
+        Deliberately an event and not an error status: lazy validation absorbs
+        the drift, so the call the customer made still succeeds. Failing the span
+        reports an outage that isn't one, and a single client on a stale SDK can
+        then outnumber every genuine error in the platform's telemetry.
+        """
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.add_event(
+                SCHEMA_DRIFT_EVENT_NAME,
+                {
+                    "api.schema_drift.model": model_name,
+                    "api.schema_drift.fields": fields,
+                },
+            )
 
     def __getattr__(self, name: str) -> Any:
         """Delegate attribute access to the appropriate tracer."""

--- a/tests/api_client/test_lazy_model_telemetry.py
+++ b/tests/api_client/test_lazy_model_telemetry.py
@@ -1,0 +1,85 @@
+"""Tests for how lazy validation reports backend/SDK schema drift to telemetry.
+
+Absorbed drift used to fail the enclosing span. That reported an outage that had
+not happened: the model is still constructed and the caller still gets its result,
+so the only client that a removed field actually breaks is one that reads it. A
+single customer on a stale SDK polling one endpoint was enough to make absorbed
+drift outnumber every genuine platform error, which is what these tests pin down —
+drift is an event, an access-time failure is an error.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+from pydantic import Field, ValidationError
+
+from rapidata.api_client.lazy_model import LazyValidatedModel
+
+
+class _Audience(LazyValidatedModel):
+    id: str
+    graduation_score: float = Field(alias="graduationScore")
+
+
+class _RecordingSpan:
+    """Minimal stand-in for an OTel span that records what it was told."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+        self.status: Optional[str] = None
+
+    def is_recording(self) -> bool:
+        return True
+
+    def add_event(self, name: str, attributes: Optional[dict] = None) -> None:
+        self.events.append((name, attributes or {}))
+
+    def set_status(self, status) -> None:
+        self.status = str(status)
+
+
+def _construct_with_drift() -> _Audience:
+    """Build the model from a payload missing the field the SDK still requires."""
+    try:
+        return _Audience.model_validate({"id": "aud_1"})
+    except ValidationError as error:
+        return _Audience._lazy_construct({"id": "aud_1"}, error)
+
+
+@pytest.fixture
+def recording_span(monkeypatch) -> _RecordingSpan:
+    span = _RecordingSpan()
+    # The tracer resolves get_current_span off the opentelemetry.trace module at
+    # call time; patching the module attribute is what reaches it, since
+    # `rapidata.rapidata_client.config.tracer` is the exported tracer instance
+    # rather than the submodule of the same name.
+    monkeypatch.setattr("opentelemetry.trace.get_current_span", lambda: span)
+    return span
+
+
+class TestAbsorbedDrift:
+    def test_drift_is_recorded_as_an_event(self, recording_span):
+        _construct_with_drift()
+
+        assert [name for name, _ in recording_span.events] == ["api.schema_drift"]
+        attributes = recording_span.events[0][1]
+        assert attributes["api.schema_drift.model"] == "_Audience"
+        assert attributes["api.schema_drift.fields"] == ["graduation_score"]
+
+    def test_drift_does_not_fail_the_span(self, recording_span):
+        _construct_with_drift()
+
+        assert recording_span.status is None
+
+    def test_unaffected_fields_stay_readable(self, recording_span):
+        assert _construct_with_drift().id == "aud_1"
+
+
+class TestAccessTimeFailure:
+    def test_reading_the_drifted_field_still_raises(self, recording_span):
+        model = _construct_with_drift()
+
+        with pytest.raises(TypeError, match="graduation_score"):
+            _ = model.graduation_score


### PR DESCRIPTION
## What

`LazyValidatedModel` absorbs backend/SDK schema drift on purpose — the model is still constructed and the call still returns, and only *reading* a drifted field raises. But `_lazy_construct` also called `tracer.fail_current_span(...)`, so every absorbed drift was reported as a failed operation.

This makes drift a span event (`api.schema_drift`) instead of an error status. The failure that does matter is unchanged.

## Why

Found while sweeping the last 24h of failing traces.

`GET /audience/{id}` replaced the flat `graduationScore` / `demotionScore` fields with the polymorphic `graduationRule` object on **2026-07-22**. SDKs older than v3.17.2 still declare `graduation_score` as required, so it is absorbed on every single call:

| SDK version | `get_audience_by_id` calls (24h) | Result |
|---|---|---|
| 3.19.x | 13 | all clean |
| ≤ 3.16.1 | 1121 | all flagged as errors |

One customer polling that endpoint produced **1121 error spans in a day — 58% of every error span across all Rapidata services**, and not one of them was a real failure. Over 30 days no caller has read `graduation_score`, so nothing broke; the errors were entirely an artefact of the reporting.

Genuine drift breakages still surface — `tags` on `GetPromptsByBenchmarkEndpointOutput` raised `TypeError` 9 times in 30 days for a real customer — and those were being buried under the false positives.

## What stays the same

- `logger.warning` on every drift.
- Reading a drifted field raises `TypeError` with the outdated-SDK hint.
- That escaping exception still sets the span to `ERROR` (OTel's `set_status_on_exception`), so real breakage is still an error.
- The strict `_t` discriminator path still re-raises.

## Querying drift after this change

```sql
SELECT toString(ResourceAttributes.service.version) v,
       arrayJoin(Events.Name) e, count()
FROM otel.otel_traces
WHERE ServiceName = 'Rapidata.Python.SDK'
  AND has(Events.Name, 'api.schema_drift')
  AND Timestamp > now() - INTERVAL 24 HOUR
GROUP BY v, e
```

## Follow-ups not in this PR

- The `graduationScore` and `tags` contract changes shipped with no compatibility window and no detection. A breaking-change gate on the OpenAPI diff in `update-openapi-client.yml` would have caught both.
- `derek@odyssey.systems` is getting `403 insufficient_access` on 69 of 72 `get_job_by_id` calls (OpenIddict ID2095 — a token-scope problem, not FGA). Their credentials likely need reissuing.

## Testing

- `tests/api_client/test_lazy_model_telemetry.py` — 4 new tests: drift emits the event, drift does not set span status, unaffected fields stay readable, reading the drifted field still raises.
- `uv run pytest tests/api_client` — 20 passed.
- `uv run pyright src/rapidata/rapidata_client` — 0 errors.
- Full suite: 136 passed, 4 pre-existing failures in `tests/rapidata_client/audience/` that also fail on unmodified `main` (unrelated to this change).

🔗 Session: https://poseidon.rapidata.internal/chat/node-974485f2d73d