### PR TITLE
fix(benchmark): read prompt assets from the read-side asset models

### DIFF
--- a/src/rapidata/rapidata_client/benchmark/prompt_metadata.py
+++ b/src/rapidata/rapidata_client/benchmark/prompt_metadata.py
@@ -33,7 +33,7 @@ class BenchmarkPromptInfo:
     identifier: str
     prompt: str | None
     english_prompt: str | None
-    prompt_asset: str | None
+    prompt_asset: str | list[str] | None
     tags: list[Tag]
     origin: Origin | None
 

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -47,6 +47,8 @@ if TYPE_CHECKING:
     from rapidata.api_client.models.get_prompts_by_benchmark_endpoint_output import (
         GetPromptsByBenchmarkEndpointOutput,
     )
+    from rapidata.api_client.models.i_asset import IAsset
+    from rapidata.api_client.models.i_asset_file_asset import IAssetFileAsset
     from rapidata.rapidata_client.settings import RapidataSetting
     from rapidata.service.openapi_service import OpenAPIService
 
@@ -77,7 +79,7 @@ class RapidataBenchmark:
         self._openapi_service = openapi_service
         self.__prompts: list[str | None] = []
         self.__english_prompts: list[str | None] = []
-        self.__prompt_assets: list[str | None] = []
+        self.__prompt_assets: list[str | list[str] | None] = []
         self.__leaderboards: list["RapidataLeaderboard"] = []
         self.__identifiers: list[str] = []
         self.__tags: list[list[str]] = []
@@ -91,37 +93,67 @@ class RapidataBenchmark:
         self._prompt_uploader = BenchmarkPromptUploader(id, openapi_service)
 
     @staticmethod
-    def __extract_asset_url(prompt: GetPromptsByBenchmarkEndpointOutput) -> str | None:
-        """Reconstruct a prompt's asset reference from the server metadata.
+    def __extract_file_asset_reference(file_asset: IAssetFileAsset) -> str | None:
+        """Reconstruct a single file asset's reference from its metadata.
 
         Remote assets come back as their `sourceUrl`; locally-uploaded ones as
         the bare `originalFilename`.
         """
-        from rapidata.api_client.models.i_asset_model_file_asset_model import (
-            IAssetModelFileAssetModel,
+        from rapidata.api_client.models.i_metadata_source_url_metadata import (
+            IMetadataSourceUrlMetadata,
         )
-        from rapidata.api_client.models.i_metadata_model_source_url_metadata_model import (
-            IMetadataModelSourceUrlMetadataModel,
-        )
-        from rapidata.api_client.models.i_metadata_model_original_filename_metadata_model import (
-            IMetadataModelOriginalFilenameMetadataModel,
+        from rapidata.api_client.models.i_metadata_original_filename_metadata import (
+            IMetadataOriginalFilenameMetadata,
         )
 
-        if prompt.prompt_asset is None:
-            return None
-        file_asset = prompt.prompt_asset.actual_instance
-        assert isinstance(file_asset, IAssetModelFileAssetModel)
         source_url = file_asset.metadata.get("sourceUrl")
-        original_filename = file_asset.metadata.get("originalFilename")
         if source_url is not None:
             instance = source_url.actual_instance
-            assert isinstance(instance, IMetadataModelSourceUrlMetadataModel)
-            return instance.url
+            if isinstance(instance, IMetadataSourceUrlMetadata):
+                return instance.url
+        original_filename = file_asset.metadata.get("originalFilename")
         if original_filename is not None:
             instance = original_filename.actual_instance
-            assert isinstance(instance, IMetadataModelOriginalFilenameMetadataModel)
-            return instance.original_filename
+            if isinstance(instance, IMetadataOriginalFilenameMetadata):
+                return instance.original_filename
         return None
+
+    @classmethod
+    def __extract_asset_reference(cls, asset: IAsset) -> str | list[str] | None:
+        """Resolve any asset the read API can return into its reference(s).
+
+        A multi-asset resolves to the list of its parts, mirroring the
+        `str | list[str]` shape the SDK's asset uploader takes for a single
+        versus a multi asset. Text and null assets carry no file to point at.
+        """
+        from rapidata.api_client.models.i_asset_file_asset import IAssetFileAsset
+        from rapidata.api_client.models.i_asset_multi_asset import IAssetMultiAsset
+
+        instance = asset.actual_instance
+        if isinstance(instance, IAssetFileAsset):
+            return cls.__extract_file_asset_reference(instance)
+
+        if isinstance(instance, IAssetMultiAsset):
+            references: list[str] = []
+            for part in instance.assets:
+                reference = cls.__extract_asset_reference(part)
+                if isinstance(reference, str):
+                    references.append(reference)
+                elif reference is not None:
+                    references.extend(reference)
+            return references or None
+
+        return None
+
+    @classmethod
+    def __extract_asset_url(
+        cls, prompt: GetPromptsByBenchmarkEndpointOutput
+    ) -> str | list[str] | None:
+        """Reconstruct a prompt's asset reference from the server metadata."""
+        if prompt.prompt_asset is None:
+            return None
+
+        return cls.__extract_asset_reference(prompt.prompt_asset)
 
     @classmethod
     def __to_prompt_info(
@@ -236,9 +268,12 @@ class RapidataBenchmark:
         return self.__english_prompts
 
     @property
-    def prompt_assets(self) -> list[str | None]:
+    def prompt_assets(self) -> list[str | list[str] | None]:
         """
         Returns the prompt assets that are registered for the benchmark.
+
+        A prompt registered with several assets at once comes back as the list
+        of its parts.
         """
         if not self.__prompt_assets:
             self.__instantiate_prompts()

--- a/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
+++ b/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
@@ -1,0 +1,148 @@
+"""Tests for reading back the asset a benchmark prompt carries.
+
+The prompts endpoint returns the read-side ``IAsset`` union
+(``IAssetFileAsset`` / ``IAssetMultiAsset`` / ``IAssetNullAsset`` /
+``IAssetTextAsset``), never the write-side ``IAssetModel*`` classes. Asserting
+on the write-side class made every asset-carrying benchmark raise on
+``identifiers`` — and so on ``add_model``, which validates against it — before
+a single byte was uploaded. Only text-only benchmarks stayed usable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rapidata.api_client.models.get_prompts_by_benchmark_endpoint_output import (
+    GetPromptsByBenchmarkEndpointOutput,
+)
+from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
+
+_FILE_ASSET = {
+    "_t": "FileAsset",
+    "fileName": "38719dc3-31e1-491b-b5ec-f72e4260562e.jpg",
+    "metadata": {
+        "fileType": {"_t": "FileTypeMetadata", "fileType": "Image"},
+        "originalFilename": {
+            "_t": "OriginalFilenameMetadata",
+            "originalFilename": "8.jpg",
+        },
+    },
+    "identifier": "38719dc3-31e1-491b-b5ec-f72e4260562e.jpg",
+}
+
+_REMOTE_FILE_ASSET = {
+    "_t": "FileAsset",
+    "fileName": "9c0b5f21-1f4f-4a2b-9f3e-1d0c2b3a4e5f.jpg",
+    "metadata": {
+        "sourceUrl": {
+            "_t": "SourceUrlMetadataModel",
+            "url": "https://assets.rapidata.ai/prompt_1.jpg",
+        },
+        "originalFilename": {
+            "_t": "OriginalFilenameMetadata",
+            "originalFilename": "prompt_1.jpg",
+        },
+    },
+    "identifier": "9c0b5f21-1f4f-4a2b-9f3e-1d0c2b3a4e5f.jpg",
+}
+
+_MULTI_ASSET = {
+    "_t": "MultiAsset",
+    "assets": [
+        {
+            "_t": "FileAsset",
+            "fileName": "3b9b0cca-e70b-45e6-908a-fbc318b218fe.gif",
+            "metadata": {
+                "originalFilename": {
+                    "_t": "OriginalFilenameMetadata",
+                    "originalFilename": "camera-moves-forward.gif",
+                }
+            },
+            "identifier": "3b9b0cca-e70b-45e6-908a-fbc318b218fe.gif",
+        },
+        {
+            "_t": "FileAsset",
+            "fileName": "d87f1813-d2fe-4d79-8a08-2680f4d3f2bc.jpg",
+            "metadata": {
+                "originalFilename": {
+                    "_t": "OriginalFilenameMetadata",
+                    "originalFilename": "interior-2685521.jpg",
+                }
+            },
+            "identifier": "d87f1813-d2fe-4d79-8a08-2680f4d3f2bc.jpg",
+        },
+    ],
+    "metadata": {},
+    "identifier": "3b9b0cca-e70b-45e6-908a-fbc318b218fe.gif,d87f1813-d2fe-4d79-8a08-2680f4d3f2bc.jpg",
+}
+
+_NULL_ASSET = {"_t": "NullAsset", "metadata": {}, "identifier": "null"}
+
+_TEXT_ASSET = {
+    "_t": "TextAsset",
+    "text": "a cat on a bicycle",
+    "metadata": {},
+    "identifier": "a cat on a bicycle",
+}
+
+
+def _prompt(identifier: str, prompt_asset: dict | None) -> dict:
+    return {
+        "id": f"prm_{identifier}",
+        "identifier": identifier,
+        "originalPrompt": f"prompt for {identifier}",
+        "englishPrompt": f"prompt for {identifier}",
+        "promptAsset": prompt_asset,
+        "createdAt": "2026-09-04T12:00:00Z",
+        "tags": [{"value": "scene", "category": "kind"}],
+        "origin": {"source": "coco"},
+    }
+
+
+def _make_benchmark(prompts: list[dict]) -> RapidataBenchmark:
+    svc = MagicMock()
+    svc.environment = "rapidata.ai"
+
+    items = [GetPromptsByBenchmarkEndpointOutput.from_dict(p) for p in prompts]
+    page = MagicMock(items=items, total_pages=1)
+    svc.leaderboard.benchmark_api.benchmark_benchmark_id_prompts_get.return_value = page
+
+    return RapidataBenchmark("bm", "bm-1", svc)
+
+
+@pytest.mark.parametrize(
+    "asset,expected",
+    [
+        (_FILE_ASSET, "8.jpg"),
+        # A remote asset keeps its URL; the filename is only the fallback.
+        (_REMOTE_FILE_ASSET, "https://assets.rapidata.ai/prompt_1.jpg"),
+        (_MULTI_ASSET, ["camera-moves-forward.gif", "interior-2685521.jpg"]),
+        (_NULL_ASSET, None),
+        (_TEXT_ASSET, None),
+        (None, None),
+    ],
+)
+def test_prompt_assets_read_back(asset, expected) -> None:
+    benchmark = _make_benchmark([_prompt("id0", asset)])
+
+    assert benchmark.identifiers == ["id0"]
+    assert benchmark.prompt_assets == [expected]
+
+
+def test_identifiers_across_mixed_asset_kinds() -> None:
+    benchmark = _make_benchmark(
+        [
+            _prompt("realism", _FILE_ASSET),
+            _prompt("camera", _MULTI_ASSET),
+            _prompt("text-only", None),
+        ]
+    )
+
+    assert benchmark.identifiers == ["realism", "camera", "text-only"]
+    assert benchmark.prompts == [
+        "prompt for realism",
+        "prompt for camera",
+        "prompt for text-only",
+    ]


### PR DESCRIPTION
## Problem

`benchmark.identifiers` raised `AssertionError` on every MRI benchmark whose prompts carry an asset — on `main` and on the released 3.22.3. Because `add_model` validates its `identifiers` argument against `self.identifiers`, it blew up too, before a single byte was uploaded.

`__extract_asset_url` asserted `isinstance(file_asset, IAssetModelFileAssetModel)`, but that is the **write-side** generated class. `benchmark_benchmark_id_prompts_get` returns the **read-side** `IAsset` union, whose `actual_instance` is one of `IAssetFileAsset` / `IAssetMultiAsset` / `IAssetNullAsset` / `IAssetTextAsset`. The same write-vs-read mismatch applied to the two metadata classes checked right after (`IMetadataModelSourceUrlMetadataModel` / `IMetadataModelOriginalFilenameMetadataModel` vs `IMetadataSourceUrlMetadata` / `IMetadataOriginalFilenameMetadata`).

Text-only benchmarks return `promptAsset: null`, skip the assertion entirely, and kept working — which is why this went unnoticed.

## Fix

Resolve each variant the read API can actually return, and never assert on a class it cannot:

| read-side class | result |
| --- | --- |
| `IAssetFileAsset` | `sourceUrl`, else `originalFilename` (unchanged behaviour) |
| `IAssetMultiAsset` | the list of its parts' references |
| `IAssetNullAsset` / `IAssetTextAsset` | `None` |

The metadata lookups became `isinstance` checks that fall through instead of assertions, so an unexpected metadata shape degrades to "no asset reference" rather than taking down the whole benchmark.

### Why a multi-asset becomes a `list[str]`

The two candidates were a list of the parts, or just the first part's URL. A list is what the SDK already means by "one thing, several assets" on the write side — `AssetUploader.upload_and_map_asset` / `build_asset_input` take `str | list[str]` and bundle a list into a `MultiAssetInput`, and `_DatapointValidator(multi_asset=True)` *requires* lists. Returning the first part instead would silently drop data: the camera benchmark's 600 prompts each pair a reference GIF with a still image, and reporting only the GIF would make `prompt_assets` lie about every one of them.

`BenchmarkPromptInfo.prompt_asset` and the `prompt_assets` property widen from `str | None` to `str | list[str] | None` to carry that. Nothing regresses — the property raised for these benchmarks before this PR.

Note that `add_prompts` still only accepts one asset per prompt (`list[str | None]`), so a multi-asset value read back is not yet re-feedable into it. Widening the write path is a separate change, deliberately left out of this fix.

## Verification

Read-only against the three live benchmarks (no `add_model`, no `run()`):

| benchmark | id | `len(identifiers)` | prompt asset kind |
| --- | --- | --- | --- |
| realism | `bmk_1U5tRyRIQPQF9I` | 25 ✅ | `IAssetFileAsset` |
| physics | `bmk_1U6OmpqcWwoRpy` | 65 ✅ | `IAssetFileAsset` |
| camera | `bmk_1Tv91mr3qi4xPE` | 600 ✅ | `IAssetMultiAsset` (2 parts each) |

All three raise `AssertionError` on `main`.

The `sourceUrl` branch has no coverage in those three (all their assets were uploaded as files, so they only carry `originalFilename`), so it was confirmed separately against `bmk_1RMYsix5Zy3vtK`, whose assets resolve to `IMetadataSourceUrlMetadata` and yield their CloudFront URL. Worth flagging for review: the read-side `IMetadataSourceUrlMetadata` discriminator is the string `"SourceUrlMetadataModel"`, not `"SourceUrlMetadata"` — confirmed both in `openapi/schemas/*.json` and on live data.

## Tests

`tests/rapidata_client/benchmark/test_prompt_asset_extraction.py` drives `identifiers` / `prompts` / `prompt_assets` through `GetPromptsByBenchmarkEndpointOutput.from_dict` on captured live wire payloads — a local file asset, a remote (`sourceUrl`) one, a two-part multi-asset, a null asset, a text asset, and no asset — plus a mixed-kind benchmark.

`uv run pytest` — 168 passed. The 4 failures in `tests/rapidata_client/audience/` are pre-existing on `main` and untouched by this PR. `pyright src/rapidata/rapidata_client` is clean at v1.1.396 (the version CI pins) and at 1.1.407.

## Impact

Unblocks the Odyssey handoff notebooks in `RapidataAI/scripts-odyssey`, which call `add_model` on these three benchmarks.

---

🔗 Session: https://poseidon.rapidata.internal/chat/node-630aabfd
