### PR TITLE
docs: surface audience targeting in quickstart, drop legacy order mentions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,11 +3,13 @@ This Project is a Python SDK for the Rapidata API.
 It is built around the RapidataClient class which is the main entry point for interacting with the Rapidata API.
 
 As a customer you can use the RapidataClient class to access the following:
-- OrderCreation
-- ValidationSetCreation
-- AudienceCreation
 - JobDefinitionCreation
+- AudienceCreation (including filtered audiences via `.filter()` for country/language/demographic targeting)
+- ValidationSetCreation
+- FlowCreation
 - BenchmarkCreation / MRI Creation
+
+Orders were removed from the SDK entirely (v3.21.0) — do not add, document, or reference order creation.
 
 The whole authentication and backend communication is handled by the OpenAPIService class. It works in combination with the AUTO GENERATED API CLIENT that is used to make the actual API calls.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -57,7 +57,7 @@ curl -X POST https://auth.rapidata.ai/connect/token \
 
 # → {"access_token": "...", "token_type": "Bearer", "expires_in": 3600}
 
-curl https://api.rapidata.ai/order/openapi/v1.json \
+curl https://api.rapidata.ai/jobs \
   -H "Authorization: Bearer ACCESS_TOKEN"
 ```
 

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -48,7 +48,7 @@ The exception exposes these to help you understand and recover from failures:
 - `dataset` — the dataset that was being uploaded to. `retry()` reuses it.
 - `failed_uploads` / `detailed_failures` / `failures_by_reason` — which datapoints failed and why (see below).
 - `retry()` — re-upload the failed datapoints into `dataset` and finish creating the definition. Returns the `RapidataJobDefinition`.
-- `job_definition` — `None` for job creation (nothing was persisted). Populated only when tolerating failures on a legacy order.
+- `job_definition` — `None` for job-definition creation (nothing was persisted). Populated when the exception comes from updating an existing definition (e.g. `update_dataset`), where the definition already exists.
 
 ### Understanding Failure Information
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -75,6 +75,21 @@ audience = client.audience.get_audience_by_id("aud_MU1GZYoESyO") # (1)!
 !!! note
     The global and curated audiences get you started quickly, but results may be less accurate than a custom audience trained with examples specific to your task. For higher quality, see [Custom Audiences](audiences.md).
 
+#### Targeting countries, languages, or demographics
+
+To restrict any audience — including the global one — to specific countries, languages, age groups, genders, or device types, derive a filtered audience with `.filter(...)`. No new recruiting or qualification is needed:
+
+```py
+from rapidata import CountryFilter, LanguageFilter
+
+audience = client.audience.get_audience_by_id("global").filter([
+    CountryFilter(["US"]),
+    LanguageFilter(["en"]),
+])
+```
+
+The result can be used anywhere a regular audience is accepted, e.g. `audience.assign_job(...)` in Step 3. See [Filtered Audiences](audiences.md#filtered-audiences) for all supported filters and how to combine them.
+
 ### Step 2: Create a Job Definition
 
 A job definition configures what you want labeled:

--- a/docs/understanding_the_results.md
+++ b/docs/understanding_the_results.md
@@ -103,7 +103,7 @@ Here's an example of the results you might receive when running a COMPARE task (
     - `createdAt`: The timestamp indicating when the results overview was generated, in UTC time.
     - `version`: The version of the aggregator system that produced the results.
     - `type`: The type of task that was run (e.g. `Compare`, `Classify`).
-    - `name`: The name given to the job or order.
+    - `name`: The name given to the job.
     - `instruction`: The instruction that was shown to the labelers.
 
 2. `results`: This section contains the actual comparison data collected from the labelers. For comparison jobs, each item includes:


### PR DESCRIPTION
## Why

A brand-new customer's coding agent fell back to the legacy `POST /order` REST API (removed from the SDK in #830) for country/language-targeted runs, because:

1. The quickstart never mentions targeting — the only `.filter()` documentation sits at the bottom of the audiences page.
2. Several docs still reference orders, reinforcing agents' stale training-data knowledge of the old order API.

## What

- **quickstart.md** — add a "Targeting countries, languages, or demographics" example: `.filter([CountryFilter, LanguageFilter])` on the global audience, linking to the full Filtered Audiences section.
- **authentication.md** — bearer-token example now calls `GET /jobs` instead of the order-service OpenAPI URL.
- **error_handling.md** — `job_definition` on `FailedUploadException` is populated on the definition-update path (`update_dataset`), not "on a legacy order" (matches `rapidata_job_definition.py:137`).
- **understanding_the_results.md** — `info.name` described as the job's name.
- **CLAUDE.md** — drop `OrderCreation` from the capability list; note orders are gone so future changes don't reintroduce them.

Docs build clean with `uv run --group docs mkdocs build` (remaining warnings pre-existing).

🔗 Session: [session-3e96c665](https://poseidon.rapidata.internal/chat/session-3e96c665)
