### PR TITLE
fix(services): drop deleted pipeline/workflow imports from services __init__

### DIFF
--- a/src/rapidata/service/services/__init__.py
+++ b/src/rapidata/service/services/__init__.py
@@ -5,11 +5,11 @@ from rapidata.service.services.dataset_service import DatasetService
 from rapidata.service.services.flow_service import FlowService
 from rapidata.service.services.leaderboard_service import LeaderboardService
 from rapidata.service.services.order_service import OrderService
-from rapidata.service.services.pipeline_service import PipelineService
+from rapidata.service.services.payment_service import PaymentService
 from rapidata.service.services.rapid_service import RapidService
 from rapidata.service.services.signal_service import SignalService
+from rapidata.service.services.translation_service import TranslationService
 from rapidata.service.services.validation_service import ValidationService
-from rapidata.service.services.workflow_service import WorkflowService
 
 __all__ = [
     "AssetService",
@@ -19,9 +19,9 @@ __all__ = [
     "FlowService",
     "LeaderboardService",
     "OrderService",
-    "PipelineService",
+    "PaymentService",
     "RapidService",
     "SignalService",
+    "TranslationService",
     "ValidationService",
-    "WorkflowService",
 ]


### PR DESCRIPTION
## What

`src/rapidata/service/services/__init__.py` still imported `pipeline_service` and `workflow_service` after those modules were removed, and was missing `payment_service` / `translation_service` (which exist and are wired into `openapi_service.py`). Because the package `__init__` imports eagerly, **any** access that touches `rapidata.service.services` crashed with:

```
ModuleNotFoundError: No module named 'rapidata.service.services.pipeline_service'
```

This is why unrelated calls failed too — e.g. `client.validation.create_classification_set(...)` blew up on the import of `pipeline_service`, not on anything validation-related.

## Fix

Reconcile `__init__.py` with the modules that actually exist in `services/` (matches what `openapi_service.py` already exposes): drop `PipelineService` / `WorkflowService`, add `PaymentService` / `TranslationService`.

## Verification

- `pip install -e .` then import the former crash path — `import rapidata`, `from rapidata.service.services import *`, `from rapidata.service.services.validation_service import ValidationService` — all succeed.

🔗 Session: [session-2cb9badb](https://poseidon.rapidata.internal/chat/session-2cb9badb)
