### PR TITLE
feat(benchmark): submit participants in one batch request

### DIFF
--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -321,8 +321,10 @@ participant.run()
 # Or add multiple models and submit them all at once
 benchmark.add_model(name="ModelB", media=["https://example.com/img2.png"], identifiers=["scene_1"])
 benchmark.add_model(name="ModelC", media=["https://example.com/img3.png"], identifiers=["scene_1"])
-benchmark.run()  # Submits all participants in CREATED state
+benchmark.run()  # Submits all CREATED participants in a single batch request
 ```
+
+Submitting in one batch evaluates the participants symmetrically as a single run — each model compared against every other and against the benchmark's already-submitted field — rather than as separate per-participant runs.
 
 ### Inspecting a Participant's Elo
 

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -54,6 +54,10 @@ if TYPE_CHECKING:
 # A batch-wide failure would otherwise print one full error block per sample.
 _MAX_REPORTED_FAILURES = 5
 
+# The submit endpoint accepts at most 100 participant ids per request and
+# rejects anything larger outright, so submissions are chunked to this size.
+_SUBMIT_BATCH_SIZE = 100
+
 
 class RapidataBenchmark:
     """
@@ -947,16 +951,31 @@ class RapidataBenchmark:
         """Submits all participants that are in `CREATED` state.
 
         This is a convenience method to submit all unsubmitted participants at once.
+
+        Unlike submitting each participant individually, a batch is evaluated
+        symmetrically as one run: every participant is compared against every
+        other and against the benchmark's already-submitted field.
         """
         from rapidata.api_client.models.participant_status import ParticipantStatus
+        from rapidata.api_client.models.submit_participants_endpoint_input import (
+            SubmitParticipantsEndpointInput,
+        )
 
         with tracer.start_as_current_span("RapidataBenchmark.run"):
             created = [
                 p for p in self.participants if p.status == ParticipantStatus.CREATED
             ]
             logger.info(f"Submitting {len(created)} participants in CREATED state")
-            for participant in created:
-                participant.run()
+
+            for start in range(0, len(created), _SUBMIT_BATCH_SIZE):
+                batch = created[start : start + _SUBMIT_BATCH_SIZE]
+                self._openapi_service.leaderboard.participant_api.participants_submit_post(
+                    submit_participants_endpoint_input=SubmitParticipantsEndpointInput(
+                        participantIds=[p.id for p in batch]
+                    )
+                )
+                for participant in batch:
+                    participant._status = ParticipantStatus.SUBMITTED
 
             # Clear cache so next access re-fetches
             self.__participants = []

--- a/tests/rapidata_client/benchmark/test_benchmark_batch_submit.py
+++ b/tests/rapidata_client/benchmark/test_benchmark_batch_submit.py
@@ -1,0 +1,92 @@
+"""Tests for ``RapidataBenchmark.run`` submitting participants in batches.
+
+``run`` sends every ``CREATED`` participant to the batch submit endpoint in one
+request (chunked to the endpoint's 100-id cap) rather than one request per
+participant, so the batch is evaluated symmetrically as a single run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from rapidata.api_client.models.participant_status import ParticipantStatus
+from rapidata.rapidata_client.benchmark.participant.participant import (
+    BenchmarkParticipant,
+)
+from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
+
+
+def _make_benchmark(
+    statuses: list[ParticipantStatus],
+) -> tuple[RapidataBenchmark, list[BenchmarkParticipant]]:
+    svc = MagicMock()
+    svc.environment = "rapidata.ai"
+    benchmark = RapidataBenchmark("bm", "bm-1", svc)
+
+    participants = [
+        BenchmarkParticipant(
+            name=f"model-{i}",
+            id=f"p-{i}",
+            openapi_service=svc,
+            benchmark_id="bm-1",
+            status=status,
+        )
+        for i, status in enumerate(statuses)
+    ]
+    # Seed the participants cache so `run` does not hit the (mocked) list endpoint.
+    setattr(benchmark, "_RapidataBenchmark__participants", participants)
+    return benchmark, participants
+
+
+def _submit_calls(benchmark: RapidataBenchmark):
+    return benchmark._openapi_service.leaderboard.participant_api.participants_submit_post.call_args_list
+
+
+def test_run_submits_created_participants_in_a_single_batch() -> None:
+    benchmark, participants = _make_benchmark([ParticipantStatus.CREATED] * 3)
+
+    benchmark.run()
+
+    calls = _submit_calls(benchmark)
+    assert len(calls) == 1
+    payload = calls[0].kwargs["submit_participants_endpoint_input"]
+    assert payload.participant_ids == ["p-0", "p-1", "p-2"]
+    assert all(p.status == ParticipantStatus.SUBMITTED for p in participants)
+
+
+def test_run_only_submits_created_participants() -> None:
+    benchmark, participants = _make_benchmark(
+        [
+            ParticipantStatus.CREATED,
+            ParticipantStatus.SUBMITTED,
+            ParticipantStatus.CREATED,
+        ]
+    )
+
+    benchmark.run()
+
+    calls = _submit_calls(benchmark)
+    assert len(calls) == 1
+    payload = calls[0].kwargs["submit_participants_endpoint_input"]
+    assert payload.participant_ids == ["p-0", "p-2"]
+
+
+def test_run_chunks_at_the_hundred_id_cap() -> None:
+    benchmark, _ = _make_benchmark([ParticipantStatus.CREATED] * 150)
+
+    benchmark.run()
+
+    calls = _submit_calls(benchmark)
+    assert len(calls) == 2
+    first = calls[0].kwargs["submit_participants_endpoint_input"].participant_ids
+    second = calls[1].kwargs["submit_participants_endpoint_input"].participant_ids
+    assert len(first) == 100
+    assert len(second) == 50
+
+
+def test_run_with_no_created_participants_sends_nothing() -> None:
+    benchmark, _ = _make_benchmark([ParticipantStatus.SUBMITTED])
+
+    benchmark.run()
+
+    assert _submit_calls(benchmark) == []


### PR DESCRIPTION
## What

`RapidataBenchmark.run()` now submits all `CREATED` participants with a single call to the batch endpoint (`participants_submit_post`) instead of one request per participant. Submissions are chunked to the endpoint's 100-id cap.

## Why

A batch is evaluated **symmetrically as one run** — every participant compared against every other and against the benchmark's already-submitted field — whereas per-participant submits produce separate per-participant runs. This also collapses N HTTP requests into ⌈N/100⌉.

## Details

1. `run()` replaces the `for participant in created: participant.run()` loop with chunked `participants_submit_post(SubmitParticipantsEndpointInput(participantIds=...))` calls.
2. Kept: CREATED-state filtering, the log line, per-participant in-memory status → `SUBMITTED`, and clearing the participants cache.
3. `BenchmarkParticipant.run()` is unchanged — it remains the single-submit path.
4. Docs (`mri_advanced.md`) updated to note `benchmark.run()` submits in one batch request.
5. Added `test_benchmark_batch_submit.py` covering single-batch submission, CREATED-only filtering, 100-id chunking, and the empty case.

## Checks

- `uv run pyright src/rapidata/rapidata_client` — 0 errors
- `uv run pytest tests/rapidata_client/benchmark/` — 69 passed
- `uv run black` clean; `mkdocs build` succeeds

🔗 Session: https://poseidon.rapidata.internal/chat/node-365f1205
