### PR TITLE
feat(benchmark): set a participant's price for the score-vs-cost chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ As a customer you can use the RapidataClient class to access the following:
 - AudienceCreation (including filtered audiences via `.filter()` for country/language/demographic targeting)
 - ValidationSetCreation
 - FlowCreation
-- BenchmarkCreation / MRI Creation
+- BenchmarkCreation / MRI Creation (including participant metadata such as `participant.rename()` and `participant.set_price()` for the score-vs-cost chart)
 
 Orders were removed from the SDK entirely (v3.21.0) — do not add, document, or reference order creation.
 

--- a/docs/mri.md
+++ b/docs/mri.md
@@ -152,6 +152,43 @@ participant.run()
 benchmark.run()
 ```
 
+### Update participant metadata
+
+A participant's metadata can be changed after it has been added, independently
+of uploading media or submitting it for evaluation. Any participant works —
+one returned by `add_model` or one taken from `benchmark.participants`.
+
+```python
+participant = benchmark.participants[0]
+
+participant.rename("MyAIModel_v2.2")
+```
+
+#### Price
+
+A model's price places it on the benchmark's "Score vs. cost" chart. The chart
+only shows priced models, and only those quoted in the unit most models in the
+benchmark use — unpriced models stay on the leaderboard but are hidden from the
+chart.
+
+Prices are in USD per one of three units:
+
+| `unit`             | Meaning                       |
+| ------------------ | ----------------------------- |
+| `"image"`          | USD per generated image       |
+| `"video_second"`   | USD per second of video       |
+| `"million_tokens"` | USD per million tokens        |
+
+```python
+participant.set_price(0.04, "image")
+
+print(participant.price, participant.price_unit)  # 0.04 image
+
+participant.clear_price()  # hides the model from the chart again
+```
+
+`price` and `price_unit` are `None` for models without a price.
+
 ### 3c. Recovering a Partial Upload
 
 Large uploads over a slow or flaky connection can leave individual samples

--- a/docs/mri_advanced.md
+++ b/docs/mri_advanced.md
@@ -302,8 +302,11 @@ You can list all participants in a benchmark using the `participants` property:
 
 ```python
 for participant in benchmark.participants:
-    print(f"{participant.name} - {participant.status}")
+    print(f"{participant.name} - {participant.status} - {participant.price} per {participant.price_unit}")
 ```
+
+`price` and `price_unit` are `None` for models without a price. See
+[Update participant metadata](mri.md#update-participant-metadata) for how to set them.
 
 ### Submitting Participants
 

--- a/src/rapidata/rapidata_client/benchmark/participant/_pricing.py
+++ b/src/rapidata/rapidata_client/benchmark/participant/_pricing.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import math
+from typing import Literal, get_args
+
+from rapidata.api_client.models.cost_unit import CostUnit
+
+PriceUnit = Literal["image", "video_second", "million_tokens"]
+"""The unit a participant's price is quoted in, always in USD."""
+
+_UNIT_TO_COST_UNIT: dict[PriceUnit, CostUnit] = {
+    "image": CostUnit.USDPERIMAGE,
+    "video_second": CostUnit.USDPERVIDEOSECOND,
+    "million_tokens": CostUnit.USDPERMILLIONTOKENS,
+}
+
+_COST_UNIT_TO_UNIT: dict[CostUnit, PriceUnit] = {
+    cost_unit: unit for unit, cost_unit in _UNIT_TO_COST_UNIT.items()
+}
+
+
+def validate_price(price: float, unit: PriceUnit) -> tuple[float, CostUnit]:
+    """Checks a price/unit pair and returns it in the backend's representation.
+
+    Raises:
+        ValueError: If the price is not a finite number greater than zero or the
+            unit is not one of :data:`PriceUnit`.
+    """
+    # bool is an int subclass, so `True` would otherwise pass as a price of 1.
+    if isinstance(price, bool) or not isinstance(price, (int, float)):
+        raise ValueError("price must be a number")
+    if not math.isfinite(price) or price <= 0:
+        raise ValueError("price must be a finite number greater than 0")
+
+    cost_unit = _UNIT_TO_COST_UNIT.get(unit)
+    if cost_unit is None:
+        allowed = ", ".join(repr(u) for u in get_args(PriceUnit))
+        raise ValueError(f"unit must be one of {allowed}, got {unit!r}")
+
+    return float(price), cost_unit
+
+
+def to_price_unit(cost_unit: CostUnit | None) -> PriceUnit | None:
+    """Maps the backend's cost unit back to the SDK's unit name."""
+    if cost_unit is None:
+        return None
+    return _COST_UNIT_TO_UNIT[CostUnit(cost_unit)]

--- a/src/rapidata/rapidata_client/benchmark/participant/participant.py
+++ b/src/rapidata/rapidata_client/benchmark/participant/participant.py
@@ -16,6 +16,11 @@ from rapidata.rapidata_client.api.rapidata_api_client import (
 from opentelemetry import context as otel_context
 from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 from rapidata.rapidata_client.benchmark.participant.sample_upload import SampleUpload
+from rapidata.rapidata_client.benchmark.participant._pricing import (
+    PriceUnit,
+    to_price_unit,
+    validate_price,
+)
 from rapidata.rapidata_client.exceptions.failed_upload import FailedUpload
 from rapidata.rapidata_client.exceptions.rapidata_error import RapidataError
 
@@ -44,6 +49,8 @@ class BenchmarkParticipant:
         openapi_service: The OpenAPI service for API communication.
         benchmark_id: The id of the benchmark the participant belongs to.
         status: The current status of the participant.
+        price: The model's price in USD per ``price_unit``, or ``None`` if unpriced.
+        price_unit: The unit the price is quoted in, or ``None`` if unpriced.
     """
 
     def __init__(
@@ -53,6 +60,8 @@ class BenchmarkParticipant:
         openapi_service: OpenAPIService,
         benchmark_id: str,
         status: ParticipantStatus = ParticipantStatus.CREATED,
+        price: float | None = None,
+        price_unit: PriceUnit | None = None,
     ):
         self.name = name
         self.id = id
@@ -60,6 +69,8 @@ class BenchmarkParticipant:
         self._benchmark_id = benchmark_id
         self._asset_uploader = AssetUploader(openapi_service)
         self._status = status
+        self.price: float | None = price
+        self.price_unit: PriceUnit | None = price_unit
 
     @property
     def status(self) -> ParticipantStatus:
@@ -191,6 +202,57 @@ class BenchmarkParticipant:
                 ),
             )
             self.name = name
+
+    def set_price(self, price: float, unit: PriceUnit) -> None:
+        """Sets the model's price so it appears on the benchmark's score-vs-cost chart.
+
+        Only priced participants are shown on that chart, and only those quoted
+        in the unit most participants of the benchmark use.
+
+        Args:
+            price: The price in USD per ``unit``. Must be a finite number greater than 0.
+            unit: What the price is per — ``"image"``, ``"video_second"`` or
+                ``"million_tokens"``.
+
+        Raises:
+            ValueError: If the price or unit is invalid.
+        """
+        from rapidata.api_client.models.update_participant_endpoint_input import (
+            UpdateParticipantEndpointInput,
+        )
+
+        cost, cost_unit = validate_price(price, unit)
+
+        with tracer.start_as_current_span("BenchmarkParticipant.set_price"):
+            self._openapi_service.leaderboard.participant_api.participant_participant_id_patch(
+                participant_id=self.id,
+                update_participant_endpoint_input=UpdateParticipantEndpointInput(
+                    cost=cost,
+                    costUnit=cost_unit,
+                ),
+            )
+            self.price = cost
+            self.price_unit = unit
+
+    def clear_price(self) -> None:
+        """Removes the model's price, hiding it from the score-vs-cost chart."""
+        from rapidata.api_client.models.update_participant_endpoint_input import (
+            UpdateParticipantEndpointInput,
+        )
+
+        with tracer.start_as_current_span("BenchmarkParticipant.clear_price"):
+            # Both fields must be set explicitly: the generated model only
+            # serialises a null for fields that were assigned, and an omitted
+            # field means "leave unchanged" to the PATCH endpoint.
+            self._openapi_service.leaderboard.participant_api.participant_participant_id_patch(
+                participant_id=self.id,
+                update_participant_endpoint_input=UpdateParticipantEndpointInput(
+                    cost=None,
+                    costUnit=None,
+                ),
+            )
+            self.price = None
+            self.price_unit = None
 
     def __str__(self) -> str:
         return f"BenchmarkParticipant(name={self.name}, id={self.id}, status={self._status})"

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -21,6 +21,7 @@ from rapidata.rapidata_client.benchmark._vote_filters import (
 from rapidata.rapidata_client.benchmark.leaderboard.vote_aggregation import (
     VoteAggregation,
 )
+from rapidata.rapidata_client.benchmark.participant._pricing import to_price_unit
 from rapidata.rapidata_client.benchmark.prompt_metadata import (
     DEFAULT_ASSET_SEGMENT_KEY,
     BenchmarkPromptInfo,
@@ -409,6 +410,8 @@ class RapidataBenchmark:
                         openapi_service=self._openapi_service,
                         benchmark_id=self.id,
                         status=p.status,
+                        price=p.cost,
+                        price_unit=to_price_unit(p.cost_unit),
                     )
                     for p in result.items
                 ]

--- a/tests/rapidata_client/benchmark/test_participant_price.py
+++ b/tests/rapidata_client/benchmark/test_participant_price.py
@@ -1,0 +1,141 @@
+"""Tests for participant pricing.
+
+A priced participant appears on the benchmark's score-vs-cost chart. The price
+is set on an existing participant through ``PATCH /participant/{id}`` with
+``cost`` and ``costUnit``; clearing requires both fields to be sent as explicit
+nulls, because an omitted field means "leave unchanged".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rapidata.api_client.models.cost_unit import CostUnit
+from rapidata.api_client.models.participant_status import ParticipantStatus
+from rapidata.rapidata_client.benchmark.participant.participant import (
+    BenchmarkParticipant,
+)
+from rapidata.rapidata_client.benchmark.rapidata_benchmark import RapidataBenchmark
+
+
+def _make_participant() -> BenchmarkParticipant:
+    return BenchmarkParticipant(
+        name="model-a",
+        id="p-0",
+        openapi_service=MagicMock(),
+        benchmark_id="bm-1",
+    )
+
+
+def _make_benchmark() -> RapidataBenchmark:
+    svc = MagicMock()
+    svc.environment = "rapidata.ai"
+    return RapidataBenchmark("bm", "bm-1", svc)
+
+
+def _patch_payload(participant: BenchmarkParticipant):
+    patch = (
+        participant._openapi_service.leaderboard.participant_api.participant_participant_id_patch
+    )
+    patch.assert_called_once()
+    assert patch.call_args.kwargs["participant_id"] == "p-0"
+    return patch.call_args.kwargs["update_participant_endpoint_input"]
+
+
+@pytest.mark.parametrize(
+    ("unit", "cost_unit"),
+    [
+        ("image", CostUnit.USDPERIMAGE),
+        ("video_second", CostUnit.USDPERVIDEOSECOND),
+        ("million_tokens", CostUnit.USDPERMILLIONTOKENS),
+    ],
+)
+def test_set_price_maps_unit_and_patches_cost(unit, cost_unit) -> None:
+    participant = _make_participant()
+
+    participant.set_price(0.04, unit)
+
+    payload = _patch_payload(participant)
+    assert payload.cost == 0.04
+    assert payload.cost_unit == cost_unit
+    # Only the price fields travel; an omitted field leaves e.g. the name untouched.
+    assert payload.to_dict() == {"cost": 0.04, "costUnit": cost_unit.value}
+    assert participant.price == 0.04
+    assert participant.price_unit == unit
+
+
+def test_set_price_accepts_int_and_stores_float() -> None:
+    participant = _make_participant()
+
+    participant.set_price(3, "million_tokens")
+
+    assert _patch_payload(participant).cost == 3.0
+    assert participant.price == 3.0
+
+
+@pytest.mark.parametrize(
+    "price", [0, -1.5, True, float("nan"), float("inf"), "0.04", None]
+)
+def test_set_price_rejects_invalid_price(price) -> None:
+    participant = _make_participant()
+
+    with pytest.raises(ValueError):
+        participant.set_price(price, "image")
+
+    participant._openapi_service.leaderboard.participant_api.participant_participant_id_patch.assert_not_called()
+    assert participant.price is None
+
+
+@pytest.mark.parametrize("unit", ["images", "UsdPerImage", "token", "", None])
+def test_set_price_rejects_unknown_unit(unit) -> None:
+    participant = _make_participant()
+
+    with pytest.raises(ValueError):
+        participant.set_price(0.04, unit)
+
+    participant._openapi_service.leaderboard.participant_api.participant_participant_id_patch.assert_not_called()
+
+
+def test_clear_price_sends_explicit_nulls() -> None:
+    participant = BenchmarkParticipant(
+        name="model-a",
+        id="p-0",
+        openapi_service=MagicMock(),
+        benchmark_id="bm-1",
+        price=0.04,
+        price_unit="image",
+    )
+
+    participant.clear_price()
+
+    payload = _patch_payload(participant)
+    assert payload.cost is None
+    assert payload.cost_unit is None
+    assert payload.to_dict() == {"cost": None, "costUnit": None}
+    assert participant.price is None
+    assert participant.price_unit is None
+
+
+def test_participants_expose_price_from_backend() -> None:
+    benchmark = _make_benchmark()
+    item = MagicMock()
+    item.name, item.id, item.status = "model-a", "p-0", ParticipantStatus.SUBMITTED
+    item.cost, item.cost_unit = 2.5, CostUnit.USDPERMILLIONTOKENS
+    unpriced = MagicMock()
+    unpriced.name, unpriced.id, unpriced.status = (
+        "model-b",
+        "p-1",
+        ParticipantStatus.CREATED,
+    )
+    unpriced.cost, unpriced.cost_unit = None, None
+    benchmark._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_participants_get.return_value.items = [
+        item,
+        unpriced,
+    ]
+
+    priced, without = benchmark.participants
+
+    assert (priced.price, priced.price_unit) == (2.5, "million_tokens")
+    assert (without.price, without.price_unit) == (None, None)


### PR DESCRIPTION
## What

Lets SDK users set a benchmark participant's price so it appears on the benchmark's "Score vs. cost" chart. The backend already accepts `cost` + `costUnit` on the participant create and PATCH endpoints; this PR only adds the SDK surface.

- `BenchmarkParticipant.set_price(price: float, unit: Literal["image", "video_second", "million_tokens"]) -> None` — PATCHes `cost` + `costUnit` only, updates the cached attributes.
- `BenchmarkParticipant.clear_price() -> None` — PATCHes both fields as explicit nulls (the generated pydantic model only serialises a null for fields that were assigned; omitted means "unchanged").
- `participant.price: float | None` and `participant.price_unit: Literal[...] | None`, populated from `benchmark.participants`. Constructor stays backwards compatible (new keyword params default to `None`).
- `add_model` / `evaluate_model` are unchanged. Pricing is participant-level metadata set after the participant exists, per review: adding a model and describing it are separate concerns.
- One private helper (`benchmark/participant/_pricing.py`) owns the unit mapping (`image → UsdPerImage`, `video_second → UsdPerVideoSecond`, `million_tokens → UsdPerMillionTokens`) and validation (finite number > 0, `bool` rejected, unit must be one of the three).

No client regeneration was needed: the list / get / patch models on `main` already carry `cost` and `costUnit`.

## Docs

- `docs/mri.md`: new "Update participant metadata" subsection between 3b and 3c — `rename`, then a Price part: what the price is for, the three units, `set_price` / `clear_price` / `price` read-back example, note that unpriced models are hidden from the chart.
- `docs/mri_advanced.md`: participants listing shows `price` / `price_unit`.
- `CLAUDE.md`: capability mentioned in the list.

## Tests

`tests/rapidata_client/benchmark/test_participant_price.py` (18 cases): unit mapping for all three units, validation errors for price and unit, `clear_price` sends `{"cost": null, "costUnit": null}`, `participants` reads cost back.

## Verification

- `uv run pytest tests` — the 18 new tests pass. 4 pre-existing failures in `tests/rapidata_client/audience` fail identically on `main`.
- `pyright src/rapidata/rapidata_client` — clean after rebasing onto `main` with #864; the `type-check` job is green.
- `black` run on the touched files only; it wanted to reformat 14 unrelated files on `main`, which were left alone to keep this PR focused.

## Out of scope

No faucet changes, no backend changes, no automatic price lookup. The price is whatever the caller passes; "USD per million tokens" is documented as the unit without prescribing how to blend input/output token prices.

## Related

- Docs PR in the skills repo documenting this contract: https://github.com/RapidataAI/skills/pull/10

🔗 Session: [node-d03b9ff7](https://poseidon.rapidata.internal/chat/node-d03b9ff7)


