### PR TITLE
fix(benchmark): send prompt content as segments

### DIFF
--- a/src/rapidata/rapidata_client/benchmark/_prompt_segments.py
+++ b/src/rapidata/rapidata_client/benchmark/_prompt_segments.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+if TYPE_CHECKING:
+    from rapidata.api_client.models.i_asset import IAsset
+    from rapidata.api_client.models.prompt_segment import PromptSegment
+
+# The two keys every benchmark's prompt structure starts with, and that the
+# backend migration moved the old flat `prompt` / `promptAsset` content into.
+# They mirror `PromptSegmentKeys` in the leaderboard service — writing an
+# unknown key is a backend error, not a silently ignored field.
+DEFAULT_TEXT_SEGMENT_KEY = "prompt"
+DEFAULT_ASSET_SEGMENT_KEY = "prompt_asset"
+
+
+def find_asset_segment(
+    segments: Sequence[PromptSegment] | None,
+) -> IAsset | None:
+    """Resolve the asset a prompt's segments carry, if any.
+
+    Prefers the default key so a default-structure benchmark round-trips
+    exactly; falls back to the first asset-kind segment, which is how the
+    backend's own faucets resolve reference media on a benchmark that renamed
+    its segments.
+    """
+    from rapidata.api_client.models.prompt_segment_kind import PromptSegmentKind
+
+    if not segments:
+        return None
+
+    asset_segments = [
+        segment for segment in segments if segment.kind == PromptSegmentKind.ASSET
+    ]
+    for segment in asset_segments:
+        if segment.key == DEFAULT_ASSET_SEGMENT_KEY and segment.asset is not None:
+            return segment.asset
+
+    for segment in asset_segments:
+        if segment.asset is not None:
+            return segment.asset
+
+    return None

--- a/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
+++ b/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
@@ -9,6 +9,10 @@ from tqdm.auto import tqdm
 
 from rapidata.rapidata_client.config import logger, rapidata_config, tracer
 from rapidata.rapidata_client.benchmark.prompt_metadata import Origin, Tag
+from rapidata.rapidata_client.benchmark._prompt_segments import (
+    DEFAULT_ASSET_SEGMENT_KEY,
+    DEFAULT_TEXT_SEGMENT_KEY,
+)
 from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 
 if TYPE_CHECKING:
@@ -52,27 +56,42 @@ class BenchmarkPromptUploader:
             IAssetInputExistingAssetInput,
         )
         from rapidata.api_client.models.i_asset_input import IAssetInput
+        from rapidata.api_client.models.prompt_segment_input import PromptSegmentInput
+        from rapidata.api_client.models.prompt_segment_kind import PromptSegmentKind
 
         # Aliased: the generated wire models share their names with the
         # user-facing Tag/Origin imported at module scope.
         from rapidata.api_client.models.tag import Tag as ApiTag
         from rapidata.api_client.models.origin import Origin as ApiOrigin
 
-        self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post(
-            benchmark_id=self._benchmark_id,
-            create_prompt_for_benchmark_endpoint_input=CreatePromptForBenchmarkEndpointInput(
-                identifier=prompt.identifier,
-                prompt=prompt.prompt,
-                promptAsset=(
-                    IAssetInput(
+        segments: list[PromptSegmentInput] = []
+        if prompt.prompt is not None:
+            segments.append(
+                PromptSegmentInput(
+                    key=DEFAULT_TEXT_SEGMENT_KEY,
+                    kind=PromptSegmentKind.TEXT,
+                    text=prompt.prompt,
+                )
+            )
+        if prompt.prompt_asset is not None:
+            segments.append(
+                PromptSegmentInput(
+                    key=DEFAULT_ASSET_SEGMENT_KEY,
+                    kind=PromptSegmentKind.ASSET,
+                    asset=IAssetInput(
                         actual_instance=IAssetInputExistingAssetInput(
                             _t="ExistingAssetInput",
                             name=self._asset_uploader.upload_asset(prompt.prompt_asset),
                         )
-                    )
-                    if prompt.prompt_asset is not None
-                    else None
-                ),
+                    ),
+                )
+            )
+
+        self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post(
+            benchmark_id=self._benchmark_id,
+            create_prompt_for_benchmark_endpoint_input=CreatePromptForBenchmarkEndpointInput(
+                identifier=prompt.identifier,
+                segments=segments or None,
                 tags=[
                     ApiTag(value=tag.value, category=tag.category)
                     for tag in prompt.tags

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -14,6 +14,7 @@ from rapidata.rapidata_client.benchmark._prompt_uploader import (
 from rapidata.api_client.models.benchmark_demographic_dimension import (
     BenchmarkDemographicDimension,
 )
+from rapidata.rapidata_client.benchmark._prompt_segments import find_asset_segment
 from rapidata.rapidata_client.benchmark._vote_filters import (
     demographic_filters,
     in_filter,
@@ -150,10 +151,11 @@ class RapidataBenchmark:
         cls, prompt: GetPromptsByBenchmarkEndpointOutput
     ) -> str | list[str] | None:
         """Reconstruct a prompt's asset reference from the server metadata."""
-        if prompt.prompt_asset is None:
+        asset = find_asset_segment(prompt.segments)
+        if asset is None:
             return None
 
-        return cls.__extract_asset_reference(prompt.prompt_asset)
+        return cls.__extract_asset_reference(asset)
 
     @classmethod
     def __to_prompt_info(

--- a/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
+++ b/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
@@ -88,13 +88,28 @@ _TEXT_ASSET = {
 }
 
 
-def _prompt(identifier: str, prompt_asset: dict | None) -> dict:
+def _prompt(
+    identifier: str,
+    prompt_asset: dict | None,
+    asset_key: str = "prompt_asset",
+) -> dict:
+    segments: list[dict] = [
+        {
+            "key": "prompt",
+            "kind": "Text",
+            "originalText": f"prompt for {identifier}",
+            "englishText": f"prompt for {identifier}",
+        }
+    ]
+    if prompt_asset is not None:
+        segments.append({"key": asset_key, "kind": "Asset", "asset": prompt_asset})
+
     return {
         "id": f"prm_{identifier}",
         "identifier": identifier,
         "originalPrompt": f"prompt for {identifier}",
         "englishPrompt": f"prompt for {identifier}",
-        "promptAsset": prompt_asset,
+        "segments": segments,
         "createdAt": "2026-09-04T12:00:00Z",
         "tags": [{"value": "scene", "category": "kind"}],
         "origin": {"source": "coco"},
@@ -129,6 +144,17 @@ def test_prompt_assets_read_back(asset, expected) -> None:
 
     assert benchmark.identifiers == ["id0"]
     assert benchmark.prompt_assets == [expected]
+
+
+def test_prompt_asset_read_from_renamed_segment() -> None:
+    """A benchmark that renamed its asset segment still surfaces the asset.
+
+    Only the default `prompt_asset` key is guaranteed; a custom prompt
+    structure (the MRI video/first-frame split, say) names its own.
+    """
+    benchmark = _make_benchmark([_prompt("id0", _FILE_ASSET, asset_key="first_frame")])
+
+    assert benchmark.prompt_assets == ["8.jpg"]
 
 
 def test_identifiers_across_mixed_asset_kinds() -> None:

--- a/tests/rapidata_client/benchmark/test_prompt_upload_segments.py
+++ b/tests/rapidata_client/benchmark/test_prompt_upload_segments.py
@@ -1,0 +1,84 @@
+"""Tests for the body the prompt-upload endpoint actually receives.
+
+The upload path had no coverage over the wire body, so when the backend
+replaced the flat ``prompt`` / ``promptAsset`` fields with keyed ``segments``
+the generated model silently dropped both kwargs — pydantic ignores unknown
+fields — and every prompt uploaded with no text and no asset while the asset
+itself was still uploaded and billed. Asserting on the serialized body is the
+only assertion that would have caught it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from rapidata.rapidata_client.benchmark._prompt_uploader import (
+    BenchmarkPrompt,
+    BenchmarkPromptUploader,
+)
+from rapidata.rapidata_client.benchmark.prompt_metadata import Origin, Tag
+
+
+def _upload(prompt: BenchmarkPrompt) -> dict:
+    svc = MagicMock()
+    svc.environment = "rapidata.ai"
+    uploader = BenchmarkPromptUploader("bm-1", svc)
+    uploader._asset_uploader.upload_asset = MagicMock(return_value="uploaded.jpg")  # type: ignore[method-assign]
+
+    uploader.upload(prompt)
+
+    post = svc.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post
+    post.assert_called_once()
+    return post.call_args.kwargs["create_prompt_for_benchmark_endpoint_input"].to_dict()
+
+
+def test_text_prompt_is_sent_as_a_text_segment() -> None:
+    body = _upload(BenchmarkPrompt(identifier="id0", prompt="a cat"))
+
+    assert body["identifier"] == "id0"
+    assert body["segments"] == [{"key": "prompt", "kind": "Text", "text": "a cat"}]
+
+
+def test_prompt_asset_is_sent_as_an_asset_segment() -> None:
+    body = _upload(
+        BenchmarkPrompt(identifier="id0", prompt_asset="https://x.test/cat.jpg")
+    )
+
+    assert body["segments"] == [
+        {
+            "key": "prompt_asset",
+            "kind": "Asset",
+            "asset": {"_t": "ExistingAssetInput", "name": "uploaded.jpg"},
+        }
+    ]
+
+
+def test_text_and_asset_are_sent_as_two_segments() -> None:
+    body = _upload(
+        BenchmarkPrompt(
+            identifier="id0",
+            prompt="a cat",
+            prompt_asset="https://x.test/cat.jpg",
+            tags=[Tag("scene", category="kind")],
+            origin=Origin("coco"),
+        )
+    )
+
+    assert [segment["key"] for segment in body["segments"]] == [
+        "prompt",
+        "prompt_asset",
+    ]
+    assert body["tags"] == [{"value": "scene", "category": "kind"}]
+    assert body["origin"] == {"source": "coco"}
+
+
+def test_legacy_fields_are_never_sent() -> None:
+    """Sending both representations is a 400, so the flat fields must stay off."""
+    body = _upload(
+        BenchmarkPrompt(
+            identifier="id0", prompt="a cat", prompt_asset="https://x.test/cat.jpg"
+        )
+    )
+
+    assert "prompt" not in body
+    assert "promptAsset" not in body


### PR DESCRIPTION
## What broke

`main` cannot upload or read benchmark prompts.

Backend [rapidata-backend#5279](https://github.com/RapidataAI/rapidata-backend/pull/5279) replaced the flat `prompt` / `promptAsset` prompt fields with keyed `segments`, keeping the flat pair working but marking it `[Obsolete]`. The SDK's public-spec filter strips deprecated members, so `rapidata.filtered.openapi.json` — the spec the client generates from — lost both fields in #857. The hand-written wrapper still passed them.

| Path | Symptom |
| --- | --- |
| `benchmark.add_prompts(...)` | Every prompt uploaded with **no text and no asset**. Pydantic ignores unknown fields, so there was no error — and `upload_asset` still ran, so the asset was uploaded and billed before being discarded. `upload_many` logs failures at `info`, so a whole batch of empty prompts reported success. |
| `benchmark.prompts` / `.prompt_assets` / `.identifiers` / `.tags` | `AttributeError: 'GetPromptsByBenchmarkEndpointOutput' object has no attribute 'prompt_asset'` |

Not yet released: `3.22.4` was published five commits before #857 landed, so PyPI users are unaffected until the next version bump.

## The fix

Both paths now go through the two default structure keys — `prompt` and `prompt_asset` — which is where the backend migration moved the old flat content (`PromptSegmentKeys` in the leaderboard service).

- `_prompt_segments.py` — one home for the two keys and the read-side lookup.
- Write: text and asset become one `PromptSegmentInput` each. The flat fields are never sent, since sending both representations is a 400.
- Read: `__extract_asset_url` resolves the asset out of `segments`, preferring the default key and falling back to the first asset-kind segment so a benchmark with a renamed structure (the MRI video/first-frame split) still resolves — the same way the backend's own faucets resolve reference media.

**No public interface change.** `add_prompts(prompts=, prompt_assets=)` and `.prompt_assets` keep their shapes, so docs and examples are unaffected.

## Why it wasn't caught

Pyright named all four errors on #857's head commit ([run 34330656077](https://github.com/RapidataAI/rapidata-python-sdk/actions/runs/34330656077)) and the PR was merged past the failing check — `automerge-openapi-client.yml`'s Guard 0 would have refused it.

The deeper gap: the write path had **no coverage over the wire body**. `test_prompt_tags.py` stubs out `upload_many`, so nothing asserted on what the endpoint actually receives — a field the generator drops looks identical to a field set correctly. `test_prompt_upload_segments.py` now asserts on the serialized request, so the next rename fails a test rather than a customer's upload.

Worth a separate look: this repo runs pyright in CI but **not pytest**. These tests only fail locally.

## Verification

- `pyright src/rapidata/rapidata_client` (pinned v1.1.396, as CI runs it) — 0 errors
- `pytest tests/rapidata_client/benchmark` — 89 passed
- `black src/rapidata/rapidata_client` — clean
- The 4 pre-existing `tests/rapidata_client/audience` failures are unrelated and reproduce on a clean `main`.

🔗 Session: [poseidon](https://poseidon.rapidata.internal/chat/session-97fbbf98)
