### PR TITLE
feat(upload): apply compression override to batched URL uploads

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,7 +49,7 @@ logger.info("This will be shown") # (2)!
 | `cacheShards` | `int` | `32` | Number of disk-cache shards for concurrent access (immutable). Each shard holds open file handles — see [Too many open files](#too-many-open-files) |
 | `batchSize` | `int` | `1000` | Number of URLs per batch (100–5000) |
 | `batchPollInterval` | `float` | `0.5` | Batch polling interval in seconds |
-| `compression` | `CompressionConfig \| None` | `None` | Per-upload image-compression settings; see [Compression override](#compression-override) below. |
+| `compression` | `CompressionConfig \| None` | `None` | Per-upload compression settings; `enabled=False` preserves the original image and video. See [Compression override](#compression-override) below. |
 | `contextShortening` | `bool` | `False` | Shorten every datapoint context for the job instruction before upload. Contexts longer than the 400-character backend limit are always shortened regardless of this setting, with a warning. See [contexts](job_definition_parameters.md#contexts). |
 | `checkForExplicitContent` | `bool \| None` | `None` | Opt in/out of the server-side explicit-content check on job assignment. `None` uses the account default; `True` forces it on; `False` requests skipping it (honored only if the account is permitted, otherwise the check still runs and a warning is logged). |
 
@@ -65,9 +65,13 @@ rapidata_config.upload.compression = CompressionConfig(
     quality=70,
     max_dimension=1024,
 )
+
+# Or preserve originals untouched — e.g. to guarantee a benchmark set keeps full
+# resolution. enabled=False skips both image and video compression.
+rapidata_config.upload.compression = CompressionConfig(enabled=False)
 ```
 
-Any field left as `None` falls back to the server-side default. Currently applies to single-asset uploads (`/asset/file` and `/asset/url`); batched URL uploads will pick the override up in a follow-up after the OpenAPI client regenerates.
+`enabled` governs both image and video compression, so `enabled=False` preserves the original image *and* the original video (resolution and bitrate). `quality` and `max_dimension` only affect images. Any field left as `None` falls back to the server-side default. The override applies to single-asset uploads (`/asset/file` and `/asset/url`) and to batched URL uploads (`/asset/batch-upload`).
 
 #### Too many open files
 

--- a/src/rapidata/rapidata_client/config/upload_config.py
+++ b/src/rapidata/rapidata_client/config/upload_config.py
@@ -12,7 +12,7 @@ from rapidata.rapidata_client.config._env_utils import apply_env_overrides
 
 class CompressionConfig(BaseModel):
     """
-    Per-upload override for the asset service's image-compression behaviour.
+    Per-upload override for the asset service's compression behaviour.
 
     Any field left as ``None`` falls back to the value the asset service has
     configured globally. Set ``enabled`` to ``True`` (or ``False``) to force the
@@ -20,16 +20,19 @@ class CompressionConfig(BaseModel):
     expected in the 1..100 range and ``max_dimension`` must be at least 1; both
     are validated server-side.
 
-    Currently applies to single-asset uploads (file paths and individual URLs
-    via the ``/asset/file`` and ``/asset/url`` endpoints). Batched URL uploads
-    via the orchestrator's ``/asset/batch-upload`` path will gain the same
-    override in a follow-up once the SDK's OpenAPI client is regenerated to
-    include the ``compression`` field on the batch input model.
+    ``enabled`` governs both image and video compression: ``enabled=False``
+    preserves the original image *and* the original video (resolution and
+    bitrate), which is the way to guarantee an uploaded 1080p clip reaches
+    annotators untouched. ``quality`` and ``max_dimension`` only affect images;
+    videos have no equivalent knob.
+
+    Applies to single-asset uploads (``/asset/file`` and ``/asset/url``) and to
+    batched URL uploads via the orchestrator's ``/asset/batch-upload`` path.
 
     Attributes:
-        enabled (bool | None): Force compression on or off. ``None`` to defer to the server default.
-        quality (int | None): WebP quality (1..100) to use when compression runs.
-        max_dimension (int | None): Maximum width or height in pixels when compression runs.
+        enabled (bool | None): Force compression on or off for both images and videos. ``None`` to defer to the server default.
+        quality (int | None): WebP quality (1..100) to use when image compression runs. Images only.
+        max_dimension (int | None): Maximum width or height in pixels when image compression runs. Images only.
     """
 
     model_config = ConfigDict(validate_assignment=True)

--- a/src/rapidata/rapidata_client/datapoints/_batch_asset_uploader.py
+++ b/src/rapidata/rapidata_client/datapoints/_batch_asset_uploader.py
@@ -16,6 +16,7 @@ from rapidata.api_client.models.batch_upload_url_status import BatchUploadUrlSta
 from rapidata.api_client.models.create_batch_upload_endpoint_input import (
     CreateBatchUploadEndpointInput,
 )
+from rapidata.api_client.models.compression_override import CompressionOverride
 
 if TYPE_CHECKING:
     from rapidata.service.openapi_service import OpenAPIService
@@ -76,6 +77,11 @@ class BatchAssetUploader:
         # by correlation ID instead of passing all batch IDs as query params
         correlation_id = str(uuid.uuid4())
 
+        # Snapshot the compression override once so every batch in this run is
+        # submitted with the same setting, matching the compression-aware cache
+        # key get_url_cache_key already produces.
+        compression_override = self._compression_override()
+
         # Split into batches
         batches = self._split_into_batches(urls)
 
@@ -103,7 +109,9 @@ class BatchAssetUploader:
                         try:
                             result = self.openapi_service.asset.batch_upload_api.asset_batch_upload_post(
                                 create_batch_upload_endpoint_input=CreateBatchUploadEndpointInput(
-                                    urls=batch, correlationId=correlation_id
+                                    urls=batch,
+                                    correlationId=correlation_id,
+                                    compression=compression_override,
                                 )
                             )
                             batch_id = result.batch_upload_id
@@ -162,6 +170,23 @@ class BatchAssetUploader:
             # Cleanup: abort batches if interrupted
             if self._interrupted:
                 self._abort_batches(batch_ids, batch_ids_lock)
+
+    @staticmethod
+    def _compression_override() -> CompressionOverride | None:
+        """Build the batch-request compression override from the current config.
+
+        Returns ``None`` when nothing is overridden so the request shape is
+        unchanged. ``enabled=False`` skips both image and video compression
+        server-side, keeping the batch's original media.
+        """
+        compression = rapidata_config.upload.compression
+        if compression is None or not compression.is_set():
+            return None
+        return CompressionOverride(
+            enabled=compression.enabled,
+            quality=compression.quality,
+            maxDimension=compression.max_dimension,
+        )
 
     def _split_into_batches(self, urls: list[str]) -> list[list[str]]:
         """Split URLs into batches of configured size."""

--- a/tests/rapidata_client/datapoints/test_batch_compression_override.py
+++ b/tests/rapidata_client/datapoints/test_batch_compression_override.py
@@ -1,0 +1,56 @@
+"""The upload compression override must reach batched URL uploads.
+
+`CompressionConfig(enabled=False)` preserves original media (image and video).
+The batch path builds a `CompressionOverride` from the same global config the
+single-upload path uses, so a benchmark set submitted in bulk keeps its
+original resolution instead of silently ignoring the setting.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rapidata import rapidata_config, CompressionConfig
+from rapidata.rapidata_client.datapoints._batch_asset_uploader import BatchAssetUploader
+
+
+@pytest.fixture(autouse=True)
+def _reset_compression():
+    original = rapidata_config.upload.compression
+    yield
+    rapidata_config.upload.compression = original
+
+
+def test_no_config_sends_no_override():
+    rapidata_config.upload.compression = None
+    assert BatchAssetUploader._compression_override() is None
+
+
+def test_unset_config_sends_no_override():
+    rapidata_config.upload.compression = CompressionConfig()
+    assert BatchAssetUploader._compression_override() is None
+
+
+def test_disabled_compression_is_forwarded():
+    rapidata_config.upload.compression = CompressionConfig(enabled=False)
+
+    override = BatchAssetUploader._compression_override()
+
+    assert override is not None
+    assert override.to_dict() == {
+        "enabled": False,
+        "quality": None,
+        "maxDimension": None,
+    }
+
+
+def test_all_fields_map_to_wire_names():
+    rapidata_config.upload.compression = CompressionConfig(
+        enabled=True, quality=70, max_dimension=1024
+    )
+
+    override = BatchAssetUploader._compression_override()
+
+    assert override is not None
+    # max_dimension maps to the wire alias maxDimension.
+    assert override.to_dict() == {"enabled": True, "quality": 70, "maxDimension": 1024}


### PR DESCRIPTION
## What

Threads the upload compression override through **batched URL uploads**, and clarifies that `enabled` governs video too.

## Why

`CompressionConfig` already reached single-asset uploads (`/asset/file`, `/asset/url`), but the batch path (`/asset/batch-upload`) submitted no `compression` field — so a benchmark set uploaded in bulk **silently ignored the setting**. Both the backend and the generated client already carry a `compression` field on the batch input model; this just passes it through.

Combined with the backend change that makes `enabled=false` skip **video** compression ([rapidata-backend#5212](https://github.com/RapidataAI/rapidata-backend/pull/5212)), `CompressionConfig(enabled=False)` now preserves the original image **and** video (resolution + bitrate) across every upload path — the way to guarantee an uploaded 1080p clip reaches annotators untouched.

## How

1. `_batch_asset_uploader.py` — new `_compression_override()` helper builds a `CompressionOverride` from `rapidata_config.upload.compression` (snapshotted once per run) and passes it into `CreateBatchUploadEndpointInput`. `max_dimension` maps to the wire alias `maxDimension`.
2. The URL cache key was already compression-aware (`get_url_cache_key`), so dedup across different compression settings still holds — no cache change needed.
3. Docstring + `docs/config.md` updated: `enabled` covers image **and** video; `quality`/`max_dimension` stay image-only; removed the stale "batch is a follow-up" note.

## Usage

```python
from rapidata import rapidata_config, CompressionConfig

# Preserve originals (full resolution image + video) for a benchmark set:
rapidata_config.upload.compression = CompressionConfig(enabled=False)
```

## Tests

New `test_batch_compression_override.py` — 4 cases: no config / unset → no override; `enabled=False` forwarded; all fields map to wire names (`maxDimension`). `pyright` clean, `black` clean, existing upload tests pass (9 passed).

🔗 Session: [session-ba04fdee](https://poseidon.rapidata.internal/chat/session-ba04fdee)
