### PR TITLE
fix(benchmark): register prompts through prompt segments

### DIFF
--- a/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
+++ b/src/rapidata/rapidata_client/benchmark/_prompt_uploader.py
@@ -8,7 +8,12 @@ from opentelemetry import context as otel_context
 from tqdm.auto import tqdm
 
 from rapidata.rapidata_client.config import logger, rapidata_config, tracer
-from rapidata.rapidata_client.benchmark.prompt_metadata import Origin, Tag
+from rapidata.rapidata_client.benchmark.prompt_metadata import (
+    DEFAULT_ASSET_SEGMENT_KEY,
+    DEFAULT_TEXT_SEGMENT_KEY,
+    Origin,
+    Tag,
+)
 from rapidata.rapidata_client.datapoints._asset_uploader import AssetUploader
 
 if TYPE_CHECKING:
@@ -48,31 +53,39 @@ class BenchmarkPromptUploader:
         from rapidata.api_client.models.create_prompt_for_benchmark_endpoint_input import (
             CreatePromptForBenchmarkEndpointInput,
         )
-        from rapidata.api_client.models.i_asset_input_existing_asset_input import (
-            IAssetInputExistingAssetInput,
-        )
-        from rapidata.api_client.models.i_asset_input import IAssetInput
+        from rapidata.api_client.models.prompt_segment_input import PromptSegmentInput
+        from rapidata.api_client.models.prompt_segment_kind import PromptSegmentKind
 
         # Aliased: the generated wire models share their names with the
         # user-facing Tag/Origin imported at module scope.
         from rapidata.api_client.models.tag import Tag as ApiTag
         from rapidata.api_client.models.origin import Origin as ApiOrigin
 
+        segments: list[PromptSegmentInput] = []
+        if prompt.prompt is not None:
+            segments.append(
+                PromptSegmentInput(
+                    key=DEFAULT_TEXT_SEGMENT_KEY,
+                    kind=PromptSegmentKind.TEXT,
+                    text=prompt.prompt,
+                )
+            )
+        if prompt.prompt_asset is not None:
+            segments.append(
+                PromptSegmentInput(
+                    key=DEFAULT_ASSET_SEGMENT_KEY,
+                    kind=PromptSegmentKind.ASSET,
+                    asset=self._asset_uploader.upload_and_map_asset(
+                        prompt.prompt_asset
+                    ),
+                )
+            )
+
         self._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post(
             benchmark_id=self._benchmark_id,
             create_prompt_for_benchmark_endpoint_input=CreatePromptForBenchmarkEndpointInput(
                 identifier=prompt.identifier,
-                prompt=prompt.prompt,
-                promptAsset=(
-                    IAssetInput(
-                        actual_instance=IAssetInputExistingAssetInput(
-                            _t="ExistingAssetInput",
-                            name=self._asset_uploader.upload_asset(prompt.prompt_asset),
-                        )
-                    )
-                    if prompt.prompt_asset is not None
-                    else None
-                ),
+                segments=segments,
                 tags=[
                     ApiTag(value=tag.value, category=tag.category)
                     for tag in prompt.tags

--- a/src/rapidata/rapidata_client/benchmark/prompt_metadata.py
+++ b/src/rapidata/rapidata_client/benchmark/prompt_metadata.py
@@ -5,6 +5,13 @@ from dataclasses import dataclass
 from typing import Any
 
 
+#: The two segment keys every benchmark starts with — the default prompt
+#: structure the backend creates when none is supplied. The flat
+#: ``prompt`` / ``prompt_asset`` SDK surface is a view over exactly these.
+DEFAULT_TEXT_SEGMENT_KEY = "prompt"
+DEFAULT_ASSET_SEGMENT_KEY = "prompt_asset"
+
+
 @dataclass
 class Tag:
     """A structured tag attached to a benchmark prompt.

--- a/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
+++ b/src/rapidata/rapidata_client/benchmark/rapidata_benchmark.py
@@ -22,6 +22,7 @@ from rapidata.rapidata_client.benchmark.leaderboard.vote_aggregation import (
     VoteAggregation,
 )
 from rapidata.rapidata_client.benchmark.prompt_metadata import (
+    DEFAULT_ASSET_SEGMENT_KEY,
     BenchmarkPromptInfo,
     Origin,
     Tag,
@@ -149,11 +150,24 @@ class RapidataBenchmark:
     def __extract_asset_url(
         cls, prompt: GetPromptsByBenchmarkEndpointOutput
     ) -> str | list[str] | None:
-        """Reconstruct a prompt's asset reference from the server metadata."""
-        if prompt.prompt_asset is None:
+        """Reconstruct a prompt's asset reference from the server metadata.
+
+        Reads the default asset segment: the flat `prompt_assets` surface is a
+        view over that one key, not over whatever else the benchmark's prompt
+        structure defines.
+        """
+        segment = next(
+            (
+                segment
+                for segment in prompt.segments
+                if segment.key == DEFAULT_ASSET_SEGMENT_KEY
+            ),
+            None,
+        )
+        if segment is None or segment.asset is None:
             return None
 
-        return cls.__extract_asset_reference(prompt.prompt_asset)
+        return cls.__extract_asset_reference(segment.asset)
 
     @classmethod
     def __to_prompt_info(

--- a/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
+++ b/tests/rapidata_client/benchmark/test_prompt_asset_extraction.py
@@ -1,11 +1,12 @@
 """Tests for reading back the asset a benchmark prompt carries.
 
-The prompts endpoint returns the read-side ``IAsset`` union
-(``IAssetFileAsset`` / ``IAssetMultiAsset`` / ``IAssetNullAsset`` /
-``IAssetTextAsset``), never the write-side ``IAssetModel*`` classes. Asserting
-on the write-side class made every asset-carrying benchmark raise on
-``identifiers`` — and so on ``add_model``, which validates against it — before
-a single byte was uploaded. Only text-only benchmarks stayed usable.
+The asset lives in the prompt's ``prompt_asset`` segment, and the prompts
+endpoint returns it as the read-side ``IAsset`` union (``IAssetFileAsset`` /
+``IAssetMultiAsset`` / ``IAssetNullAsset`` / ``IAssetTextAsset``), never the
+write-side ``IAssetModel*`` classes. Asserting on the write-side class made
+every asset-carrying benchmark raise on ``identifiers`` — and so on
+``add_model``, which validates against it — before a single byte was uploaded.
+Only text-only benchmarks stayed usable.
 """
 
 from __future__ import annotations
@@ -89,12 +90,24 @@ _TEXT_ASSET = {
 
 
 def _prompt(identifier: str, prompt_asset: dict | None) -> dict:
+    text = f"prompt for {identifier}"
+    segments: list[dict] = [
+        {
+            "key": "prompt",
+            "kind": "Text",
+            "originalText": text,
+            "englishText": text,
+        }
+    ]
+    if prompt_asset is not None:
+        segments.append({"key": "prompt_asset", "kind": "Asset", "asset": prompt_asset})
+
     return {
         "id": f"prm_{identifier}",
         "identifier": identifier,
-        "originalPrompt": f"prompt for {identifier}",
-        "englishPrompt": f"prompt for {identifier}",
-        "promptAsset": prompt_asset,
+        "originalPrompt": text,
+        "englishPrompt": text,
+        "segments": segments,
         "createdAt": "2026-09-04T12:00:00Z",
         "tags": [{"value": "scene", "category": "kind"}],
         "origin": {"source": "coco"},

--- a/tests/rapidata_client/benchmark/test_prompt_segment_upload.py
+++ b/tests/rapidata_client/benchmark/test_prompt_segment_upload.py
@@ -1,0 +1,81 @@
+"""Tests for the segment payload a benchmark prompt is registered with.
+
+The create-prompt endpoint no longer takes a flat ``prompt`` / ``promptAsset``
+pair — those are deprecated on the wire and stripped from the generated client
+entirely. The SDK's flat surface now maps onto the two segment keys of the
+default prompt structure, and an absent value must send no segment at all
+rather than an empty one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from rapidata.api_client.models.i_asset_input import IAssetInput
+from rapidata.api_client.models.i_asset_input_existing_asset_input import (
+    IAssetInputExistingAssetInput,
+)
+from rapidata.api_client.models.prompt_segment_kind import PromptSegmentKind
+from rapidata.rapidata_client.benchmark._prompt_uploader import (
+    BenchmarkPrompt,
+    BenchmarkPromptUploader,
+)
+from rapidata.rapidata_client.benchmark.prompt_metadata import Origin, Tag
+
+
+def _upload(prompt: BenchmarkPrompt):
+    uploader = BenchmarkPromptUploader("bm-1", MagicMock())
+    uploader._asset_uploader = MagicMock()  # type: ignore[method-assign]
+    uploader._asset_uploader.upload_and_map_asset.side_effect = (
+        lambda asset: IAssetInput(
+            actual_instance=IAssetInputExistingAssetInput(
+                _t="ExistingAssetInput", name=f"mapped:{asset}"
+            )
+        )
+    )
+
+    uploader.upload(prompt)
+
+    post = (
+        uploader._openapi_service.leaderboard.benchmark_api.benchmark_benchmark_id_prompt_post
+    )
+    post.assert_called_once()
+    return post.call_args.kwargs["create_prompt_for_benchmark_endpoint_input"]
+
+
+def test_text_and_asset_map_to_the_default_segment_keys() -> None:
+    payload = _upload(
+        BenchmarkPrompt(
+            identifier="id0",
+            prompt="a red car",
+            prompt_asset="https://assets.rapidata.ai/ref.jpg",
+            tags=[Tag("scene", "kind")],
+            origin=Origin("coco"),
+        )
+    )
+
+    assert payload.identifier == "id0"
+    assert [(s.key, s.kind) for s in payload.segments] == [
+        ("prompt", PromptSegmentKind.TEXT),
+        ("prompt_asset", PromptSegmentKind.ASSET),
+    ]
+    assert payload.segments[0].text == "a red car"
+    asset = payload.segments[1].asset
+    assert asset is not None
+    assert asset.actual_instance.name == "mapped:https://assets.rapidata.ai/ref.jpg"
+
+
+def test_missing_values_send_no_segment() -> None:
+    payload = _upload(BenchmarkPrompt(identifier="id0", prompt="text only"))
+
+    assert [s.key for s in payload.segments] == ["prompt"]
+
+
+def test_asset_only_prompt_sends_only_the_asset_segment() -> None:
+    payload = _upload(
+        BenchmarkPrompt(
+            identifier="id0", prompt_asset="https://assets.rapidata.ai/a.jpg"
+        )
+    )
+
+    assert [s.key for s in payload.segments] == ["prompt_asset"]


### PR DESCRIPTION
## What broke

The `2026.09.09.0832` OpenAPI regeneration ([#857](https://github.com/RapidataAI/rapidata-python-sdk/pull/857)) replaced the flat prompt shape with **prompt segments**. `pyright` went red on `main` with 4 errors, and 7 benchmark tests failed with it:

| File | Error |
| --- | --- |
| `_prompt_uploader.py:65-66` | `prompt` / `promptAsset` are no longer parameters of `CreatePromptForBenchmarkEndpointInput` |
| `rapidata_benchmark.py:153,156` | `prompt_asset` is no longer an attribute of `GetPromptsByBenchmarkEndpointOutput` |

The backend still *accepts* `prompt` / `promptAsset`, but they are marked `deprecated: true`, and `scripts/build_public_openapi.py` strips deprecated properties before generation — `rapidata.filtered.openapi.json` has no trace of them. They are unreachable from the generated client by design, so no shim can bring them back. Segments are the only forward path.

## What this changes

The flat SDK surface is now a view over the two keys of the default prompt structure the backend creates for every benchmark — `prompt` (Text, optional) and `prompt_asset` (Asset, optional), per `PromptSegmentKeys.cs` / `DefaultPromptStructureFactory.cs` in the leaderboard service.

1. **Write side** — `_prompt_uploader.py` builds `segments=[PromptSegmentInput(...)]` instead of the flat pair. An absent value sends no segment rather than an empty one.
2. **Read side** — `__extract_asset_url` reads the `prompt_asset` segment instead of the removed field.
3. The two keys live in `prompt_metadata.py` as `DEFAULT_TEXT_SEGMENT_KEY` / `DEFAULT_ASSET_SEGMENT_KEY`.

**No public API change.** `.prompts`, `.prompt_assets`, `.english_prompts` and `add_prompts(prompts=, prompt_assets=)` behave exactly as before. One incidental improvement: the segment builder reuses `upload_and_map_asset`, so a `list[str]` multi-asset prompt now works on the write side too — previously only readable.

## Verification

- `uv run pyright src/rapidata/rapidata_client` — **0 errors** (was 4)
- `uv run pytest` — 164 passed, up from 154; the 7 prompt tests are ported to segments and 3 new ones cover the segment payload nothing was asserting on before
- 4 failures remain in `tests/rapidata_client/audience/` — **pre-existing**, verified failing at `fb86474~1`, unrelated to prompts. Not touched here.

## Deliberately out of scope

Richer use of the structure — declaring custom segment keys, reading a prompt's segments, `PUT /benchmark/{id}/prompt-structure`, `PUT /benchmark-prompt/{id}/segments`, and the leaderboard's `rapidContextProjection` — is a public API design, not a fix. It lands with the RFC that designs that surface.

## Separately

[#857](https://github.com/RapidataAI/rapidata-python-sdk/pull/857) was merged with `type-check` red. The automerge workflow's pyright gate was not bypassed — it was manually overridden.

---
🔗 Session: https://poseidon.rapidata.internal/chat/session-1801303a
