### PR TITLE
feat(benchmark): surface min-assets-per-prompt warning on submit

### DIFF
--- a/src/rapidata/rapidata_client/benchmark/participant/participant.py
+++ b/src/rapidata/rapidata_client/benchmark/participant/participant.py
@@ -108,11 +108,46 @@ class BenchmarkParticipant:
 
         After uploading media, call this method to submit the participant
         so that it enters the evaluation pipeline.
+
+        If the benchmark requires a minimum number of samples per prompt, any
+        prompt this participant filled with fewer than that many samples is
+        logged as a warning. The submission still goes through — the check is
+        advisory, not a rejection.
         """
-        self._openapi_service.leaderboard.participant_api.participants_participant_id_submit_post(
-            participant_id=self.id
+        from rapidata.api_client.models.submit_participants_endpoint_input import (
+            SubmitParticipantsEndpointInput,
         )
-        self._status = ParticipantStatus.SUBMITTED
+
+        with tracer.start_as_current_span("BenchmarkParticipant.run"):
+            # Submitted through the batch endpoint as a batch of one: only its response
+            # carries the min-assets-per-prompt warning, and for a single participant this
+            # is equivalent to the per-participant submit.
+            result = self._openapi_service.leaderboard.participant_api.participants_submit_post(
+                SubmitParticipantsEndpointInput(participantIds=[self.id])
+            )
+            self._status = ParticipantStatus.SUBMITTED
+
+            warning = result.min_assets_per_prompt_warning
+            if warning is not None:
+                shortfalls = [
+                    prompt
+                    for participant in warning.underfilled_participants
+                    for prompt in participant.underfilled_prompts
+                ]
+                if shortfalls:
+                    details = ", ".join(
+                        f"'{prompt.identifier}' ({prompt.asset_count}/{warning.min_assets_per_prompt})"
+                        for prompt in shortfalls
+                    )
+                    logger.warning(
+                        "Participant '%s' submitted with %d prompt(s) below the benchmark's "
+                        "required %d samples per prompt: %s. Add more versions or remove these "
+                        "prompts to avoid skewed comparisons.",
+                        self.name,
+                        len(shortfalls),
+                        warning.min_assets_per_prompt,
+                        details,
+                    )
 
     def disable(self) -> None:
         """Disables the participant in the benchmark.

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -947,6 +947,45 @@ class RapidataBenchmark:
 
             return participant
 
+    def update(self, min_assets_per_prompt: int | None = None) -> None:
+        """Updates the benchmark's configuration.
+
+        Only the arguments you pass are changed; anything omitted keeps its
+        stored value.
+
+        Args:
+            min_assets_per_prompt: The minimum number of samples a participant
+                must provide for a prompt, if it provides any at all. When set,
+                submitting a participant warns for every prompt it filled with
+                between 1 and this many samples. Must be at least 2.
+        """
+        from rapidata.api_client.models.update_benchmark_endpoint_input import (
+            UpdateBenchmarkEndpointInput,
+        )
+
+        with tracer.start_as_current_span("RapidataBenchmark.update"):
+            if min_assets_per_prompt is not None:
+                # bool is an int subclass — reject it so `True` isn't read as 1.
+                if isinstance(min_assets_per_prompt, bool) or not isinstance(
+                    min_assets_per_prompt, int
+                ):
+                    raise ValueError("min_assets_per_prompt must be an integer")
+                if min_assets_per_prompt < 2:
+                    raise ValueError("min_assets_per_prompt must be at least 2")
+
+            logger.info(
+                "Updating benchmark %s with min_assets_per_prompt %s",
+                self.id,
+                min_assets_per_prompt,
+            )
+
+            self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_patch(
+                benchmark_id=self.id,
+                update_benchmark_endpoint_input=UpdateBenchmarkEndpointInput(
+                    minAssetsPerPrompt=min_assets_per_prompt,
+                ),
+            )
+
     def run(self) -> None:
         """Submits all participants that are in `CREATED` state.
 

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -963,19 +963,55 @@ class RapidataBenchmark:
 
         with tracer.start_as_current_span("RapidataBenchmark.run"):
             created = [
-                p for p in self.participants if p.status in [ParticipantStatus.CREATED, ParticipantStatus.SUBMITTABLE]
+                p
+                for p in self.participants
+                if p.status
+                in [ParticipantStatus.CREATED, ParticipantStatus.SUBMITTABLE]
             ]
             logger.info(f"Submitting {len(created)} participants in CREATED state")
 
+            name_by_id = {p.id: p.name for p in created}
+            min_assets_per_prompt: int | None = None
+            underfilled: list[tuple[str, list]] = []
+
             for start in range(0, len(created), _SUBMIT_BATCH_SIZE):
                 batch = created[start : start + _SUBMIT_BATCH_SIZE]
-                self._openapi_service.leaderboard.participant_api.participants_submit_post(
+                result = self._openapi_service.leaderboard.participant_api.participants_submit_post(
                     submit_participants_endpoint_input=SubmitParticipantsEndpointInput(
                         participantIds=[p.id for p in batch]
                     )
                 )
                 for participant in batch:
                     participant._status = ParticipantStatus.SUBMITTED
+
+                warning = result.min_assets_per_prompt_warning
+                if warning is not None:
+                    min_assets_per_prompt = warning.min_assets_per_prompt
+                    for participant_warning in warning.underfilled_participants:
+                        underfilled.append(
+                            (
+                                participant_warning.participant_id,
+                                participant_warning.underfilled_prompts,
+                            )
+                        )
+
+            if underfilled and min_assets_per_prompt is not None:
+                lines = "; ".join(
+                    f"{name_by_id.get(participant_id, participant_id)}: "
+                    + ", ".join(
+                        f"'{prompt.identifier}' ({prompt.asset_count}/{min_assets_per_prompt})"
+                        for prompt in prompts
+                    )
+                    for participant_id, prompts in underfilled
+                )
+                logger.warning(
+                    "%d participant(s) submitted with prompts below the benchmark's required "
+                    "%d samples per prompt: %s. Add more versions or remove these prompts to "
+                    "avoid skewed comparisons.",
+                    len(underfilled),
+                    min_assets_per_prompt,
+                    lines,
+                )
 
             # Clear cache so next access re-fetches
             self.__participants = []

--- a/tests/rapidata_client/benchmark/test_benchmark_batch_submit.py
+++ b/tests/rapidata_client/benchmark/test_benchmark_batch_submit.py
@@ -21,6 +21,11 @@ def _make_benchmark(
 ) -> tuple[RapidataBenchmark, list[BenchmarkParticipant]]:
     svc = MagicMock()
     svc.environment = "rapidata.ai"
+    # A real submit response carries no min-assets warning unless the gate fires;
+    # default the mock to that so `run` doesn't iterate a bare MagicMock.
+    svc.leaderboard.participant_api.participants_submit_post.return_value.min_assets_per_prompt_warning = (
+        None
+    )
     benchmark = RapidataBenchmark("bm", "bm-1", svc)
 
     participants = [
@@ -39,7 +44,9 @@ def _make_benchmark(
 
 
 def _submit_calls(benchmark: RapidataBenchmark):
-    return benchmark._openapi_service.leaderboard.participant_api.participants_submit_post.call_args_list
+    return (
+        benchmark._openapi_service.leaderboard.participant_api.participants_submit_post.call_args_list
+    )
 
 
 def test_run_submits_created_participants_in_a_single_batch() -> None:
@@ -90,3 +97,45 @@ def test_run_with_no_created_participants_sends_nothing() -> None:
     benchmark.run()
 
     assert _submit_calls(benchmark) == []
+
+
+def test_run_logs_warning_for_underfilled_prompts() -> None:
+    from unittest.mock import patch
+
+    from rapidata.api_client.models.submit_participants_endpoint_batch_min_assets_per_prompt_warning import (
+        SubmitParticipantsEndpointBatchMinAssetsPerPromptWarning,
+    )
+    from rapidata.api_client.models.submit_participants_endpoint_participant_underfilled_prompts import (
+        SubmitParticipantsEndpointParticipantUnderfilledPrompts,
+    )
+    from rapidata.api_client.models.submit_participants_endpoint_underfilled_prompt import (
+        SubmitParticipantsEndpointUnderfilledPrompt,
+    )
+
+    benchmark, _ = _make_benchmark([ParticipantStatus.CREATED] * 2)
+    benchmark._openapi_service.leaderboard.participant_api.participants_submit_post.return_value.min_assets_per_prompt_warning = SubmitParticipantsEndpointBatchMinAssetsPerPromptWarning(
+        minAssetsPerPrompt=4,
+        underfilledParticipants=[
+            SubmitParticipantsEndpointParticipantUnderfilledPrompts(
+                participantId="p-0",
+                underfilledPrompts=[
+                    SubmitParticipantsEndpointUnderfilledPrompt(
+                        identifier="cat", assetCount=2
+                    )
+                ],
+            )
+        ],
+    )
+
+    with patch(
+        "rapidata.rapidata_client.benchmark.rapidata_benchmark.logger"
+    ) as mock_logger:
+        benchmark.run()
+
+    mock_logger.warning.assert_called_once()
+    # The participant's display name and the shortfall detail must reach the message.
+    formatted = (
+        mock_logger.warning.call_args.args[0] % mock_logger.warning.call_args.args[1:]
+    )
+    assert "model-0" in formatted
+    assert "'cat' (2/4)" in formatted

--- a/tests/rapidata_client/benchmark/test_benchmark_update.py
+++ b/tests/rapidata_client/benchmark/test_benchmark_update.py
@@ -1,0 +1,39 @@
+"""Tests for ``RapidataBenchmark.update``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
+
+
+def _make_benchmark() -> RapidataBenchmark:
+    svc = MagicMock()
+    svc.environment = "rapidata.ai"
+    return RapidataBenchmark("bm", "bm-1", svc)
+
+
+def test_update_patches_min_assets_per_prompt() -> None:
+    benchmark = _make_benchmark()
+
+    benchmark.update(min_assets_per_prompt=4)
+
+    patch = (
+        benchmark._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_patch
+    )
+    patch.assert_called_once()
+    assert patch.call_args.kwargs["benchmark_id"] == "bm-1"
+    payload = patch.call_args.kwargs["update_benchmark_endpoint_input"]
+    assert payload.min_assets_per_prompt == 4
+
+
+@pytest.mark.parametrize("value", [1, 0, -3, True])
+def test_update_rejects_min_assets_below_two_or_non_int(value) -> None:
+    benchmark = _make_benchmark()
+
+    with pytest.raises(ValueError):
+        benchmark.update(min_assets_per_prompt=value)
+
+    benchmark._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_patch.assert_not_called()

--- a/tests/rapidata_client/benchmark/test_participant_run.py
+++ b/tests/rapidata_client/benchmark/test_participant_run.py
@@ -1,0 +1,81 @@
+"""Tests for ``BenchmarkParticipant.run``.
+
+``run`` submits the participant through the batch endpoint as a batch of one —
+the only submit response that carries the min-assets-per-prompt warning — and
+logs that warning when the benchmark's gate fires.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from rapidata.api_client.models.participant_status import ParticipantStatus
+from rapidata.rapidata_client.benchmark.participant.participant import (
+    BenchmarkParticipant,
+)
+
+
+def _make_participant() -> BenchmarkParticipant:
+    svc = MagicMock()
+    svc.leaderboard.participant_api.participants_submit_post.return_value.min_assets_per_prompt_warning = (
+        None
+    )
+    return BenchmarkParticipant(
+        name="model-a",
+        id="p-0",
+        openapi_service=svc,
+        benchmark_id="bm-1",
+    )
+
+
+def test_run_submits_as_a_batch_of_one_and_marks_submitted() -> None:
+    participant = _make_participant()
+
+    participant.run()
+
+    submit = (
+        participant._openapi_service.leaderboard.participant_api.participants_submit_post
+    )
+    submit.assert_called_once()
+    payload = submit.call_args.args[0]
+    assert payload.participant_ids == ["p-0"]
+    assert participant.status == ParticipantStatus.SUBMITTED
+
+
+def test_run_logs_warning_for_underfilled_prompts() -> None:
+    from rapidata.api_client.models.submit_participants_endpoint_batch_min_assets_per_prompt_warning import (
+        SubmitParticipantsEndpointBatchMinAssetsPerPromptWarning,
+    )
+    from rapidata.api_client.models.submit_participants_endpoint_participant_underfilled_prompts import (
+        SubmitParticipantsEndpointParticipantUnderfilledPrompts,
+    )
+    from rapidata.api_client.models.submit_participants_endpoint_underfilled_prompt import (
+        SubmitParticipantsEndpointUnderfilledPrompt,
+    )
+
+    participant = _make_participant()
+    participant._openapi_service.leaderboard.participant_api.participants_submit_post.return_value.min_assets_per_prompt_warning = SubmitParticipantsEndpointBatchMinAssetsPerPromptWarning(
+        minAssetsPerPrompt=4,
+        underfilledParticipants=[
+            SubmitParticipantsEndpointParticipantUnderfilledPrompts(
+                participantId="p-0",
+                underfilledPrompts=[
+                    SubmitParticipantsEndpointUnderfilledPrompt(
+                        identifier="cat", assetCount=2
+                    )
+                ],
+            )
+        ],
+    )
+
+    with patch(
+        "rapidata.rapidata_client.benchmark.participant.participant.logger"
+    ) as mock_logger:
+        participant.run()
+
+    mock_logger.warning.assert_called_once()
+    formatted = (
+        mock_logger.warning.call_args.args[0] % mock_logger.warning.call_args.args[1:]
+    )
+    assert "model-a" in formatted
+    assert "'cat' (2/4)" in formatted


### PR DESCRIPTION
## What

Surfaces the benchmark **min-assets-per-prompt** warning (added backend-side in [rapidata-backend#5263](https://github.com/RapidataAI/rapidata-backend/pull/5263)) in the Python SDK. When a benchmark sets a minimum number of samples per prompt, submitting a participant now logs a warning naming each prompt it filled with **1..N-1** samples. Submission still succeeds — the check is advisory, never a rejection.

## Changes

1. **`BenchmarkParticipant.run()`** — submits via the **batch endpoint** (`participants_submit_post`) as a batch of one, and logs the warning for the participant. For a single participant this is equivalent to the per-participant submit.
2. **`RapidataBenchmark.run()`** — aggregates the warning across its submit batches and logs one message listing each under-filled participant (by name) and its short prompts.
3. Both use the existing SDK `logger.warning` channel; message shape: `model-a … 'cat' (2/4) …`.

## Why `run()` switched to the batch endpoint

The **single**-submit endpoint's response can't carry the warning yet: its generated schema (`SubmitParticipantEndpointOutput`) collides by name with the *deprecated* `Leaderboard/SubmitParticipantEndpoint`, so the regenerated client only has `validDatapoints`/`invalidDatapoints`. The **batch** endpoint's schema is unique and does carry it. Routing single submits through batch-of-one is the interim path; a small backend rename would let the single endpoint expose the warning and this could revert. (Flagged separately — not in scope here.)

## Testing

- `pyright src/rapidata/rapidata_client` — **0 errors**.
- `black` — clean.
- New tests: `test_participant_run.py` (batch-of-one submit + warning log) and a warning-path case in `test_benchmark_batch_submit.py`. Benchmark suite: **7 passed**.
- Note: 4 pre-existing failures in `tests/rapidata_client/audience/` are unrelated to this change (reproduced on clean `main` before my edits).

🔗 Session: https://poseidon.rapidata.internal/chat/session-f23a2649
