### PR TITLE
refactor(benchmark): prompt assets as one list of strings per prompt

### DIFF
--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -21,9 +21,9 @@ benchmark = client.mri.create_new_benchmark(
         "A portrait of a wise old wizard"
     ],
     prompt_assets=[
-        "https://assets.rapidata.ai/mountain_sunset.png",
-        "https://assets.rapidata.ai/futuristic_city.png", 
-        "https://assets.rapidata.ai/wizard_portrait.png"
+        ["https://assets.rapidata.ai/mountain_sunset.png"],
+        ["https://assets.rapidata.ai/futuristic_city.png"],
+        ["https://assets.rapidata.ai/wizard_portrait.png"]
     ]
 )
 
@@ -32,19 +32,30 @@ benchmark = client.mri.create_new_benchmark(
     name="Preference Benchmark",
     identifiers=["seed_1", "seed_2", "seed_3"],
     prompts=["prompt_1", "prompt_1", "prompt_1"],
-    prompt_assets=["https://example.com/asset1.jpg", "https://example.com/asset1.jpg", "https://example.com/asset1.jpg"]
+    prompt_assets=[["https://example.com/asset1.jpg"], ["https://example.com/asset1.jpg"], ["https://example.com/asset1.jpg"]]
 )
 
 # Example 3: Using only prompt assets
 benchmark = client.mri.create_new_benchmark(
     name="Preference Benchmark",
     identifiers=["image_1", "image_2", "image_3"],   
-    prompt_assets=["https://example.com/asset1.jpg", "https://example.com/asset2.jpg", "https://example.com/asset3.jpg"]
+    prompt_assets=[["https://example.com/asset1.jpg"], ["https://example.com/asset2.jpg"], ["https://example.com/asset3.jpg"]]
+)
+
+# Example 4: Several assets for one prompt, e.g. a reference clip plus a start frame
+benchmark = client.mri.create_new_benchmark(
+    name="Camera Motion Benchmark",
+    identifiers=["move_forward", "pan_left"],
+    prompts=["The camera moves forward", "The camera pans left"],
+    prompt_assets=[
+        ["https://example.com/move_forward.gif", "https://example.com/interior.jpg"],
+        ["https://example.com/pan_left.gif", "https://example.com/street.jpg"]
+    ]
 )
 ```
 
 !!! note
-    Media assets are images, videos, or audio files that provide visual or auditory context for your evaluation prompts. For example when evaluating image to video models.
+    Media assets are images, videos, or audio files that provide visual or auditory context for your evaluation prompts. For example when evaluating image to video models. `prompt_assets` takes one list per prompt, the same shape as `media_contexts` on job definitions: one entry for a single asset, several to show them together. `benchmark.prompt_assets` reads them back in that same shape.
 
 ### Tagging System
 
@@ -105,7 +116,7 @@ If you have already created a benchmark and want to add new prompts and assets a
 benchmark.add_prompts(
     identifiers=["new_style"],
     prompts=["Generate artwork in this new style"],
-    prompt_assets=["https://assets.rapidata.ai/new_style_ref.jpg"],
+    prompt_assets=[["https://assets.rapidata.ai/new_style_ref.jpg"]],
     tags=[["abstract", "modern"]],
 )
 ```

--- a/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
+++ b/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
@@ -31,7 +31,7 @@ class BenchmarkPrompt:
 
     identifier: str
     prompt: str | None = None
-    prompt_asset: str | None = None
+    prompt_asset: list[str] | None = None
     tags: list[Tag] = field(default_factory=list)
     origin: Origin | None = None
 

--- a/src/rapidata/rapidata_client/benchmark/prompt_metadata.py
+++ b/src/rapidata/rapidata_client/benchmark/prompt_metadata.py
@@ -40,7 +40,7 @@ class BenchmarkPromptInfo:
     identifier: str
     prompt: str | None
     english_prompt: str | None
-    prompt_asset: str | list[str] | None
+    prompt_asset: list[str] | None
     tags: list[Tag]
     origin: Origin | None
 
@@ -67,3 +67,34 @@ def coerce_tags(tags: Sequence[str | Tag] | None) -> list[Tag]:
 def coerce_origin(origin: Origin | str | None) -> Origin | None:
     """Normalize a user-supplied origin into an ``Origin``."""
     return Origin(source=origin) if isinstance(origin, str) else origin
+
+
+def coerce_prompt_asset(asset: object) -> list[str] | None:
+    """Normalize one prompt's asset(s) to ``list[str] | None``.
+
+    A prompt's assets are a list of URLs / file paths, the same shape the job
+    definitions use for ``media_contexts``; several entries are registered as
+    one multi-asset. A bare ``str`` is still accepted for scripts written when
+    a prompt could only carry one asset and is wrapped in a single-element list.
+    """
+    if asset is None:
+        return None
+    if isinstance(asset, str):
+        if asset == "":
+            raise ValueError(
+                "A prompt asset cannot be an empty string. If not needed, set to None."
+            )
+        return [asset]
+    if isinstance(asset, list):
+        if len(asset) == 0:
+            raise ValueError(
+                "A prompt asset list cannot be empty. If not needed, set to None."
+            )
+        if any(not isinstance(item, str) or item == "" for item in asset):
+            raise ValueError(
+                "Every entry in a prompt asset list must be a non-empty string."
+            )
+        return asset
+    raise ValueError(
+        f"A prompt asset must be a list of strings or None, got {type(asset).__name__}."
+    )

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -27,6 +27,7 @@ from rapidata.rapidata_client.benchmark.prompt_metadata import (
     Origin,
     Tag,
     coerce_origin,
+    coerce_prompt_asset,
     coerce_tags,
     is_tag_list,
 )
@@ -80,7 +81,7 @@ class RapidataBenchmark:
         self._openapi_service = openapi_service
         self.__prompts: list[str | None] = []
         self.__english_prompts: list[str | None] = []
-        self.__prompt_assets: list[str | list[str] | None] = []
+        self.__prompt_assets: list[list[str] | None] = []
         self.__leaderboards: list["RapidataLeaderboard"] = []
         self.__identifiers: list[str] = []
         self.__tags: list[list[str]] = []
@@ -120,28 +121,28 @@ class RapidataBenchmark:
         return None
 
     @classmethod
-    def __extract_asset_reference(cls, asset: IAsset) -> str | list[str] | None:
-        """Resolve any asset the read API can return into its reference(s).
+    def __extract_asset_reference(cls, asset: IAsset) -> list[str] | None:
+        """Resolve any asset the read API can return into its list of references.
 
-        A multi-asset resolves to the list of its parts, mirroring the
-        `str | list[str]` shape the SDK's asset uploader takes for a single
-        versus a multi asset. Text and null assets carry no file to point at.
+        A single file asset is a one-element list and a multi-asset the list of
+        its parts: the same list-per-prompt shape `add_prompts` accepts, so what
+        is read back can be fed straight into it. Text and null assets carry no
+        file to point at.
         """
         from rapidata.api_client.models.i_asset_file_asset import IAssetFileAsset
         from rapidata.api_client.models.i_asset_multi_asset import IAssetMultiAsset
 
         instance = asset.actual_instance
         if isinstance(instance, IAssetFileAsset):
-            return cls.__extract_file_asset_reference(instance)
+            reference = cls.__extract_file_asset_reference(instance)
+            return [reference] if reference is not None else None
 
         if isinstance(instance, IAssetMultiAsset):
-            references: list[str] = []
-            for part in instance.assets:
-                reference = cls.__extract_asset_reference(part)
-                if isinstance(reference, str):
-                    references.append(reference)
-                elif reference is not None:
-                    references.extend(reference)
+            references = [
+                reference
+                for part in instance.assets
+                for reference in (cls.__extract_asset_reference(part) or [])
+            ]
             return references or None
 
         return None
@@ -149,7 +150,7 @@ class RapidataBenchmark:
     @classmethod
     def __extract_asset_url(
         cls, prompt: GetPromptsByBenchmarkEndpointOutput
-    ) -> str | list[str] | None:
+    ) -> list[str] | None:
         """Reconstruct a prompt's asset reference from the server metadata.
 
         Reads the default asset segment: the flat `prompt_assets` surface is a
@@ -237,7 +238,7 @@ class RapidataBenchmark:
     __URL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
 
     @classmethod
-    def __normalize_cached_asset(cls, asset: str | None) -> str | None:
+    def __normalize_cached_asset(cls, asset: list[str] | None) -> list[str] | None:
         """Mirror the representation a re-fetch would reconstruct for an asset.
 
         `__instantiate_prompts` rebuilds assets from server metadata: remote
@@ -246,10 +247,13 @@ class RapidataBenchmark:
         uploaded value here keeps `prompt_assets` identical before and after any
         re-fetch, so it stays idempotent as input to downstream calls.
         """
-        if asset is None or cls.__URL_SCHEME_RE.match(asset):
-            return asset
+        if asset is None:
+            return None
 
-        return os.path.basename(asset)
+        return [
+            part if cls.__URL_SCHEME_RE.match(part) else os.path.basename(part)
+            for part in asset
+        ]
 
     @property
     def identifiers(self) -> list[str]:
@@ -282,12 +286,13 @@ class RapidataBenchmark:
         return self.__english_prompts
 
     @property
-    def prompt_assets(self) -> list[str | list[str] | None]:
+    def prompt_assets(self) -> list[list[str] | None]:
         """
-        Returns the prompt assets that are registered for the benchmark.
+        Returns the prompt assets registered for the benchmark, aligned by index with `prompts`.
 
-        A prompt registered with several assets at once comes back as the list
-        of its parts.
+        Each entry is the list of assets shown with that prompt (one element for
+        a single asset, several for a multi-asset), or None if the prompt has no
+        asset. This is the same shape `add_prompts` takes.
         """
         if not self.__prompt_assets:
             self.__instantiate_prompts()
@@ -419,7 +424,7 @@ class RapidataBenchmark:
         self,
         identifiers: Optional[list[str]] = None,
         prompts: Optional[list[str | None] | list[str]] = None,
-        prompt_assets: Optional[list[str | None] | list[str]] = None,
+        prompt_assets: Optional[list[list[str] | None] | list[list[str]]] = None,
         tags: Optional[Sequence[Sequence[str | Tag] | None]] = None,
         origins: Optional[Sequence[Origin | str | None]] = None,
     ) -> None:
@@ -436,7 +441,7 @@ class RapidataBenchmark:
         Args:
             identifiers: The identifiers of the prompts/assets/tags that will be used to match up the media. If not provided, it will use the prompts as the identifiers.
             prompts: The prompts that will be registered for the benchmark.
-            prompt_assets: The prompt assets that will be registered for the benchmark.
+            prompt_assets: The assets per prompt, matching the `media_contexts` shape of the job definitions. Each entry is a list of image / video / audio URLs or file paths shown alongside that prompt (several entries are registered as one multi-asset), or None for no asset.
             tags: The tags per prompt, used to filter and organize the leaderboard results. They are NOT shown to the users. Each entry is a list of plain strings, a list of :class:`Tag` (a `value` plus an optional `category`), or a mix of both — strings are converted to `Tag(value, category=None)` internally. None means no tags for that prompt.
             origins: The origin of each prompt (e.g. a source dataset). Each entry is a plain string (converted to `Origin(source)`), an :class:`Origin`, or None.
 
@@ -446,7 +451,11 @@ class RapidataBenchmark:
             benchmark.add_prompts(
                 identifiers=["id1", "id2"],
                 prompts=["prompt 1", "prompt 2"],
-                prompt_assets=["https://assets.rapidata.ai/prompt_1.jpg", "https://assets.rapidata.ai/prompt_2.jpg"],
+                prompt_assets=[
+                    ["https://assets.rapidata.ai/prompt_1.jpg"],
+                    # Several assets for one prompt, e.g. a reference clip plus a still.
+                    ["https://assets.rapidata.ai/prompt_2.gif", "https://assets.rapidata.ai/prompt_2.jpg"],
+                ],
                 tags=[["landscape", "outdoor"], ["portrait"]],
                 origins=["coco", "coco"],
             )
@@ -470,13 +479,17 @@ class RapidataBenchmark:
             ):
                 raise ValueError("Prompts must be a list of strings or None.")
 
-            if prompt_assets and (
-                not isinstance(prompt_assets, list)
-                or not all(
-                    isinstance(asset, str) or asset is None for asset in prompt_assets
-                )
-            ):
-                raise ValueError("Media assets must be a list of strings or None.")
+            if prompt_assets:
+                if not isinstance(prompt_assets, list):
+                    raise ValueError(
+                        "Prompt assets must be a list with one entry per prompt, each a list of strings or None."
+                    )
+                if any(isinstance(asset, str) for asset in prompt_assets):
+                    logger.warning(
+                        "Passing a string as a prompt asset is deprecated; pass a list of strings per prompt instead. "
+                        "Wrapping each string in a single-element list."
+                    )
+                prompt_assets = [coerce_prompt_asset(asset) for asset in prompt_assets]
 
             if identifiers and (
                 not isinstance(identifiers, list)
@@ -538,7 +551,7 @@ class RapidataBenchmark:
                 prompts = cast(list[str | None], [None] * expected_length)
 
             if not prompt_assets:
-                prompt_assets = cast(list[str | None], [None] * expected_length)
+                prompt_assets = cast(list[list[str] | None], [None] * expected_length)
 
             if not tags:
                 tags = cast(

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark_manager.py
@@ -28,7 +28,7 @@ class RapidataBenchmarkManager:
         name: str,
         identifiers: Optional[list[str]] = None,
         prompts: Optional[list[str | None] | list[str]] = None,
-        prompt_assets: Optional[list[str | None] | list[str]] = None,
+        prompt_assets: Optional[list[list[str] | None] | list[list[str]]] = None,
         tags: Optional[Sequence[Sequence[str | Tag] | None]] = None,
         origins: Optional[Sequence[Origin | str | None]] = None,
     ) -> RapidataBenchmark:
@@ -42,7 +42,7 @@ class RapidataBenchmarkManager:
             name: The name of the benchmark.
             identifiers: The identifiers of the prompts/assets/tags that will be used to match up the media. If not provided, it will use the prompts as the identifiers.
             prompts: The prompts that will be registered for the benchmark.
-            prompt_assets: The prompt assets that will be registered for the benchmark.
+            prompt_assets: The assets per prompt, matching the `media_contexts` shape of the job definitions. Each entry is a list of image / video / audio URLs or file paths shown alongside that prompt (several entries are registered as one multi-asset), or None for no asset.
             tags: The tags per prompt, used to filter and organize the leaderboard results. They are NOT shown to the users. Each entry is a list of plain strings, a list of :class:`Tag` (a `value` plus an optional `category`), or a mix of both — strings are converted to `Tag(value, category=None)` internally. None means no tags for that prompt.
             origins: The origin of each prompt (e.g. a source dataset). Each entry is a plain string (converted to `Origin(source)`), an :class:`Origin`, or None.
 
@@ -51,7 +51,7 @@ class RapidataBenchmarkManager:
             name = "Example Benchmark"
             identifiers = ["id1", "id2", "id3"]
             prompts = ["prompt 1", "prompt 2", "prompt 3"]
-            prompt_assets = ["https://assets.rapidata.ai/prompt_1.jpg", "https://assets.rapidata.ai/prompt_2.jpg", "https://assets.rapidata.ai/prompt_3.jpg"]
+            prompt_assets = [["https://assets.rapidata.ai/prompt_1.jpg"], ["https://assets.rapidata.ai/prompt_2.jpg"], ["https://assets.rapidata.ai/prompt_3.jpg"]]
             tags = [["tag1", "tag2"], ["tag2"], ["tag2", "tag3"]]
 
             benchmark = create_new_benchmark(name=name, identifiers=identifiers, prompts=prompts, prompt_assets=prompt_assets, tags=tags)

--- a/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
+++ b/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
@@ -128,9 +128,10 @@ def _make_benchmark(prompts: list[dict]) -> RapidataBenchmark:
 @pytest.mark.parametrize(
     "asset,expected",
     [
-        (_FILE_ASSET, "8.jpg"),
+        # A single asset is a one-element list: the same shape `add_prompts` takes.
+        (_FILE_ASSET, ["8.jpg"]),
         # A remote asset keeps its URL; the filename is only the fallback.
-        (_REMOTE_FILE_ASSET, "https://assets.rapidata.ai/prompt_1.jpg"),
+        (_REMOTE_FILE_ASSET, ["https://assets.rapidata.ai/prompt_1.jpg"]),
         (_MULTI_ASSET, ["camera-moves-forward.gif", "interior-2685521.jpg"]),
         (_NULL_ASSET, None),
         (_TEXT_ASSET, None),

--- a/tests/rapidata_client/benchmark/test_prompt_assets_write.py
+++ b/tests/rapidata_client/benchmark/test_prompt_assets_write.py
@@ -1,0 +1,174 @@
+"""Tests for the assets a benchmark prompt is registered with.
+
+A prompt's assets are a ``list[str]`` per prompt, the same shape the job
+definitions take for ``media_contexts`` and the same shape ``prompt_assets``
+reads back, so a value read from one benchmark can be fed straight into
+``add_prompts`` on another. Scripts written when a prompt could only carry a
+single asset pass a bare ``str`` per prompt; those keep working.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rapidata.api_client.models.i_asset_input_existing_asset_input import (
+    IAssetInputExistingAssetInput,
+)
+from rapidata.api_client.models.i_asset_input_multi_asset_input import (
+    IAssetInputMultiAssetInput,
+)
+from rapidata.rapidata_client.benchmark._prompt_uploader import (
+    BenchmarkPrompt,
+    BenchmarkPromptUploader,
+)
+from rapidata.rapidata_client.benchmark.prompt_metadata import (
+    DEFAULT_ASSET_SEGMENT_KEY,
+)
+from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
+
+
+def _make_benchmark() -> tuple[RapidataBenchmark, list[list[BenchmarkPrompt]]]:
+    svc = MagicMock()
+    svc.environment = "rapidata.ai"
+    benchmark = RapidataBenchmark("bm", "bm-1", svc)
+
+    uploaded: list[list[BenchmarkPrompt]] = []
+
+    def upload_many(prompts: list[BenchmarkPrompt]) -> list[BenchmarkPrompt]:
+        uploaded.append(prompts)
+        return prompts
+
+    benchmark._prompt_uploader.upload_many = upload_many  # type: ignore[method-assign]
+    return benchmark, uploaded
+
+
+def _add_prompts(benchmark: RapidataBenchmark, prompt_assets) -> None:
+    # `identifiers` re-fetches over HTTP while the cache is empty; an empty
+    # benchmark is all these cases need.
+    with patch.object(RapidataBenchmark, "identifiers", property(lambda self: [])):
+        benchmark.add_prompts(
+            identifiers=[f"id{i}" for i in range(len(prompt_assets))],
+            prompt_assets=prompt_assets,
+        )
+
+
+def test_add_prompts_takes_a_list_of_assets_per_prompt() -> None:
+    benchmark, uploaded = _make_benchmark()
+
+    _add_prompts(
+        benchmark,
+        [
+            ["https://assets.rapidata.ai/a.jpg"],
+            ["https://assets.rapidata.ai/ref.gif", "https://assets.rapidata.ai/b.jpg"],
+            None,
+        ],
+    )
+
+    assert [p.prompt_asset for p in uploaded[0]] == [
+        ["https://assets.rapidata.ai/a.jpg"],
+        ["https://assets.rapidata.ai/ref.gif", "https://assets.rapidata.ai/b.jpg"],
+        None,
+    ]
+    assert benchmark.prompt_assets == [
+        ["https://assets.rapidata.ai/a.jpg"],
+        ["https://assets.rapidata.ai/ref.gif", "https://assets.rapidata.ai/b.jpg"],
+        None,
+    ]
+
+
+def test_add_prompts_still_accepts_one_string_per_prompt(caplog) -> None:
+    benchmark, uploaded = _make_benchmark()
+
+    with caplog.at_level(logging.WARNING, logger="rapidata"):
+        _add_prompts(benchmark, ["https://assets.rapidata.ai/a.jpg", None])
+
+    assert [p.prompt_asset for p in uploaded[0]] == [
+        ["https://assets.rapidata.ai/a.jpg"],
+        None,
+    ]
+    # One notice per call, not one per prompt.
+    deprecations = [r for r in caplog.records if "deprecated" in r.getMessage()]
+    assert len(deprecations) == 1
+
+
+def test_cached_assets_match_what_a_refetch_reads_back() -> None:
+    # Locally uploaded files come back from the server as their bare filename,
+    # so the cache holds the same value the read side would reconstruct.
+    benchmark, _ = _make_benchmark()
+
+    _add_prompts(
+        benchmark,
+        [["/data/frames/ref.gif", "https://assets.rapidata.ai/still.jpg"]],
+    )
+
+    assert benchmark.prompt_assets == [
+        ["ref.gif", "https://assets.rapidata.ai/still.jpg"]
+    ]
+
+
+@pytest.mark.parametrize(
+    "prompt_assets",
+    [
+        [[]],
+        [[""]],
+        [""],
+        [["a.jpg", 3]],
+        [42],
+        "a.jpg",
+    ],
+)
+def test_add_prompts_rejects_malformed_assets(prompt_assets) -> None:
+    benchmark, _ = _make_benchmark()
+
+    with pytest.raises(ValueError):
+        _add_prompts(benchmark, prompt_assets)
+
+
+def _make_uploader() -> tuple[BenchmarkPromptUploader, MagicMock]:
+    svc = MagicMock()
+    uploader = BenchmarkPromptUploader("bm-1", svc)
+    uploader._asset_uploader.upload_asset = MagicMock(side_effect=lambda a: f"up:{a}")  # type: ignore[method-assign]
+    return uploader, svc.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post
+
+
+def _sent_asset(post: MagicMock):
+    """The asset carried by the default asset segment, or None if no segment was sent."""
+    payload = post.call_args.kwargs["create_prompt_for_benchmark_endpoint_input"]
+    segment = next(
+        (s for s in payload.segments if s.key == DEFAULT_ASSET_SEGMENT_KEY), None
+    )
+    return segment.asset if segment is not None else None
+
+
+def test_single_asset_is_sent_as_an_existing_asset() -> None:
+    uploader, post = _make_uploader()
+
+    uploader.upload(BenchmarkPrompt("id0", "p0", ["a.jpg"]))
+
+    sent = _sent_asset(post).actual_instance
+    assert isinstance(sent, IAssetInputExistingAssetInput)
+    assert sent.name == "up:a.jpg"
+
+
+def test_several_assets_are_sent_as_one_multi_asset() -> None:
+    uploader, post = _make_uploader()
+
+    uploader.upload(BenchmarkPrompt("id0", "p0", ["ref.gif", "still.jpg"]))
+
+    sent = _sent_asset(post).actual_instance
+    assert isinstance(sent, IAssetInputMultiAssetInput)
+    assert [part.actual_instance.name for part in sent.assets] == [
+        "up:ref.gif",
+        "up:still.jpg",
+    ]
+
+
+def test_no_asset_sends_none() -> None:
+    uploader, post = _make_uploader()
+
+    uploader.upload(BenchmarkPrompt("id0", "p0", None))
+
+    assert _sent_asset(post) is None

--- a/tests/rapidata_client/benchmark/test_prompt_segment_upload.py
+++ b/tests/rapidata_client/benchmark/test_prompt_segment_upload.py
@@ -29,7 +29,7 @@ def _upload(prompt: BenchmarkPrompt):
     uploader._asset_uploader.upload_and_map_asset.side_effect = (
         lambda asset: IAssetInput(
             actual_instance=IAssetInputExistingAssetInput(
-                _t="ExistingAssetInput", name=f"mapped:{asset}"
+                _t="ExistingAssetInput", name=f"mapped:{','.join(asset)}"
             )
         )
     )
@@ -48,7 +48,7 @@ def test_text_and_asset_map_to_the_default_segment_keys() -> None:
         BenchmarkPrompt(
             identifier="id0",
             prompt="a red car",
-            prompt_asset="https://assets.rapidata.ai/ref.jpg",
+            prompt_asset=["https://assets.rapidata.ai/ref.jpg"],
             tags=[Tag("scene", "kind")],
             origin=Origin("coco"),
         )
@@ -74,7 +74,7 @@ def test_missing_values_send_no_segment() -> None:
 def test_asset_only_prompt_sends_only_the_asset_segment() -> None:
     payload = _upload(
         BenchmarkPrompt(
-            identifier="id0", prompt_asset="https://assets.rapidata.ai/a.jpg"
+            identifier="id0", prompt_asset=["https://assets.rapidata.ai/a.jpg"]
         )
     )
 


### PR DESCRIPTION
## Problem

#858 made `benchmark.prompt_assets` return `str | list[str] | None` per prompt: a bare string for a single asset, a list for a multi-asset. That is a shape nothing else in the SDK uses, and it left the two sides of the benchmark API out of sync with each other and with the job definitions:

| surface | per-prompt / per-datapoint asset shape (before) |
| --- | --- |
| `benchmark.prompt_assets` (read) | `str \| list[str] \| None` |
| `add_prompts(prompt_assets=…)` / `create_new_benchmark` (write) | `str \| None` — no way to register a multi-asset |
| `create_*_job_definition(media_contexts=…)` | `list[str]` |

So a multi-asset read back from one benchmark could not be passed into `add_prompts` on another, and callers had to `isinstance` every entry.

## Fix

One shape everywhere: **a `list[str]` per prompt**, exactly like `media_contexts` on the job definitions. `None` still means "no asset".

| surface | after |
| --- | --- |
| `benchmark.prompt_assets` / `BenchmarkPromptInfo.prompt_asset` | `list[str] \| None` — a single asset is a one-element list, a multi-asset the list of its parts |
| `add_prompts(prompt_assets=…)` / `create_new_benchmark` | `list[list[str] \| None]` — several entries for one prompt are uploaded as one `MultiAssetInput` |

On the wire this rides on the prompt-segment path #864 introduced: the `prompt_asset` segment's asset is built by `AssetUploader.upload_and_map_asset`, the same helper the datapoint and media-context uploads use, so a one-element list produces the identical `ExistingAssetInput` shape as before and a longer list a `MultiAssetInput`. This PR is rebased on #864 and only changes the types and validation around that path. Read and write are round-trippable: `other.add_prompts(identifiers=b.identifiers, prompt_assets=b.prompt_assets)` works for every benchmark.

### Backwards compatibility

The typed surface is strict (`list[list[str] | None]`), but a bare `str` per prompt still works at runtime: it is wrapped in a one-element list with a single deprecation warning per call. This is the same soft landing `media_context` got when it moved from `str` to `list[str]` (`coerce_media_context`), so existing notebooks passing `prompt_assets=["a.jpg", "b.jpg"]` keep running. If you would rather drop the shim and make it a hard `ValueError`, it is the `isinstance(asset, str)` branch in `coerce_prompt_asset`.

The read side does change for callers of `prompt_assets`: a single file asset now comes back as `["8.jpg"]` instead of `"8.jpg"`. Before #858 the property raised on every asset-carrying benchmark, and #858 shipped in 3.22.4 earlier today, so the window in which anyone could have relied on the bare-string form is a few hours.

## Docs

`docs/mri_advanced.md` examples moved to the list-per-prompt shape and gained a multi-asset example (reference clip + start frame). Docstrings on `add_prompts` / `create_new_benchmark` describe the shape and point at `media_contexts`.

## Tests

- `test_prompt_asset_extraction.py`: read-side expectations updated to one-element lists; multi / null / text / none unchanged.
- `test_prompt_assets_write.py` (new): list-per-prompt passes through `add_prompts` and is cached in the read shape; a bare `str` still works with exactly one warning per call; local paths are normalised per element; malformed entries (`[]`, `""`, non-str, non-list) raise; the uploader sends one part as `ExistingAssetInput`, several as `MultiAssetInput`, none as `null`.

`uv run pytest`: 176 passed (rebased on #864; its three segment-payload tests now pass a `list[str]` asset). The 4 failures in `tests/rapidata_client/audience/` are pre-existing on `main` (re-confirmed with the change stashed) and untouched here. `pyright src/rapidata/rapidata_client`: 0 errors. `black`: clean.

---

🔗 Session: [poseidon.rapidata.internal/chat/cli-karl-77149c6d](https://poseidon.rapidata.internal/chat/cli-karl-77149c6d)

