### PR TITLE
refactor(auth): stop requesting the roles scope

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -53,7 +53,7 @@ curl -X POST https://auth.rapidata.ai/connect/token \
   -d grant_type=client_credentials \
   -d client_id=YOUR_CLIENT_ID \
   -d client_secret=YOUR_CLIENT_SECRET \
-  -d scope="openid email roles"
+  -d scope="openid email api"
 
 # → {"access_token": "...", "token_type": "Bearer", "expires_in": 3600}
 
@@ -63,7 +63,7 @@ curl https://api.rapidata.ai/order/openapi/v1.json \
 
 ## Scopes
 
-Tokens are scoped. The SDK requests `openid roles email` by default, which is
+Tokens are scoped. The SDK requests `openid email api` by default, which is
 sufficient for all SDK operations. Request only the scopes you need. Every
 endpoint in the [OpenAPI specification](https://docs.rapidata.ai/openapi.json)
 declares the scopes it requires under its `OpenIdConnect` security scheme.
@@ -72,5 +72,5 @@ declares the scopes it requires under its `OpenIdConnect` security scheme.
 |-------|--------|
 | `openid` | Required for OIDC; identifies the token subject. |
 | `email` | Access to the account email claim. |
-| `roles` | The account's role claims, which gate API operations. |
+| `api` | Access to the Rapidata API resource. |
 | `offline_access` | A refresh token for long-lived sessions. |

--- a/src/rapidata/rapidata_client/rapidata_client.py
+++ b/src/rapidata/rapidata_client/rapidata_client.py
@@ -72,7 +72,7 @@ class RapidataClient:
         client_id: str | None = None,
         client_secret: str | None = None,
         environment: str | None = None,
-        oauth_scope: str = "openid roles email api",
+        oauth_scope: str = "openid email api",
         cert_path: str | None = None,
         token: dict | None = None,
         token_file: str | None = None,

--- a/src/rapidata/service/credential_manager.py
+++ b/src/rapidata/service/credential_manager.py
@@ -268,7 +268,7 @@ class CredentialManager:
         if not bridge_endpoint:
             return None
 
-        auth_url = f"{self.endpoint}/connect/authorize/external?clientId=rapidata-cli&scope=openid profile email roles api&writeKey={bridge_endpoint.write_key}"
+        auth_url = f"{self.endpoint}/connect/authorize/external?clientId=rapidata-cli&scope=openid profile email api&writeKey={bridge_endpoint.write_key}"
         could_open_browser = webbrowser.open(auth_url)
 
         if not could_open_browser:


### PR DESCRIPTION
The SDK requested the `roles` scope, but nothing has minted a `role` claim since rapidata-backend#5068 dropped the role tables — authorization is resolved from the OpenFGA relation graph. So the scope bought a claim that never arrives.

Two call sites:

- `credential_manager.py` — the interactive `rapidata-cli` browser flow, which hardcoded `scope=openid profile email roles api`
- `rapidata_client.py` — the `oauth_scope` default, `openid roles email api`

`docs/authentication.md` also described `roles` as granting "the account's role claims, which gate API operations", which is no longer true in either half of the sentence. The scope table now lists `api` (which the default actually requests) in its place, and the bare-`curl` example matches.

## Why this matters beyond tidiness

Requesting fewer scopes is safe against every backend, but the reverse is not: an **unpermitted** scope fails the whole authorization request. So the identity service cannot stop permitting `roles` while released SDK versions still ask for it — every installed copy would break. This PR is what starts that clock; the backend registration can only be removed once versions predating it have aged out.

Paired changes: RapidataAI/app-frontend#3007, RapidataAI/poseidon (gateway), and rapidata-backend#5119 which removes the now-unreachable destination branch while deliberately keeping the scope permitted.

## Verification

- `pyright src/rapidata/rapidata_client` — 0 errors, 0 warnings
- `pytest` — 132 pass, 4 fail. All 4 are **pre-existing**: I re-ran them on a clean tree and got the same failures (`test_audience_base` and `test_rapidata_audience` cost/graduation warning assertions). Untouched by this change.
- No `uv.lock` churn committed — running `uv` under this container's Python rewrites dependency markers, which I reverted rather than commit.

🔗 Session: [session-4aacf371](https://poseidon.rapidata.internal/chat/session-4aacf371)
