### PR TITLE
fix(service): restore services package imports

### DIFF
--- a/.github/workflows/pyright-type-checking.yml
+++ b/.github/workflows/pyright-type-checking.yml
@@ -20,7 +20,9 @@ jobs:
       - run: uv sync
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
       
+      # No working-directory: pyright reads pyrightconfig.json from the repo root so the
+      # checked paths live in one place. src/rapidata/service was outside the old scope,
+      # which is how a dead import there shipped in 3.21.0 and broke every API call.
       - uses: jakebailey/pyright-action@v2
         with:
           version: v1.1.396
-          working-directory: src/rapidata/rapidata_client

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,3 +1,3 @@
 {
-  "include": ["src/rapidata/rapidata_client"]
+  "include": ["src/rapidata/rapidata_client", "src/rapidata/service"]
 }

--- a/src/rapidata/service/services/__init__.py
+++ b/src/rapidata/service/services/__init__.py
@@ -5,11 +5,11 @@ from rapidata.service.services.dataset_service import DatasetService
 from rapidata.service.services.flow_service import FlowService
 from rapidata.service.services.leaderboard_service import LeaderboardService
 from rapidata.service.services.order_service import OrderService
-from rapidata.service.services.pipeline_service import PipelineService
+from rapidata.service.services.payment_service import PaymentService
 from rapidata.service.services.rapid_service import RapidService
 from rapidata.service.services.signal_service import SignalService
+from rapidata.service.services.translation_service import TranslationService
 from rapidata.service.services.validation_service import ValidationService
-from rapidata.service.services.workflow_service import WorkflowService
 
 __all__ = [
     "AssetService",
@@ -19,9 +19,9 @@ __all__ = [
     "FlowService",
     "LeaderboardService",
     "OrderService",
-    "PipelineService",
+    "PaymentService",
     "RapidService",
     "SignalService",
+    "TranslationService",
     "ValidationService",
-    "WorkflowService",
 ]

--- a/tests/service/test_services_package.py
+++ b/tests/service/test_services_package.py
@@ -1,0 +1,43 @@
+"""Tests that keep ``rapidata.service.services`` importable.
+
+``openapi_service`` reaches every backend service through a lazy
+``from rapidata.service.services.<name>_service import ...``, and that import
+runs the package ``__init__`` first. So a single stale name in ``__init__``
+breaks *every* API call in the published wheel, not just the service that was
+removed — which is how 3.21.0 shipped with a dead ``pipeline_service`` import
+and raised ``ModuleNotFoundError`` on any call.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+import rapidata.service.services as services_package
+
+
+def _service_modules() -> list[str]:
+    package_dir = Path(services_package.__file__).parent
+    return sorted(p.stem for p in package_dir.glob("*_service.py"))
+
+
+class TestServicesPackage:
+    def test_every_exported_name_is_resolvable(self):
+        """A name left in ``__all__`` after its module was deleted is the failure mode."""
+        for name in services_package.__all__:
+            assert (
+                getattr(services_package, name, None) is not None
+            ), f"{name} is exported but not bound"
+
+    @pytest.mark.parametrize("module_name", _service_modules())
+    def test_every_service_module_is_exported(self, module_name: str):
+        """Keeps ``__all__`` in sync with the modules actually on disk."""
+        module = importlib.import_module(f"rapidata.service.services.{module_name}")
+        expected = "".join(part.capitalize() for part in module_name.split("_"))
+
+        assert hasattr(module, expected), f"{module_name} has no {expected}"
+        assert (
+            expected in services_package.__all__
+        ), f"{expected} is missing from rapidata.service.services.__all__"


### PR DESCRIPTION
## What

`src/rapidata/service/services/__init__.py` still imported `pipeline_service` and `workflow_service`, which were deleted in #830 (`refactor!: remove order flow and pipeline/workflow APIs from the SDK`). It also never listed `payment_service` / `translation_service`, which do exist and are used.

## Why this breaks every API call, not just pipelines

`openapi_service.py` reaches each backend service through a lazy
`from rapidata.service.services.<name>_service import ...`. That import runs the package
`__init__` first, so one dead name there takes down **every** service accessor:

```
>>> import rapidata.service.services.order_service
ModuleNotFoundError: No module named 'rapidata.service.services.pipeline_service'
```

Reproduced on `main` and against the published **3.21.0** wheel.

Found in production traces — `rapidata-testing` E2E on 3.21.0:

```
ValidationSetManager.create_classification_set
  → openapi_service.py:178 validation
  → services/__init__.py:8
ModuleNotFoundError: No module named 'rapidata.service.services.pipeline_service'
```

## Changes

1. Drop the two dead imports/exports.
2. Add the two service modules that exist but were omitted (`PaymentService`, `TranslationService`).
3. `tests/service/test_services_package.py` — asserts every `__all__` name resolves and every `*_service.py` on disk is exported, so the next removal that forgets `__init__` fails CI instead of shipping.

Verified the guard catches the regression: reverting `__init__.py` turns the new test into a collection error.

## Test

```
uv run pytest tests/service -q      # 13 passed
uv run pytest tests -q              # 151 passed, 4 failed
```

The 4 failures are in `tests/rapidata_client/audience/` and reproduce unchanged on `main` — unrelated to this PR.

## Why CI didn't catch it

Two independent gaps, both closed here:

1. **pyright never looked at it.** `pyrightconfig.json` included only `src/rapidata/rapidata_client`, and the workflow pinned `working-directory` to the same path — so `src/rapidata/service/` was never type-checked. Widening the config to include it reports the bug directly:

   ```
   src/rapidata/service/services/__init__.py:8:6 - error: Import "rapidata.service.services.pipeline_service" could not be resolved (reportMissingImports)
   src/rapidata/service/services/__init__.py:12:6 - error: Import "rapidata.service.services.workflow_service" could not be resolved (reportMissingImports)
   ```

   `src/rapidata/service/` is already clean under pyright, so this adds a guard without adding noise: `uv run pyright` → 0 errors.

2. **There is no pytest workflow.** `.github/workflows/` runs pyright, docs and release only, so the new test in this PR will not gate a future PR until a test job exists. I left that out deliberately — `pytest tests` is currently red on `main` (4 pre-existing failures in `tests/rapidata_client/audience/`), so adding the job belongs in a PR that also fixes or quarantines those. Worth doing next.

🔗 Session: https://poseidon.rapidata.internal/chat/node-18f661b70117
