### PR TITLE
fix(telemetry): record schema drift as span event, not span error

### DIFF
--- a/src/rapidata/api_client/lazy_model.py
+++ b/src/rapidata/api_client/lazy_model.py
@@ -2,9 +2,14 @@
 
 Replaces ``BaseModel`` as the parent of every generated model so that
 construction never raises on a type mismatch.  Instead, per-field
-validation errors are logged, recorded on the current OpenTelemetry
-span, and stored on the instance.  A ``TypeError`` is raised only when
-the caller actually *accesses* a field whose value failed validation.
+validation errors are logged, recorded as an event on the current
+OpenTelemetry span, and stored on the instance.  A ``TypeError`` is
+raised only when the caller actually *accesses* a field whose value
+failed validation.
+
+Drift that nobody reads is not a failure, so it is recorded as a span
+*event* and never as an error status — otherwise every caller on an
+older SDK reports a stream of failures for calls that succeeded.
 
 This means backend schema changes that affect unused fields no longer
 break SDK callers, while type-safety is preserved for fields that are
@@ -101,18 +106,24 @@ class LazyValidatedModel(BaseModel):
             python_name = alias_to_field.get(key, key)
             construct_kwargs[python_name] = value
 
-        # --- observability: log error + fail the trace ---
+        # --- observability: log the drift and record it on the trace ---
         error_fields = list(field_errors.keys())
+        # Imported lazily for the same reason as in __getattribute__ below: this
+        # base class is imported by every generated model.
+        from rapidata.rapidata_client.api.rapidata_api_client import (
+            format_outdated_sdk_note,
+        )
+
+        note = format_outdated_sdk_note()
         logger.warning(
-            "Validation failed for %s – mismatched fields: %s",
+            "Validation failed for %s – mismatched fields: %s%s",
             cls.__name__,
             error_fields,
+            f"\n{note}" if note else "",
             exc_info=error,
         )
 
-        tracer.fail_current_span(
-            f"Validation failed for {cls.__name__}: {error_fields}"
-        )
+        tracer.record_schema_drift(cls.__name__, error_fields)
 
         # --- construct without validation ---
         instance = cls.model_construct(**construct_kwargs)

--- a/src/rapidata/rapidata_client/config/tracer.py
+++ b/src/rapidata/rapidata_client/config/tracer.py
@@ -4,7 +4,6 @@ import platform
 import sys
 import os
 from opentelemetry import trace
-from opentelemetry.trace import Status, StatusCode
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -12,6 +11,8 @@ from opentelemetry.sdk.resources import Resource
 from rapidata import __version__
 from .logging_config import LoggingConfig, register_config_handler
 from rapidata.rapidata_client.config import logger
+
+SCHEMA_DRIFT_EVENT = "sdk.schema_drift"
 
 
 def get_system_attributes() -> dict[str, str | int | None]:
@@ -39,7 +40,7 @@ class TracerProtocol(Protocol):
     def start_as_current_span(self, name: str, *args, **kwargs) -> Any: ...
     def set_session_id(self, session_id: str) -> None: ...
     def set_user_info(self, client_id: str, email: str) -> None: ...
-    def fail_current_span(self, message: str | None = None) -> None: ...
+    def record_schema_drift(self, model_name: str, fields: list[str]) -> None: ...
 
 
 class NoOpSpan:
@@ -83,7 +84,7 @@ class NoOpTracer:
     def set_user_info(self, client_id: str, email: str) -> None:
         pass
 
-    def fail_current_span(self, message: str | None = None) -> None:
+    def record_schema_drift(self, model_name: str, fields: list[str]) -> None:
         pass
 
     def __getattr__(self, name: str) -> Any:
@@ -228,11 +229,23 @@ class RapidataTracer:
             f"User info set - client_id: {self.client_id}, email: {self.email}"
         )
 
-    def fail_current_span(self, message: str | None = None) -> None:
-        """Mark the current span as errored."""
+    def record_schema_drift(self, model_name: str, fields: list[str]) -> None:
+        """Record tolerated backend schema drift as an event on the current span.
+
+        Deliberately an event rather than an error status: the SDK absorbs the drift
+        and the call succeeds, so failing the span would report a user-visible failure
+        that never happened. Reading a drifted field raises TypeError, and that marks
+        the span errored through the normal exception path.
+        """
         span = trace.get_current_span()
         if span.is_recording():
-            span.set_status(Status(StatusCode.ERROR, message))
+            span.add_event(
+                SCHEMA_DRIFT_EVENT,
+                attributes={
+                    f"{SCHEMA_DRIFT_EVENT}.model": model_name,
+                    f"{SCHEMA_DRIFT_EVENT}.fields": fields,
+                },
+            )
 
     def __getattr__(self, name: str) -> Any:
         """Delegate attribute access to the appropriate tracer."""

--- a/tests/api_client/test_lazy_model.py
+++ b/tests/api_client/test_lazy_model.py
@@ -1,0 +1,76 @@
+"""Tests for LazyValidatedModel's handling of backend schema drift.
+
+The contract under test: drift the caller never reads is absorbed silently — the
+model still constructs and the span carries an event, not an error status. Only
+reading a drifted field is a failure.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+from pydantic import Field, StrictInt, StrictStr, ValidationError
+
+import rapidata.api_client.lazy_model as lazy_model_module
+from rapidata.api_client.lazy_model import LazyValidatedModel
+
+
+class _Audience(LazyValidatedModel):
+    id: StrictStr
+    graduation_score: float = Field(alias="graduationScore")
+
+
+class _Variant(LazyValidatedModel):
+    t: Optional[StrictStr] = Field(default=None, alias="_t")
+    size: StrictInt
+
+
+def _construct(cls, data: dict):
+    """Mimic the generated from_dict path: validate, fall back to lazy construct."""
+    try:
+        return cls.model_validate(data)
+    except ValidationError as error:
+        return cls._lazy_construct(data, error)
+
+
+@pytest.fixture
+def recorded_drift(monkeypatch):
+    calls: list[tuple[str, list[str]]] = []
+
+    class _Tracer:
+        def record_schema_drift(self, model_name: str, fields: list[str]) -> None:
+            calls.append((model_name, fields))
+
+    monkeypatch.setattr(lazy_model_module, "tracer", _Tracer())
+    return calls
+
+
+def test_missing_field_does_not_fail_the_span(recorded_drift):
+    model = _construct(_Audience, {"id": "aud-1"})
+
+    assert model.id == "aud-1"
+    assert recorded_drift == [("_Audience", ["graduation_score"])]
+
+
+def test_reading_a_drifted_field_raises(recorded_drift):
+    model = _construct(_Audience, {"id": "aud-1"})
+
+    with pytest.raises(TypeError, match="graduation_score"):
+        _ = model.graduation_score
+
+
+def test_clean_payload_records_nothing(recorded_drift):
+    model = _construct(_Audience, {"id": "aud-1", "graduationScore": 0.5})
+
+    assert model.graduation_score == 0.5
+    assert recorded_drift == []
+
+
+def test_discriminator_drift_still_raises(recorded_drift):
+    # A bad `_t` means oneOf/anyOf picked the wrong variant — a structural failure
+    # that lazy validation must not absorb.
+    with pytest.raises(ValidationError):
+        _construct(_Variant, {"_t": 7, "size": 1})
+
+    assert recorded_drift == []


### PR DESCRIPTION
## What

`LazyValidatedModel` exists so a backend field the caller never reads cannot break the call. It then called `tracer.fail_current_span()`, which set `StatusCode.ERROR` on the enclosing user-facing span — reporting a failure for a call that **succeeded**.

This PR records the drift as an `sdk.schema_drift` span **event** instead.

## Why now

Found while sweeping the last 24h of failing traces. The audience API replaced the top-level `graduationScore` with the polymorphic `graduationRule`, so every SDK older than that change fails validation on `GetAudienceByIdEndpointOutput`:

| | |
|---|---|
| Error spans, 24h | **1358**, all from one customer on SDK 3.16.1 |
| Error spans, 7d | **2491**, across SDK 3.11.9 / 3.12.1 / 3.13.0 / 3.16.1 |
| Normal SDK baseline | ~90–430 errors/day |
| Actual user impact | **none** — traced the customer's session end to end; `find_jobs`, `assign_job`, `create_compare_job` all succeed afterwards |

That is 6–10× error inflation from calls that returned successfully and whose callers never touched the field. It buried every genuine failure in the same window.

## What changed

- `record_schema_drift(model_name, fields)` replaces `fail_current_span` on the tracer. It emits an `sdk.schema_drift` event carrying the model and the drifted fields, so the signal stays queryable (`has(Events.Name, 'sdk.schema_drift')`) and alertable without claiming the operation failed.
- The genuine failure is unchanged: a caller that actually **reads** a drifted field still raises `TypeError`, which marks the span errored via the normal exception path.
- The warning log now appends the outdated-SDK note, so a customer stuck on an old client sees the actionable cause where the drift is first reported rather than only when a read blows up.
- `fail_current_span` had no other caller and is removed.
- Adds `tests/api_client/test_lazy_model.py` — the module had no test coverage. Covers: drift does not fail the span, reading a drifted field raises, a clean payload records nothing, and `_t` discriminator drift still re-raises.

## Verification

- `pytest tests/api_client/` — 20 passed
- `pyright src/rapidata/rapidata_client` — 0 errors
- `black` — formatted (unrelated reformats reverted; this branch touches only the 3 files above)
- Full suite: 136 passed, 4 failed — all 4 pre-existing on `main` (`test_assign_job_*`, an extra explicit-content warning), confirmed by stashing this diff

🔗 Session: [node-9773996c3f81](https://poseidon.rapidata.internal/chat/node-9773996c3f81)