### PR TITLE
fix(telemetry): disable OTLP export under pytest

### DIFF
--- a/src/rapidata/rapidata_client/config/logging_config.py
+++ b/src/rapidata/rapidata_client/config/logging_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any, Callable
 
 from pydantic import BaseModel, Field, model_validator
@@ -9,9 +10,19 @@ from rapidata.rapidata_client.config import logger
 from rapidata.rapidata_client.config._env_utils import apply_env_overrides
 
 
+def _running_under_pytest() -> bool:
+    """Return True when the importing process is a pytest run."""
+    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules
+
+
 def _default_enable_otlp() -> bool:
     """Return the default for enable_otlp, respecting the RAPIDATA_DISABLE_OTLP env var."""
-    return os.environ.get("RAPIDATA_DISABLE_OTLP", "0").lower() not in ("1", "true", "yes")
+    if os.environ.get("RAPIDATA_DISABLE_OTLP", "0").lower() in ("1", "true", "yes"):
+        return False
+    # Test suites drive the SDK with mocks; their validation failures are
+    # indistinguishable from customer errors once they reach the collector.
+    return not _running_under_pytest()
+
 
 # Type alias for config update handlers
 ConfigUpdateHandler = Callable[["LoggingConfig"], None]
@@ -40,8 +51,9 @@ class LoggingConfig(BaseModel):
         log_file (str | None): The logging file. Defaults to None.
         format (str): The logging format. Defaults to "%(asctime)s - %(name)s - %(levelname)s - %(message)s".
         silent_mode (bool): Whether to disable the prints and progress bars. Does NOT affect the logging. Defaults to False.
-        enable_otlp (bool): Whether to enable OpenTelemetry trace logs. Defaults to True.
-            Can also be disabled via the RAPIDATA_DISABLE_OTLP=1 environment variable.
+        enable_otlp (bool): Whether to enable OpenTelemetry trace logs. Defaults to True,
+            except under pytest, where it defaults to False. Can also be disabled via the
+            RAPIDATA_DISABLE_OTLP=1 environment variable, or forced on by passing it explicitly.
         environment (str): The API environment the client targets, used to derive the
             OTLP collector host (``otlp-sdk.<environment>``). Set by RapidataClient.
     """

--- a/tests/rapidata_client/config/test_otlp_default.py
+++ b/tests/rapidata_client/config/test_otlp_default.py
@@ -1,0 +1,51 @@
+"""Tests for the OTLP default that keeps test traffic out of the production collector.
+
+The suite drives the SDK with mocks, so its validation failures are
+indistinguishable from customer errors once they reach `otlp-sdk.rapidata.ai`.
+`tests/conftest.py` sets `RAPIDATA_DISABLE_OTLP=1`, but it only covers runs that
+collect this repo's conftest — the pytest check covers every other pytest run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rapidata.rapidata_client.config.logging_config import (
+    LoggingConfig,
+    _default_enable_otlp,
+    _running_under_pytest,
+)
+
+
+def test_pytest_is_detected_in_this_process():
+    assert _running_under_pytest() is True
+
+
+def test_disabled_under_pytest_without_the_env_var(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("RAPIDATA_DISABLE_OTLP", raising=False)
+
+    assert _default_enable_otlp() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "YES"])
+def test_disabled_by_env_var(monkeypatch: pytest.MonkeyPatch, value: str):
+    monkeypatch.setenv("RAPIDATA_DISABLE_OTLP", value)
+
+    assert _default_enable_otlp() is False
+
+
+def test_enabled_outside_pytest(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("RAPIDATA_DISABLE_OTLP", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(
+        "rapidata.rapidata_client.config.logging_config.sys.modules",
+        {k: v for k, v in __import__("sys").modules.items() if k != "pytest"},
+    )
+
+    assert _default_enable_otlp() is True
+
+
+def test_explicit_true_overrides_the_pytest_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("RAPIDATA_DISABLE_OTLP", raising=False)
+
+    assert LoggingConfig(enable_otlp=True).enable_otlp is True


### PR DESCRIPTION
## What

Default `enable_otlp` to `false` when the SDK is imported inside a pytest run.

## Why

A 24h sweep of `otel.otel_traces` shows `Rapidata.Python.SDK` as the 4th-largest
source of `StatusCode = 'Error'` spans (116 in 24h). Two bursts are test runs, not
customers:

| When (UTC) | `service.version` | Signature |
| --- | --- | --- |
| 2026-09-11 12:52 | 3.3.3 | `AssertionError: flat openapi_service.audience_api was used` |
| 2026-09-11 14:21 | 3.23.0 | `TypeError: Asset must be a string, got MagicMock`, `ValidationError: … input_type=MagicMock` |

Every span in both bursts has **no** `SDK.session.id`, `identity` or `email`
attribute — the tracer only sets those after a real client authenticates. Every
genuine customer error in the same window carries all three. That is the clean
separator between the two populations.

`tests/conftest.py` (#814) already sets `RAPIDATA_DISABLE_OTLP=1`, and it is on
`main` and shipped in 3.23.0 — yet the 14:21 burst exported anyway. A conftest
only protects runs that actually collect *this* repo's conftest; it does nothing
for a suite invoked from another rootdir, or for a downstream repo that installs
the SDK and drives it with mocks. Checking for pytest inside the SDK covers all
of them, wherever the run starts.

## How

`_default_enable_otlp()` now returns `False` when `PYTEST_CURRENT_TEST` is set or
`pytest` is in `sys.modules`. `RAPIDATA_DISABLE_OTLP` keeps working unchanged, and
passing `enable_otlp=True` explicitly still forces export on for anyone who
genuinely wants SDK traces from a test process.

The existing `conftest.py` stays — it disables OTLP before `rapidata` is imported
at all, which is strictly earlier than this check can run.

## Verification

- `uv run pytest tests/rapidata_client/config/` — 7 passed (new).
- `uv run pytest` — 189 passed, 4 failed; the 4 failures are in
  `tests/rapidata_client/audience/` and reproduce on unmodified `main`.
- `uv run pyright src/rapidata/rapidata_client` — 0 errors.
- `uv run black` — clean.

## Not covered by this change

A process that drives the SDK with mocks **outside** pytest would still export.
The query that separates the populations, if this needs watching:

```sql
SELECT toString(ResourceAttributes.service.version) ver, SpanName, count()
FROM otel.otel_traces
WHERE ServiceName = 'Rapidata.Python.SDK' AND StatusCode = 'Error'
  AND Timestamp > now() - INTERVAL 24 HOUR
  AND toString(SpanAttributes.identity) = ''
GROUP BY ver, SpanName ORDER BY count() DESC
```

🔗 Session: https://poseidon.rapidata.internal/chat/node-fcfbb0540ee3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
