### PR TITLE
docs(starting-page): use global audience preference example

### DIFF
--- a/docs/js/preview-embed.js
+++ b/docs/js/preview-embed.js
@@ -20,6 +20,9 @@ function buildPreviewUrl(campaignId, refreshCount) {
         language: 'en',
         userSegment: '0',
         refreshCount: String(refreshCount),
+        // Serve only the labeling task; without this the audience's validation
+        // examples come first and the embed shows an unrelated question.
+        isBulkLabelingPreview: 'true',
     });
     return `${RAPIDS_ORIGIN}/preview/campaign?${params.toString()}`;
 }

--- a/docs/starting_page.md
+++ b/docs/starting_page.md
@@ -18,12 +18,11 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
 
     client = RapidataClient()
 
-    audience = client.audience.get_audience_by_id("aud_MU1GZYoESyO")
+    audience = client.audience.get_audience_by_id("global")
 
     job_definition = client.job.create_compare_job_definition(
-        name="Example Image Comparison",
-        instruction="Which image matches the description better?",
-        contexts=["A small blue book sitting on a large red book."],
+        name="Example Image Preference",
+        instruction="Which image do you prefer?",
         datapoints=[["https://assets.rapidata.ai/midjourney-5.2_37_3.jpg",
                     "https://assets.rapidata.ai/flux-1-pro_37_0.jpg"]],
     )
@@ -107,14 +106,14 @@ The SDK has three building blocks: **audiences** (who labels), **job definitions
     The curated/global audiences get you started quickly. For higher quality results, use a [custom audience](audiences.md) with qualification examples.
 
 <div data-preview-embed
-     data-preview-map='{"Image":"cmp_1HSFCph25U1J22","Video":"cmp_1HSMbDk5EaUExL","Audio":"cmp_1HSMsM9Ph3Sn5o","Text":"cmp_1HSN6NhgMo4C9R"}'>
+     data-preview-map='{"Image":"cmp_1UTcmTsojyXmuz","Video":"cmp_1HSMbDk5EaUExL","Audio":"cmp_1HSMsM9Ph3Sn5o","Text":"cmp_1HSN6NhgMo4C9R"}'>
   <div class="phone-preview">
     <div class="phone-preview__notch"></div>
     <div class="phone-preview__btn phone-preview__btn--left-top"></div>
     <div class="phone-preview__btn phone-preview__btn--left-bot"></div>
     <div class="phone-preview__btn phone-preview__btn--right"></div>
     <iframe class="phone-preview__iframe"
-            src="https://rapids.rapidata.ai/preview/campaign?id=cmp_1HSFCph25U1J22&language=en&userSegment=0&refreshCount=0"
+            src="https://rapids.rapidata.ai/preview/campaign?id=cmp_1UTcmTsojyXmuz&language=en&userSegment=0&refreshCount=0&isBulkLabelingPreview=true"
             allow="clipboard-write"
             title="Live Rapidata campaign preview"></iframe>
   </div>


### PR DESCRIPTION
## What

Replace the Image tab example on the docs starting page with a preference job on the `global` audience, and point the live phone preview at the new job's preview campaign.

```python
audience = client.audience.get_audience_by_id("global")

job_definition = client.job.create_compare_job_definition(
    name="Example Image Preference",
    instruction="Which image do you prefer?",
    datapoints=[["https://assets.rapidata.ai/midjourney-5.2_37_3.jpg",
                 "https://assets.rapidata.ai/flux-1-pro_37_0.jpg"]],
)
```

## Why

The first example a reader runs used the curated Alignment audience, which only accepts annotators graduated in that audience on top of the global one. Measured today on the same datapoint with 10 responses:

| Audience | Priority | Labeling time | Sessions routed |
|---|---|---|---|
| Alignment | 400 | 131 s | 22 |
| global | 50 | 52 s | 26 |

Historic runs of the old example: median 1.1 min, p90 3.2 min, 13 to 18 min between 01:00 and 07:00 UTC. The audience gate was the largest single factor. Preference also needs no `contexts`, so the snippet is shorter.

## Preview embed

`data-preview-map` Image now points at `cmp_1UTcmTsojyXmuz`, the preview campaign of the new definition. Preview campaigns created from job definitions include the audience's validation tiers, so the embed opened on a validation example ("Which object is on its side?") instead of the task. `isBulkLabelingPreview=true` makes the rapids preview serve only labeling rapids. Verified with headless Chromium across two fresh sessions. The other embedded preview campaigns (Video, Audio, Text, examples index, quickstart) are labeling-only, so the flag does not change them.

## Not in this PR

- `docs/quickstart.md` still shows the alignment example and embeds the old preview campaign.
- The Video tab still uses the Alignment audience with a context.
- The new preview campaign is owned by the Poseidon service account rather than a team member.

`docs` built locally with `uv run --group docs mkdocs build`.

🔗 Session: [https://poseidon.rapidata.internal/chat/session-995e269d](https://poseidon.rapidata.internal/chat/session-995e269d)
