### PR TITLE
feat(billing): add billing manager for the current billing period

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,0 +1,39 @@
+# Billing
+
+While [cost estimates](cost_estimates.md) tell you what a job is expected to cost *before* you run it, `client.billing` tells you what you have actually spent so far. Use it to check where the current period stands, or to guard a large run against running out of credit.
+
+## Reading the Current Period
+
+```py
+from rapidata import RapidataClient
+
+client = RapidataClient()
+
+period = client.billing.get_current_billing_period()
+
+print(f"{period.start_date:%Y-%m-%d} to {period.end_date:%Y-%m-%d}")
+print(f"Outstanding: ${period.outstanding_cost:.2f}")
+print(f"Credits left: {period.credits}") # (1)!
+```
+
+1. `credits` is `None` when your organization is billed for its usage rather than from a prepaid balance.
+
+## What the Period Contains
+
+| Field | Description |
+|---|---|
+| `id` | The billing period's id. |
+| `start_date` / `end_date` | When the period starts and ends. |
+| `status` | `Open` while the period is still accruing cost; `Invoiced`, `Void`, `Reconciling`, `PendingReview` or `Closed` afterwards. |
+| `outstanding_cost` | The net cost accrued so far — what the period would be invoiced for today. |
+| `gross_cost` | The cost accrued so far, before discounts. |
+| `discount` | The discounts applied to the period so far. |
+| `response_count` | The number of billable responses collected in the period. |
+| `credits` | The prepaid credit still available, or `None` on a usage-billed plan. |
+
+All amounts are in US dollars.
+
+!!! note
+    Billing is settled per **organization**, so these figures cover everything your organization spent in the period — not only the jobs this client created. Costs accrue while jobs run, so the values are a snapshot: fetch the period again for an up-to-date figure.
+
+A period only opens once there is something to bill. If your organization has never run a billable job, `get_current_billing_period()` raises a `RapidataError` with status `404` — see [Error Handling](error_handling.md).

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -12,11 +12,11 @@ client = RapidataClient()
 period = client.billing.get_current_billing_period()
 
 print(f"{period.start_date:%Y-%m-%d} to {period.end_date:%Y-%m-%d}")
-print(f"Outstanding: ${period.outstanding_cost:.2f}")
+print(f"Outstanding: ${period.outstanding_cost}")
 print(f"Credits left: {period.credits}") # (1)!
 ```
 
-1. `credits` is `None` when your organization is billed for its usage rather than from a prepaid balance.
+1. `credits` is `None` when your organization is billed for its usage rather than from a prepaid balance. On a prepaid plan, `credits` is what remains of `effective_limit`.
 
 ## What the Period Contains
 
@@ -30,8 +30,9 @@ print(f"Credits left: {period.credits}") # (1)!
 | `discount` | The discounts applied to the period so far. |
 | `response_count` | The number of billable responses collected in the period. |
 | `credits` | The prepaid credit still available, or `None` on a usage-billed plan. |
+| `effective_limit` | The most you may spend this period, or `None` when you spend without a cap. |
 
-All amounts are in US dollars.
+All amounts are in US dollars, rounded to the cent.
 
 !!! note
     Billing is settled per **organization**, so these figures cover everything your organization spent in the period — not only the jobs this client created. Costs accrue while jobs run, so the values are a snapshot: fetch the period again for an up-to-date figure.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ plugins:
           - error_handling.md
           - confidence_stopping.md
           - cost_estimates.md
+          - billing.md
           - job_progress.md
           - human_prompting.md
           - config.md
@@ -132,6 +133,7 @@ nav:
       - Understanding Results: understanding_the_results.md
       - Early Stopping: confidence_stopping.md
       - Cost Estimates: cost_estimates.md
+      - Billing: billing.md
       - Job Progress: job_progress.md
       - Instruction Design: human_prompting.md
       - Error Handling: error_handling.md

--- a/src/rapidata/__init__.py
+++ b/src/rapidata/__init__.py
@@ -16,6 +16,8 @@ from .rapidata_client import (
     JobProgress,
     RapidataSignal,
     RapidataSignalManager,
+    BillingPeriod,
+    RapidataBillingManager,
     ValidationSetManager,
     RapidataValidationSet,
     Box,

--- a/src/rapidata/rapidata_client/__init__.py
+++ b/src/rapidata/rapidata_client/__init__.py
@@ -15,6 +15,7 @@ from .job import (
     JobProgress,
 )
 from .signal import RapidataSignal, RapidataSignalManager
+from .billing import BillingPeriod, RapidataBillingManager
 from .validation import ValidationSetManager, RapidataValidationSet, Box
 from .results import RapidataResults
 from .selection import (

--- a/src/rapidata/rapidata_client/billing/__init__.py
+++ b/src/rapidata/rapidata_client/billing/__init__.py
@@ -1,0 +1,4 @@
+from .billing_period import BillingPeriod
+from .rapidata_billing_manager import RapidataBillingManager
+
+__all__ = ["BillingPeriod", "RapidataBillingManager"]

--- a/src/rapidata/rapidata_client/billing/billing_period.py
+++ b/src/rapidata/rapidata_client/billing/billing_period.py
@@ -13,12 +13,23 @@ if TYPE_CHECKING:
     )
 
 
+def _to_cents(amount: float | int | None) -> float | None:
+    """Round a dollar amount to the cent the invoice will actually charge.
+
+    The backend accrues cost per response, so a raw total carries far more
+    decimals than money has — rounding here keeps the reported figures
+    printable without every caller doing it.
+    """
+    return None if amount is None else round(amount, 2)
+
+
 @dataclass(frozen=True)
 class BillingPeriod:
     """What the current billing period has cost so far, and what is left to spend.
 
-    All amounts are in US dollars. Costs accrue continuously while jobs run, so
-    this is a snapshot: fetch it again for an up-to-date figure.
+    All amounts are in US dollars, rounded to the cent. Costs accrue
+    continuously while jobs run, so this is a snapshot: fetch it again for an
+    up-to-date figure.
 
     Attributes:
         id: The billing period's id.
@@ -36,6 +47,10 @@ class BillingPeriod:
             organization is not on a prepaid plan (it is billed for its usage
             instead). Credits are an organization-level balance rather than a
             property of the period, so they carry across periods until used up.
+        effective_limit: The most the organization may spend in this period, or
+            ``None`` when it spends without a cap. Vouchers raise it, so on a
+            prepaid plan this is the total credit granted and ``credits`` is
+            what remains of it.
     """
 
     id: str
@@ -47,6 +62,7 @@ class BillingPeriod:
     discount: float
     response_count: int
     credits: float | None
+    effective_limit: float | None
 
     @classmethod
     def _from_models(
@@ -59,9 +75,10 @@ class BillingPeriod:
             start_date=overview.start_date,
             end_date=overview.end_date,
             status=overview.status.value,
-            outstanding_cost=overview.total_net_cost,
-            gross_cost=overview.total_gross_cost,
-            discount=overview.total_discount,
+            outstanding_cost=round(overview.total_net_cost, 2),
+            gross_cost=round(overview.total_gross_cost, 2),
+            discount=round(overview.total_discount, 2),
             response_count=overview.total_response_count,
-            credits=summary.available_amount,
+            credits=_to_cents(summary.available_amount),
+            effective_limit=_to_cents(summary.effective_limit),
         )

--- a/src/rapidata/rapidata_client/billing/billing_period.py
+++ b/src/rapidata/rapidata_client/billing/billing_period.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rapidata.api_client.models.get_active_billing_period_overview_endpoint_output import (
+        GetActiveBillingPeriodOverviewEndpointOutput,
+    )
+    from rapidata.api_client.models.get_billing_summary_endpoint_output import (
+        GetBillingSummaryEndpointOutput,
+    )
+
+
+@dataclass(frozen=True)
+class BillingPeriod:
+    """What the current billing period has cost so far, and what is left to spend.
+
+    All amounts are in US dollars. Costs accrue continuously while jobs run, so
+    this is a snapshot: fetch it again for an up-to-date figure.
+
+    Attributes:
+        id: The billing period's id.
+        start_date: When the billing period started.
+        end_date: When the billing period ends.
+        status: The period's lifecycle status — ``"Open"`` while it is still
+            accruing cost, and one of ``"Invoiced"``, ``"Void"``,
+            ``"Reconciling"``, ``"PendingReview"`` or ``"Closed"`` afterwards.
+        outstanding_cost: The net cost accrued so far — ``gross_cost`` minus
+            ``discount``. This is what the period would be invoiced for today.
+        gross_cost: The cost accrued so far, before any discounts.
+        discount: The discounts applied to the period so far.
+        response_count: The number of billable responses collected in the period.
+        credits: The prepaid credit still available to spend, or ``None`` when the
+            organization is not on a prepaid plan (it is billed for its usage
+            instead). Credits are an organization-level balance rather than a
+            property of the period, so they carry across periods until used up.
+    """
+
+    id: str
+    start_date: datetime
+    end_date: datetime
+    status: str
+    outstanding_cost: float
+    gross_cost: float
+    discount: float
+    response_count: int
+    credits: float | None
+
+    @classmethod
+    def _from_models(
+        cls,
+        overview: GetActiveBillingPeriodOverviewEndpointOutput,
+        summary: GetBillingSummaryEndpointOutput,
+    ) -> BillingPeriod:
+        return cls(
+            id=overview.id,
+            start_date=overview.start_date,
+            end_date=overview.end_date,
+            status=overview.status.value,
+            outstanding_cost=overview.total_net_cost,
+            gross_cost=overview.total_gross_cost,
+            discount=overview.total_discount,
+            response_count=overview.total_response_count,
+            credits=summary.available_amount,
+        )

--- a/src/rapidata/rapidata_client/billing/rapidata_billing_manager.py
+++ b/src/rapidata/rapidata_client/billing/rapidata_billing_manager.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rapidata.rapidata_client.billing.billing_period import BillingPeriod
+from rapidata.rapidata_client.config import logger, tracer
+
+if TYPE_CHECKING:
+    from rapidata.service.openapi_service import OpenAPIService
+
+
+class RapidataBillingManager:
+    """Read what the current billing period has cost and what credit is left.
+
+    Billing is settled per organization, so the figures cover everything the
+    organization spent, not only the jobs this client created.
+
+    Access this manager via :py:attr:`RapidataClient.billing`.
+    """
+
+    def __init__(self, openapi_service: OpenAPIService):
+        self._openapi_service = openapi_service
+        logger.debug("RapidataBillingManager initialized")
+
+    def get_current_billing_period(self) -> BillingPeriod:
+        """Get the billing period that is currently accruing cost.
+
+        Returns:
+            BillingPeriod: The current period, its outstanding cost and the
+                remaining prepaid credits.
+
+        Raises:
+            RapidataError: With status 404 if the organization has no active
+                billing period — a period only opens once there is something
+                to bill.
+        """
+        with tracer.start_as_current_span(
+            "RapidataBillingManager.get_current_billing_period"
+        ):
+            billing_api = self._openapi_service.payment.billing_api
+            # Credits live on the organization's billing account, not on the
+            # period, so they come from the summary rather than the overview.
+            summary = billing_api.billing_summary_get()
+            overview = billing_api.billing_period_active_get()
+            return BillingPeriod._from_models(overview, summary)

--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -40,6 +40,9 @@ from rapidata.rapidata_client.flow.rapidata_flow_manager import RapidataFlowMana
 from rapidata.rapidata_client.signal.rapidata_signal_manager import (
     RapidataSignalManager,
 )
+from rapidata.rapidata_client.billing.rapidata_billing_manager import (
+    RapidataBillingManager,
+)
 from rapidata.rapidata_client.api.rapidata_api_client import (
     optional_api_call,
     mark_sdk_outdated,
@@ -125,6 +128,9 @@ class RapidataClient:
                 recurring audience-job schedules (signals) and observing their runs.
             context (ContextManager): The ContextManager instance for shortening
                 datapoint contexts against a question.
+            billing (RapidataBillingManager): The RapidataBillingManager instance for
+                reading the current billing period, its outstanding cost and the
+                remaining credits.
         """
         tracer.set_session_id(
             uuid.UUID(int=random.Random().getrandbits(128), version=4).hex
@@ -200,6 +206,9 @@ class RapidataClient:
 
             logger.debug("Initializing ContextManager")
             self.context = ContextManager(openapi_service=self._openapi_service)
+
+            logger.debug("Initializing RapidataBillingManager")
+            self.billing = RapidataBillingManager(openapi_service=self._openapi_service)
 
         self._check_beta_features()  # can't be in the trace for some reason
 

--- a/src/rapidata/service/openapi_service.py
+++ b/src/rapidata/service/openapi_service.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from rapidata.service.services.rapid_service import RapidService
     from rapidata.service.services.signal_service import SignalService
     from rapidata.service.services.translation_service import TranslationService
+    from rapidata.service.services.payment_service import PaymentService
 
 
 class OpenAPIService:
@@ -81,6 +82,7 @@ class OpenAPIService:
         self._rapid: RapidService | None = None
         self._signal: SignalService | None = None
         self._translation: TranslationService | None = None
+        self._payment: PaymentService | None = None
 
         if token or token_file:
             if token is None:
@@ -236,6 +238,13 @@ class OpenAPIService:
             from rapidata.service.services.translation_service import TranslationService
             self._translation = TranslationService(self.api_client)
         return self._translation
+
+    @property
+    def payment(self) -> PaymentService:
+        if self._payment is None:
+            from rapidata.service.services.payment_service import PaymentService
+            self._payment = PaymentService(self.api_client)
+        return self._payment
 
     def _get_rapidata_package_version(self):
         """

--- a/src/rapidata/service/services/payment_service.py
+++ b/src/rapidata/service/services/payment_service.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rapidata.api_client.api.billing_api import BillingApi
+    from rapidata.rapidata_client.api.rapidata_api_client import RapidataApiClient
+
+
+class PaymentService:
+    def __init__(self, api_client: RapidataApiClient) -> None:
+        self._api_client = api_client
+        self._billing_api: BillingApi | None = None
+
+    @property
+    def billing_api(self) -> BillingApi:
+        if self._billing_api is None:
+            from rapidata.api_client.api.billing_api import BillingApi
+            self._billing_api = BillingApi(self._api_client)
+        return self._billing_api

--- a/tests/rapidata_client/billing/test_rapidata_billing_manager.py
+++ b/tests/rapidata_client/billing/test_rapidata_billing_manager.py
@@ -2,7 +2,7 @@
 
 The period overview and the billing summary are two separate endpoints, and the
 manager's job is to fold them into one object: costs come from the period,
-credits from the organization's billing account.
+credits and the spending cap from the organization's billing account.
 """
 
 from __future__ import annotations
@@ -20,27 +20,34 @@ START = datetime(2026, 8, 1, tzinfo=timezone.utc)
 END = datetime(2026, 9, 1, tzinfo=timezone.utc)
 
 
-def _manager(available_amount: float | None) -> RapidataBillingManager:
+def _manager(
+    available_amount: float | None = 42.5,
+    effective_limit: float | None = 500.0,
+    gross_cost: float = 100.0,
+    discount: float = 10.0,
+    net_cost: float = 90.0,
+) -> RapidataBillingManager:
     openapi_service = MagicMock()
     billing_api = openapi_service.payment.billing_api
     billing_api.billing_summary_get.return_value = MagicMock(
-        available_amount=available_amount
+        available_amount=available_amount,
+        effective_limit=effective_limit,
     )
     billing_api.billing_period_active_get.return_value = MagicMock(
         id="billing_period_id",
         start_date=START,
         end_date=END,
         status=MagicMock(value="Open"),
-        total_gross_cost=100.0,
-        total_discount=10.0,
-        total_net_cost=90.0,
+        total_gross_cost=gross_cost,
+        total_discount=discount,
+        total_net_cost=net_cost,
         total_response_count=1234,
     )
     return RapidataBillingManager(openapi_service=openapi_service)
 
 
 def test_get_current_billing_period_reports_costs_and_credits():
-    period = _manager(available_amount=42.5).get_current_billing_period()
+    period = _manager().get_current_billing_period()
 
     assert period.id == "billing_period_id"
     assert period.start_date == START
@@ -51,17 +58,40 @@ def test_get_current_billing_period_reports_costs_and_credits():
     assert period.outstanding_cost == 90.0
     assert period.response_count == 1234
     assert period.credits == 42.5
+    assert period.effective_limit == 500.0
 
 
-def test_credits_are_none_when_the_organization_is_not_prepaid():
-    """A usage-billed organization has no prepaid balance to report."""
-    assert _manager(available_amount=None).get_current_billing_period().credits is None
+def test_amounts_are_rounded_to_the_cent():
+    """Per-response accrual produces far more decimals than money has."""
+    period = _manager(
+        available_amount=7.129999999,
+        effective_limit=500.005,
+        gross_cost=100.123456,
+        discount=10.987654,
+        net_cost=89.135802,
+    ).get_current_billing_period()
+
+    assert period.gross_cost == 100.12
+    assert period.discount == 10.99
+    assert period.outstanding_cost == 89.14
+    assert period.credits == 7.13
+    assert period.effective_limit == 500.0
+
+
+def test_credits_and_limit_are_none_when_unset():
+    """A usage-billed organization has no prepaid balance and no cap."""
+    period = _manager(
+        available_amount=None, effective_limit=None
+    ).get_current_billing_period()
+
+    assert period.credits is None
+    assert period.effective_limit is None
 
 
 def test_api_errors_propagate():
     from rapidata.rapidata_client.exceptions import RapidataError
 
-    manager = _manager(available_amount=0.0)
+    manager = _manager()
     manager._openapi_service.payment.billing_api.billing_period_active_get.side_effect = RapidataError(
         status_code=404, message="No active billing period found"
     )

--- a/tests/rapidata_client/billing/test_rapidata_billing_manager.py
+++ b/tests/rapidata_client/billing/test_rapidata_billing_manager.py
@@ -1,0 +1,70 @@
+"""Tests for reading the current billing period.
+
+The period overview and the billing summary are two separate endpoints, and the
+manager's job is to fold them into one object: costs come from the period,
+credits from the organization's billing account.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from rapidata.rapidata_client.billing.rapidata_billing_manager import (
+    RapidataBillingManager,
+)
+
+START = datetime(2026, 8, 1, tzinfo=timezone.utc)
+END = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def _manager(available_amount: float | None) -> RapidataBillingManager:
+    openapi_service = MagicMock()
+    billing_api = openapi_service.payment.billing_api
+    billing_api.billing_summary_get.return_value = MagicMock(
+        available_amount=available_amount
+    )
+    billing_api.billing_period_active_get.return_value = MagicMock(
+        id="billing_period_id",
+        start_date=START,
+        end_date=END,
+        status=MagicMock(value="Open"),
+        total_gross_cost=100.0,
+        total_discount=10.0,
+        total_net_cost=90.0,
+        total_response_count=1234,
+    )
+    return RapidataBillingManager(openapi_service=openapi_service)
+
+
+def test_get_current_billing_period_reports_costs_and_credits():
+    period = _manager(available_amount=42.5).get_current_billing_period()
+
+    assert period.id == "billing_period_id"
+    assert period.start_date == START
+    assert period.end_date == END
+    assert period.status == "Open"
+    assert period.gross_cost == 100.0
+    assert period.discount == 10.0
+    assert period.outstanding_cost == 90.0
+    assert period.response_count == 1234
+    assert period.credits == 42.5
+
+
+def test_credits_are_none_when_the_organization_is_not_prepaid():
+    """A usage-billed organization has no prepaid balance to report."""
+    assert _manager(available_amount=None).get_current_billing_period().credits is None
+
+
+def test_api_errors_propagate():
+    from rapidata.rapidata_client.exceptions import RapidataError
+
+    manager = _manager(available_amount=0.0)
+    manager._openapi_service.payment.billing_api.billing_period_active_get.side_effect = RapidataError(
+        status_code=404, message="No active billing period found"
+    )
+
+    with pytest.raises(RapidataError):
+        manager.get_current_billing_period()


### PR DESCRIPTION
Adds a `billing` module to the SDK with a `RapidataBillingManager`, reachable as `client.billing`.

```py
period = client.billing.get_current_billing_period()

period.start_date, period.end_date   # the period's window
period.status                        # "Open" while it is still accruing
period.outstanding_cost              # net cost accrued so far, in USD
period.credits                       # remaining prepaid credit, or None
```

## What it returns

`BillingPeriod` is a frozen dataclass with `id`, `start_date`, `end_date`, `status`, `outstanding_cost`, `gross_cost`, `discount`, `response_count` and `credits`.

## Where the numbers come from

Two payment-service endpoints, folded into one object:

- `GET /billing-period/active` — the period, its dates/status, and its costs. `outstanding_cost` is the net cost (gross minus discounts), i.e. what the period would be invoiced for today.
- `GET /billing/summary` — `availableAmount`, the remaining prepaid balance. Credits sit on the organization's billing account rather than on the period, which is why they need the second call.

`availableAmount` is only populated when the organization is on a prepaid plan (`CreditLine == 0`), so `credits` is `None` on a usage-billed plan rather than a misleading `0`.

Both endpoints are `IsAuthenticated`-only for the caller's own organization, so no extra role is needed.

## Notes

- A billing period only opens once there is something to bill, so `get_current_billing_period()` raises the usual `RapidataError` (404, "No active billing period found") for an organization that has never run a billable job. Documented in the guide.
- Adds a `PaymentService` to the service layer (matching the existing per-backend-service grouping) — no manager reached the payment service before.
- New guide at `docs/billing.md`, linked from the nav and the llms.txt sections.
- 4 pre-existing test failures under `tests/rapidata_client/audience/` are unrelated — they fail on `main` too.

🔗 Session: https://poseidon.rapidata.internal/chat/session-93f851b0
